### PR TITLE
Generate EPB (one-shot) — backend foundation: readiness + planning

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -129,7 +129,7 @@ export default function DashboardPage() {
           </>
         ) : (
           <Button variant="outline" asChild>
-            <Link href="/epb">
+            <Link href="/entries">
               <Sparkles className="size-4 mr-2" />
               Generate EPB
             </Link>

--- a/src/app/(app)/entries/page.tsx
+++ b/src/app/(app)/entries/page.tsx
@@ -55,7 +55,12 @@ import type { SelectedRatee } from "@/stores/epb-shell-store";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import type { Accomplishment, AwardQuarter } from "@/types/database";
+import type {
+  Accomplishment,
+  AwardQuarter,
+  EPBShell,
+  EPBShellSection,
+} from "@/types/database";
 import { formatShortDate, formatShortDateWithYear } from "@/lib/format";
 
 function EntriesContent() {
@@ -85,6 +90,11 @@ function EntriesContent() {
   );
   const [fuseDialogOpen, setFuseDialogOpen] = useState(false);
   const [generateEpbOpen, setGenerateEpbOpen] = useState(false);
+  const [genEpbShell, setGenEpbShell] = useState<
+    (EPBShell & { sections: EPBShellSection[] }) | null
+  >(null);
+  const [genEpbDuty, setGenEpbDuty] = useState("");
+  const [genEpbLoading, setGenEpbLoading] = useState(false);
   
   const supabase = createClient();
   // Cycle year is computed from the user's rank and SCOD
@@ -324,6 +334,34 @@ function EntriesContent() {
   );
   const showGenerateEpb = !!fuseRatee && isEnlisted(fuseRatee.rank);
 
+  // Fetch the ratee's active shell (for the duty-description preflight) before
+  // opening the Generate EPB dialog, so we can auto-open the workbench if empty.
+  async function openGenerateEpb() {
+    if (!fuseRatee) return;
+    setGenEpbLoading(true);
+    try {
+      let query = supabase
+        .from("epb_shells")
+        .select(`*, sections:epb_shell_sections(*)`)
+        .neq("status", "archived")
+        .order("updated_at", { ascending: false });
+      query = fuseRatee.isManagedMember
+        ? query.eq("team_member_id", fuseRatee.id)
+        : query.eq("user_id", fuseRatee.id).is("team_member_id", null);
+      const { data } = await query.limit(1).maybeSingle();
+      const shell =
+        (data as (EPBShell & { sections: EPBShellSection[] }) | null) ?? null;
+      setGenEpbShell(shell);
+      setGenEpbDuty(shell?.duty_description ?? "");
+    } catch {
+      setGenEpbShell(null);
+      setGenEpbDuty("");
+    } finally {
+      setGenEpbLoading(false);
+      setGenerateEpbOpen(true);
+    }
+  }
+
   function handleEdit(entry: Accomplishment) {
     setEditingEntry(entry);
     setDialogOpen(true);
@@ -374,8 +412,8 @@ function EntriesContent() {
                   <span className="inline-flex">
                     <Button
                       variant="outline"
-                      disabled={!epbReadiness.canGenerate}
-                      onClick={() => setGenerateEpbOpen(true)}
+                      disabled={!epbReadiness.canGenerate || genEpbLoading}
+                      onClick={openGenerateEpb}
                     >
                       <Sparkles className="size-4 mr-2" />
                       Generate EPB
@@ -696,6 +734,13 @@ function EntriesContent() {
           onOpenChange={setGenerateEpbOpen}
           ratee={fuseRatee}
           readiness={epbReadiness}
+          preselected={
+            selectedAccomplishments.length > 0
+              ? selectedAccomplishments
+              : undefined
+          }
+          initialShell={genEpbShell}
+          initialDutyDescription={genEpbDuty}
         />
       )}
     </div>

--- a/src/app/(app)/entries/page.tsx
+++ b/src/app/(app)/entries/page.tsx
@@ -34,11 +34,19 @@ import { EntryCard } from "@/components/entries/entry-card";
 import { EntryFormDialog } from "@/components/entries/entry-form-dialog";
 import { FuseToEpbBar } from "@/components/entries/fuse-to-epb-bar";
 import { FuseToEpbDialog } from "@/components/entries/fuse-to-epb-dialog";
+import { GenerateEpbDialog } from "@/components/entries/generate-epb-dialog";
 import { TagFilterPopover } from "@/components/entries/tag-filter-popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/sonner";
 import { Analytics } from "@/lib/analytics";
 import { deleteAccomplishment } from "@/app/actions/accomplishments";
-import { Plus, Filter, FileText, LayoutList, CalendarDays } from "lucide-react";
+import { evaluateEpbGenerationReadiness } from "@/lib/epb-generation-readiness";
+import { Plus, Filter, FileText, LayoutList, CalendarDays, Sparkles } from "lucide-react";
 import { ENTRY_MGAS, AWARD_QUARTERS, getQuarterDateRange, getFiscalQuarterDateRange, getActiveCycleYear, isEnlisted } from "@/lib/constants";
 import { EPBProgressCard } from "@/components/epb/epb-progress-card";
 import { SupervisorFeedbackPanel } from "@/components/entries/supervisor-feedback-panel";
@@ -76,6 +84,7 @@ function EntriesContent() {
     () => new Set()
   );
   const [fuseDialogOpen, setFuseDialogOpen] = useState(false);
+  const [generateEpbOpen, setGenerateEpbOpen] = useState(false);
   
   const supabase = createClient();
   // Cycle year is computed from the user's rank and SCOD
@@ -308,6 +317,13 @@ function EntriesContent() {
     isEnlisted(fuseRatee.rank) &&
     selectedAccomplishments.length > 0;
 
+  // Full-EPB generation readiness (content-based; the plan step selects entries).
+  const epbReadiness = useMemo(
+    () => evaluateEpbGenerationReadiness(accomplishments, { rank: rateeRank }),
+    [accomplishments, rateeRank]
+  );
+  const showGenerateEpb = !!fuseRatee && isEnlisted(fuseRatee.rank);
+
   function handleEdit(entry: Accomplishment) {
     setEditingEntry(entry);
     setDialogOpen(true);
@@ -351,6 +367,29 @@ function EntriesContent() {
         </div>
         <div className="flex items-center gap-2">
           <SupervisorFeedbackPanel />
+          {showGenerateEpb && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <Button
+                      variant="outline"
+                      disabled={!epbReadiness.canGenerate}
+                      onClick={() => setGenerateEpbOpen(true)}
+                    >
+                      <Sparkles className="size-4 mr-2" />
+                      Generate EPB
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                {!epbReadiness.canGenerate && epbReadiness.reasons.length > 0 && (
+                  <TooltipContent className="max-w-xs">
+                    {epbReadiness.reasons.join(" ")}
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </TooltipProvider>
+          )}
           <Button onClick={() => setDialogOpen(true)}>
             <Plus className="size-4 mr-2" />
             New Entry
@@ -648,6 +687,15 @@ function EntriesContent() {
           onOpenChange={setFuseDialogOpen}
           accomplishments={selectedAccomplishments}
           ratee={fuseRatee}
+        />
+      )}
+
+      {generateEpbOpen && fuseRatee && (
+        <GenerateEpbDialog
+          open={generateEpbOpen}
+          onOpenChange={setGenerateEpbOpen}
+          ratee={fuseRatee}
+          readiness={epbReadiness}
         />
       )}
     </div>

--- a/src/app/api/assess-epb/route.ts
+++ b/src/app/api/assess-epb/route.ts
@@ -74,6 +74,7 @@ export async function POST(request: Request) {
       user_id: string;
       created_by: string;
       duty_description: string;
+      cycle_year: number | null;
       sections: EPBShellSection[];
     }
     
@@ -84,6 +85,7 @@ export async function POST(request: Request) {
         user_id,
         created_by,
         duty_description,
+        cycle_year,
         sections:epb_shell_sections(mpa, statement_text, is_complete)
       `)
       .eq("id", shellId)
@@ -240,7 +242,36 @@ export async function POST(request: Request) {
       assessment.formUsed = assessment.rubricTier === "senior" ? "AF Form 932" : "AF Form 931";
     }
 
-    return cacheBillableJson(billableCtx, { assessment }, usageCheck);
+    // Persist a permanent record of this assessment attached to the shell.
+    // Non-fatal: if the insert fails, still return the assessment to the user.
+    let assessmentId: string | null = null;
+    try {
+      const { data: saved, error: saveError } = await supabase
+        .from("epb_assessments")
+        .insert({
+          shell_id: shellId,
+          user_id: shell.user_id,
+          created_by: user.id,
+          rank: rateeRank,
+          afsc: rateeAfsc,
+          model,
+          cycle_year: shell.cycle_year ?? null,
+          overall_strength: assessment.overallStrength,
+          form_used: assessment.formUsed,
+          assessment,
+        } as never)
+        .select("id")
+        .single();
+      if (saveError) {
+        console.error("Failed to persist EPB assessment:", saveError);
+      } else {
+        assessmentId = (saved as { id: string } | null)?.id ?? null;
+      }
+    } catch (persistError) {
+      console.error("Error persisting EPB assessment:", persistError);
+    }
+
+    return cacheBillableJson(billableCtx, { assessment, assessmentId }, usageCheck);
   } catch (error) {
     if (billableCtx) {
       return handleBillableLLMError(error, "POST /api/assess-epb", modelId, billableCtx);

--- a/src/app/api/plan-epb/route.ts
+++ b/src/app/api/plan-epb/route.ts
@@ -40,6 +40,7 @@ interface PlanEpbRequest {
   rateeAfsc?: string;
   cycleYear: number;
   model?: string;
+  dutyDescription?: string;
 }
 
 function parsePlanJson(text: string, validIds: Set<string>): EpbPlan {
@@ -68,6 +69,7 @@ export async function POST(request: Request) {
       rateeAfsc,
       cycleYear,
       model = DEFAULT_APP_MODEL_ID,
+      dutyDescription,
     } = body;
 
     if (!rateeId || !rateeRank || !cycleYear) {
@@ -172,6 +174,7 @@ export async function POST(request: Request) {
           records: chunk,
           rateeRank,
           rateeAfsc,
+          dutyDescription,
           isChunked: chunks.length > 1,
         });
         const { text } = await generateText({

--- a/src/app/api/plan-epb/route.ts
+++ b/src/app/api/plan-epb/route.ts
@@ -1,0 +1,216 @@
+import { createClient } from "@/lib/supabase/server";
+import { generateText } from "ai";
+import { NextResponse } from "next/server";
+import { getDecryptedApiKeys } from "@/app/actions/api-keys";
+import { getModelProvider } from "@/lib/llm-provider";
+import {
+  cacheBillableJson,
+  createBillableRequestContext,
+  getReplayedBillableResponse,
+  handleBillableLLMError,
+  refundAndError,
+  type BillableRequestContext,
+} from "@/lib/billing/billable-request";
+import { handleLLMError } from "@/lib/llm-error-handler";
+import { enforceUsageGate } from "@/lib/usage-gate";
+import { DEFAULT_APP_MODEL_ID, isCivilian, isEnlisted } from "@/lib/constants";
+import { resolveRequestedModel } from "@/app/actions/ai-models";
+import { checkAndTrackUsage } from "@/lib/usage-tracker";
+import { scanAccomplishmentsForLLM } from "@/lib/sensitive-data-scanner";
+import { normalizeStewardshipImpact } from "@/lib/stewardship-impact";
+import { buildPlanEpbPrompt } from "@/lib/plan-epb-prompt";
+import {
+  chunkForPlanning,
+  mergeChunkPlans,
+  sanitizePlan,
+  toPlanRecords,
+  trimMergedPlan,
+  type EpbPlan,
+  type PlanAccomplishmentRecord,
+} from "@/lib/plan-epb";
+import type { Accomplishment, Rank } from "@/types/database";
+
+// Planning fires one LLM call per chunk; allow generous time for large cycles.
+export const maxDuration = 90;
+
+interface PlanEpbRequest {
+  rateeId: string;
+  isManagedMember?: boolean;
+  rateeRank: Rank;
+  rateeAfsc?: string;
+  cycleYear: number;
+  model?: string;
+}
+
+function parsePlanJson(text: string, validIds: Set<string>): EpbPlan {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error("No JSON found in planning response");
+  return sanitizePlan(JSON.parse(match[0]), validIds);
+}
+
+export async function POST(request: Request) {
+  let modelId: string | undefined;
+  let billableCtx: BillableRequestContext | null = null;
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body: PlanEpbRequest = await request.json();
+    const {
+      rateeId,
+      isManagedMember = false,
+      rateeRank,
+      rateeAfsc,
+      cycleYear,
+      model = DEFAULT_APP_MODEL_ID,
+    } = body;
+
+    if (!rateeId || !rateeRank || !cycleYear) {
+      return NextResponse.json(
+        { error: "Missing required fields: rateeId, rateeRank, cycleYear" },
+        { status: 400 }
+      );
+    }
+    if (isCivilian(rateeRank) || !isEnlisted(rateeRank)) {
+      return NextResponse.json(
+        { error: "Full EPB planning is available for enlisted ratees only." },
+        { status: 400 }
+      );
+    }
+
+    // Load the ratee's cycle accomplishments. RLS restricts rows to those the
+    // caller may read, so this doubles as the authorization check.
+    let query = supabase
+      .from("accomplishments")
+      .select("*")
+      .eq("cycle_year", cycleYear);
+    query = isManagedMember
+      ? query.eq("team_member_id", rateeId)
+      : query.eq("user_id", rateeId).is("team_member_id", null);
+
+    const { data: rows, error: loadError } = await query;
+    if (loadError) {
+      return NextResponse.json(
+        { error: "Failed to load accomplishments" },
+        { status: 500 }
+      );
+    }
+
+    const accomplishments = (rows ?? []) as Accomplishment[];
+    const records: PlanAccomplishmentRecord[] = toPlanRecords(accomplishments);
+    if (records.length === 0) {
+      return NextResponse.json(
+        { error: "No accomplishments found for this ratee and cycle." },
+        { status: 400 }
+      );
+    }
+
+    // Block before any data reaches the LLM if PII/CUI is detected.
+    const scan = scanAccomplishmentsForLLM(
+      accomplishments.map((a) => {
+        const stewardship = normalizeStewardshipImpact(a.stewardship_impact);
+        return {
+          details: a.details,
+          impact: a.impact,
+          metrics: a.metrics,
+          stewardship_time: stewardship.time,
+          stewardship_money: stewardship.money,
+          stewardship_resources: stewardship.resources,
+          stewardship_outcome: stewardship.outcome,
+        };
+      })
+    );
+    if (scan.blocked) {
+      return NextResponse.json(
+        {
+          error:
+            "One or more accomplishments contain sensitive data (PII, CUI, or classification markings) that cannot be sent to AI providers. Remove it before generating.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const userKeys = await getDecryptedApiKeys();
+    modelId = await resolveRequestedModel(model, "generate");
+
+    billableCtx = {
+      ...(await createBillableRequestContext(request, user.id)),
+      usageCheck: null,
+    };
+    const replayed = await getReplayedBillableResponse(billableCtx);
+    if (replayed) return replayed;
+
+    const usageCheck = await checkAndTrackUsage(
+      user.id,
+      "plan_epb",
+      modelId,
+      userKeys,
+      billableCtx.idempotencyKey
+    );
+    billableCtx.usageCheck = usageCheck;
+    if (!usageCheck.allowed) {
+      return enforceUsageGate(usageCheck);
+    }
+
+    const modelProvider = getModelProvider(
+      usageCheck.effectiveModel,
+      userKeys,
+      usageCheck.tracking
+    );
+
+    const validIds = new Set(records.map((r) => r.id));
+    const chunks = chunkForPlanning(records);
+
+    const chunkPlans = await Promise.all(
+      chunks.map(async (chunk) => {
+        const prompt = buildPlanEpbPrompt({
+          records: chunk,
+          rateeRank,
+          rateeAfsc,
+          isChunked: chunks.length > 1,
+        });
+        const { text } = await generateText({
+          model: modelProvider,
+          prompt,
+          temperature: 0.2,
+          maxOutputTokens: 2000,
+        });
+        return parsePlanJson(text, validIds);
+      })
+    );
+
+    const merged = mergeChunkPlans(chunkPlans);
+    const scoreById = new Map(
+      records.map((r) => [r.id, r.overallScore ?? 0] as const)
+    );
+    const plan = trimMergedPlan(merged, scoreById);
+
+    if (plan.mpas.length === 0) {
+      return refundAndError(
+        billableCtx,
+        {
+          error:
+            "The planner could not select statements from these accomplishments. Add or strengthen entries and try again.",
+        },
+        { status: 422 }
+      );
+    }
+
+    return cacheBillableJson(billableCtx, { plan, records }, usageCheck);
+  } catch (error) {
+    if (billableCtx) {
+      return handleBillableLLMError(
+        error,
+        "POST /api/plan-epb",
+        modelId,
+        billableCtx
+      );
+    }
+    return handleLLMError(error, "POST /api/plan-epb", modelId);
+  }
+}

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -81,7 +81,12 @@ import {
   X,
 } from "lucide-react";
 
-type DialogStep = "preflight" | "planning" | "review" | "generating" | "error";
+type DialogStep =
+  | "preflight"
+  | "planning"
+  | "review"
+  | "generating"
+  | "error";
 
 type ShellWithSections = EPBShell & { sections: EPBShellSection[] };
 
@@ -127,6 +132,7 @@ export function GenerateEpbDialog({
   const [dutyDraft, setDutyDraft] = useState("");
   const [dutyLoaded, setDutyLoaded] = useState(false);
   const [dutyLoading, setDutyLoading] = useState(false);
+  const [dutyGenerating, setDutyGenerating] = useState(false);
 
   const model = getStoredModelPreference(EPB_MODEL_PREFERENCE_STORAGE_KEY);
   const writingStyle: WritingStyle =
@@ -156,6 +162,7 @@ export function GenerateEpbDialog({
     setDutyDraft("");
     setDutyLoaded(false);
     setDutyLoading(false);
+    setDutyGenerating(false);
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -209,27 +216,79 @@ export function GenerateEpbDialog({
     setActiveShell({ ...shell, duty_description: value });
   };
 
+  // Polish the drafted duty description with AI (rephrase only — same duty-safe
+  // path the workspace uses; requires a seed so scope is never fabricated).
+  const handleImproveDuty = async () => {
+    const seed = dutyDraft.trim();
+    if (!seed) {
+      toast.error("Write a short duty description first, then improve it.");
+      return;
+    }
+    setDutyGenerating(true);
+    try {
+      const response = await billableFetch("/api/revise-selection", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fullStatement: seed,
+          selectedText: seed,
+          selectionStart: 0,
+          selectionEnd: seed.length,
+          model,
+          mode: "general",
+          isDutyDescription: true,
+          versionCount: 1,
+          rateeRank: ratee.rank,
+          rateeAfsc: ratee.afsc,
+          writingStyle,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        if (handleUsageLimitResponse(errorData)) return;
+        throw new Error(errorData.error || "Could not improve duty description");
+      }
+
+      const data = (await response.json()) as { revisions?: string[] };
+      const improved = data.revisions?.[0]?.trim();
+      if (!improved) {
+        toast.error("No improved version returned — try again.");
+        return;
+      }
+      setDutyDraft(improved.slice(0, MAX_DUTY_DESCRIPTION_CHARACTERS));
+      toast.success("Duty description improved");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to improve duty description"
+      );
+    } finally {
+      setDutyGenerating(false);
+    }
+  };
+
   const handleAnalyze = async () => {
     if (!profile) return;
     setStep("planning");
     setErrorMessage("");
     try {
       const cycleYear = getActiveCycleYear(ratee.rank as Rank | null);
-      const [shell, response] = await Promise.all([
-        findActiveShell().catch(() => null),
-        billableFetch("/api/plan-epb", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            rateeId: ratee.id,
-            isManagedMember: Boolean(ratee.isManagedMember),
-            rateeRank: ratee.rank,
-            rateeAfsc: ratee.afsc,
-            cycleYear,
-            model,
-          }),
+      const shell = await findActiveShell().catch(() => null);
+      setActiveShell(shell);
+      const dutyDescription = dutyDraft.trim() || shell?.duty_description || "";
+      const response = await billableFetch("/api/plan-epb", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          rateeId: ratee.id,
+          isManagedMember: Boolean(ratee.isManagedMember),
+          rateeRank: ratee.rank,
+          rateeAfsc: ratee.afsc,
+          cycleYear,
+          model,
+          dutyDescription,
         }),
-      ]);
+      });
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
@@ -354,7 +413,10 @@ export function GenerateEpbDialog({
           ratee,
           profileId: profile.id,
         });
-        if (result.status === "active_exists" || result.status === "archived_conflict") {
+        if (
+          result.status === "active_exists" ||
+          result.status === "archived_conflict"
+        ) {
           throw new Error(
             "Could not open an EPB shell for this cycle. Open EPB to resolve, then retry."
           );
@@ -386,7 +448,6 @@ export function GenerateEpbDialog({
         const mpaRecords = selection.accomplishmentIds
           .map((id) => recordsById.get(id))
           .filter((r): r is PlanAccomplishmentRecord => !!r);
-        const customContext = buildMpaCustomContext(mpaRecords);
 
         const response = await billableFetch("/api/generate", {
           method: "POST",
@@ -400,7 +461,7 @@ export function GenerateEpbDialog({
             model,
             writingStyle,
             selectedMPAs: [selection.mpaKey],
-            customContext,
+            customContext: buildMpaCustomContext(mpaRecords),
             customContextOptions: { statementCount: selection.sentenceCount },
             dutyDescription,
             accomplishments: mpaRecords.map((r) => ({
@@ -436,42 +497,43 @@ export function GenerateEpbDialog({
         }
 
         const section = shell.sections?.find((s) => s.mpa === selection.mpaKey);
-        if (section) {
-          // Stage all versions for one-tap swap in the workspace.
-          await supabase.from("epb_saved_examples").insert(
-            versions.map((statement) => ({
-              shell_id: shell!.id,
-              section_id: section.id,
-              mpa: selection.mpaKey,
-              statement_text: statement,
-              created_by: profile.id,
-              created_by_name: profile.full_name,
-              created_by_rank: profile.rank,
-              note: "Generated by Generate EPB",
-            })) as never
-          );
-
-          const conflictStage =
-            conflictPolicy === "stage" &&
-            isSubstantialEpbStatement(existingMpaText.get(selection.mpaKey));
-
-          if (conflictStage) {
-            setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "staged" }));
-          } else {
-            await supabase
-              .from("epb_shell_sections")
-              .update({
-                statement_text: versions[0],
-                last_edited_by: profile.id,
-                updated_at: new Date().toISOString(),
-              } as never)
-              .eq("id", section.id);
-            setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "done" }));
-          }
-          if (!firstCompleted) firstCompleted = selection.mpaKey;
-        } else {
+        if (!section) {
           setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "failed" }));
+          continue;
         }
+
+        // Stage all versions for one-tap swap in the workspace.
+        await supabase.from("epb_saved_examples").insert(
+          versions.map((statement) => ({
+            shell_id: shell!.id,
+            section_id: section.id,
+            mpa: selection.mpaKey,
+            statement_text: statement,
+            created_by: profile.id,
+            created_by_name: profile.full_name,
+            created_by_rank: profile.rank,
+            note: "Generated by Generate EPB",
+          })) as never
+        );
+
+        const conflictStage =
+          conflictPolicy === "stage" &&
+          isSubstantialEpbStatement(existingMpaText.get(selection.mpaKey));
+
+        if (conflictStage) {
+          setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "staged" }));
+        } else {
+          await supabase
+            .from("epb_shell_sections")
+            .update({
+              statement_text: versions[0],
+              last_edited_by: profile.id,
+              updated_at: new Date().toISOString(),
+            } as never)
+            .eq("id", section.id);
+          setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "done" }));
+        }
+        if (!firstCompleted) firstCompleted = selection.mpaKey;
       } catch {
         setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "failed" }));
       }
@@ -481,8 +543,7 @@ export function GenerateEpbDialog({
 
     Analytics.generateCompleted(model, 0, runSelections.length);
 
-    const anySuccess = firstCompleted != null;
-    if (anySuccess) {
+    if (firstCompleted != null) {
       toast.success("EPB generated — opening your workspace");
       navigateToEpb(firstCompleted);
     } else {
@@ -567,14 +628,33 @@ export function GenerateEpbDialog({
                             aria-label="Duty description"
                             className={motionInputFocus}
                           />
-                          <p className="mt-1 text-right text-xs text-muted-foreground tabular-nums">
-                            {dutyDraft.length}/{MAX_DUTY_DESCRIPTION_CHARACTERS}
-                          </p>
+                          <div className="mt-1 flex items-center justify-between gap-3">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className={cn("h-8", motionPressOnly)}
+                              disabled={dutyGenerating || !dutyDraft.trim()}
+                              onClick={handleImproveDuty}
+                            >
+                              {dutyGenerating ? (
+                                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                              ) : (
+                                <Sparkles className="mr-1.5 size-3.5" />
+                              )}
+                              Improve with AI
+                              <TokenCostBadge cost={1} compact className="ml-1.5" />
+                            </Button>
+                            <span className="text-xs text-muted-foreground tabular-nums">
+                              {dutyDraft.length}/{MAX_DUTY_DESCRIPTION_CHARACTERS}
+                            </span>
+                          </div>
                         </>
                       )}
-                      <p className="mt-1 text-xs text-muted-foreground leading-snug">
-                        Saved to this EPB and used as context when writing every
-                        statement.
+                      <p className="mt-2 text-xs text-muted-foreground leading-snug">
+                        Draft a short duty description, then improve it with AI
+                        (rephrase only — no invented scope). Saved to this EPB and
+                        used as context when writing every statement.
                       </p>
                     </div>
                   ) : (

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -51,6 +51,7 @@ import { createEpbShell } from "@/lib/epb-shell-create";
 import {
   buildMpaCustomContext,
   combineVersions,
+  editableFromRecords,
   editableToMpaSelections,
   extractVersionArrays,
   mpaLabel,
@@ -59,10 +60,15 @@ import {
   type EditablePlan,
   type MpaRunStatus,
 } from "@/lib/generate-epb-run";
-import type { EpbPlan, PlanAccomplishmentRecord } from "@/lib/plan-epb";
+import {
+  toPlanRecords,
+  type EpbPlan,
+  type PlanAccomplishmentRecord,
+} from "@/lib/plan-epb";
 import type { EpbGenerationReadiness } from "@/lib/epb-generation-readiness";
 import { Analytics } from "@/lib/analytics";
 import type {
+  Accomplishment,
   EPBShell,
   EPBShellSection,
   Rank,
@@ -99,6 +105,12 @@ export interface GenerateEpbDialogProps {
   onOpenChange: (open: boolean) => void;
   ratee: SelectedRatee;
   readiness: EpbGenerationReadiness;
+  /** Pre-selected accomplishments from /entries — skips the AI selection step. */
+  preselected?: Accomplishment[];
+  /** Active shell (fetched by the opener) so we can gate the duty workbench. */
+  initialShell?: ShellWithSections | null;
+  /** Existing duty description text (from the active shell), for the preflight. */
+  initialDutyDescription?: string;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -110,6 +122,9 @@ export function GenerateEpbDialog({
   onOpenChange,
   ratee,
   readiness,
+  preselected,
+  initialShell,
+  initialDutyDescription,
 }: GenerateEpbDialogProps) {
   const router = useRouter();
   const supabase = createClient();
@@ -117,20 +132,34 @@ export function GenerateEpbDialog({
   const { setSelectedRatee, setSectionCollapsed, collapseAll } =
     useEPBShellStore();
 
+  const preselectedRecords = preselected?.length
+    ? toPlanRecords(preselected)
+    : [];
+  const isPreselected = preselectedRecords.length > 0;
+  const dutyProvided = initialDutyDescription !== undefined;
+
   const [step, setStep] = useState<DialogStep>("preflight");
-  const [records, setRecords] = useState<PlanAccomplishmentRecord[]>([]);
-  const [editable, setEditable] = useState<EditablePlan>({});
+  const [records, setRecords] = useState<PlanAccomplishmentRecord[]>(
+    () => preselectedRecords
+  );
+  const [editable, setEditable] = useState<EditablePlan>(() =>
+    isPreselected ? editableFromRecords(preselectedRecords) : {}
+  );
   const [rationaleByMpa, setRationaleByMpa] = useState<Record<string, string>>(
     {}
   );
-  const [activeShell, setActiveShell] = useState<ShellWithSections | null>(null);
+  const [activeShell, setActiveShell] = useState<ShellWithSections | null>(
+    initialShell ?? null
+  );
   const [conflictPolicy, setConflictPolicy] =
     useState<ConflictPolicy>("overwrite");
   const [runStatus, setRunStatus] = useState<Record<string, MpaRunStatus>>({});
   const [errorMessage, setErrorMessage] = useState("");
-  const [showDuty, setShowDuty] = useState(false);
-  const [dutyDraft, setDutyDraft] = useState("");
-  const [dutyLoaded, setDutyLoaded] = useState(false);
+  const [showDuty, setShowDuty] = useState(
+    () => (initialDutyDescription ?? "").trim() === "" && dutyProvided
+  );
+  const [dutyDraft, setDutyDraft] = useState(() => initialDutyDescription ?? "");
+  const [dutyLoaded, setDutyLoaded] = useState(dutyProvided);
   const [dutyLoading, setDutyLoading] = useState(false);
   const [dutyGenerating, setDutyGenerating] = useState(false);
 
@@ -579,6 +608,18 @@ export function GenerateEpbDialog({
 
             <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8 sm:py-7">
               <div className="flex flex-col gap-5">
+                {isPreselected && (
+                  <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 sm:p-5">
+                    <p className="text-sm font-medium">
+                      Using your {preselectedRecords.length} selected accomplishment
+                      {preselectedRecords.length === 1 ? "" : "s"}
+                    </p>
+                    <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
+                      We&apos;ll skip AI selection and generate straight from these,
+                      grouped by their performance area.
+                    </p>
+                  </div>
+                )}
                 <div className="rounded-xl border bg-muted/20 p-4 sm:p-5">
                   <button
                     type="button"
@@ -642,7 +683,7 @@ export function GenerateEpbDialog({
                               ) : (
                                 <Sparkles className="mr-1.5 size-3.5" />
                               )}
-                              Improve with AI
+                              Revise with AI
                               <TokenCostBadge cost={1} compact className="ml-1.5" />
                             </Button>
                             <span className="text-xs text-muted-foreground tabular-nums">
@@ -692,15 +733,34 @@ export function GenerateEpbDialog({
               <Button variant="outline" className="h-10 px-5" onClick={() => handleOpenChange(false)}>
                 Cancel
               </Button>
-              <Button onClick={handleAnalyze} className={cn("h-10 px-5", motionPressOnly)}>
-                <Sparkles className="mr-2 size-4" />
-                Analyze accomplishments
-                <TokenCostBadge
-                  cost={1}
-                  compact
-                  className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
-                />
-              </Button>
+              {isPreselected ? (
+                <Button
+                  onClick={handleGenerate}
+                  disabled={selections.length === 0}
+                  className={cn("h-10 px-5", motionPressOnly)}
+                >
+                  <Sparkles className="mr-2 size-4" />
+                  Generate my EPB
+                  <TokenCostBadge
+                    cost={generateCost}
+                    compact
+                    className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
+                  />
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleAnalyze}
+                  className={cn("h-10 px-5", motionPressOnly)}
+                >
+                  <Sparkles className="mr-2 size-4" />
+                  Analyze accomplishments
+                  <TokenCostBadge
+                    cost={1}
+                    compact
+                    className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
+                  />
+                </Button>
+              )}
             </DialogFooter>
           </>
         )}

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -24,17 +24,24 @@ import {
   SelectItem,
   SelectTrigger,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/sonner";
 import { TokenCostBadge } from "@/components/billing/token-cost-badge";
 import { cn } from "@/lib/utils";
 import {
+  motionChevronOpen,
   motionEnter,
   motionEnterDurList,
+  motionEnterDurNormal,
+  motionInputFocus,
   motionListEnterStagger,
   motionPressOnly,
   motionSurfaceCard,
 } from "@/lib/motion/classes";
-import { getActiveCycleYear } from "@/lib/constants";
+import {
+  getActiveCycleYear,
+  MAX_DUTY_DESCRIPTION_CHARACTERS,
+} from "@/lib/constants";
 import {
   EPB_MODEL_PREFERENCE_STORAGE_KEY,
   getStoredModelPreference,
@@ -65,6 +72,8 @@ import {
   AlertTriangle,
   Check,
   CheckCircle2,
+  ChevronDown,
+  ClipboardList,
   FileWarning,
   Loader2,
   Plus,
@@ -114,6 +123,10 @@ export function GenerateEpbDialog({
     useState<ConflictPolicy>("overwrite");
   const [runStatus, setRunStatus] = useState<Record<string, MpaRunStatus>>({});
   const [errorMessage, setErrorMessage] = useState("");
+  const [showDuty, setShowDuty] = useState(false);
+  const [dutyDraft, setDutyDraft] = useState("");
+  const [dutyLoaded, setDutyLoaded] = useState(false);
+  const [dutyLoading, setDutyLoading] = useState(false);
 
   const model = getStoredModelPreference(EPB_MODEL_PREFERENCE_STORAGE_KEY);
   const writingStyle: WritingStyle =
@@ -139,6 +152,10 @@ export function GenerateEpbDialog({
     setConflictPolicy("overwrite");
     setRunStatus({});
     setErrorMessage("");
+    setShowDuty(false);
+    setDutyDraft("");
+    setDutyLoaded(false);
+    setDutyLoading(false);
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -158,6 +175,38 @@ export function GenerateEpbDialog({
       : query.eq("user_id", ratee.id).is("team_member_id", null);
     const { data } = await query.limit(1).maybeSingle();
     return (data as ShellWithSections | null) ?? null;
+  };
+
+  const handleToggleDuty = async () => {
+    const next = !showDuty;
+    setShowDuty(next);
+    if (next && !dutyLoaded) {
+      setDutyLoading(true);
+      try {
+        const shell = await findActiveShell();
+        if (shell) setActiveShell(shell);
+        setDutyDraft(shell?.duty_description ?? "");
+      } catch {
+        // best-effort: user can still type a duty description
+      } finally {
+        setDutyLoaded(true);
+        setDutyLoading(false);
+      }
+    }
+  };
+
+  const persistDutyDescription = async (shell: ShellWithSections) => {
+    if (!profile) return;
+    const value = dutyDraft.trim();
+    if (value === (shell.duty_description ?? "").trim()) return;
+    await supabase
+      .from("epb_shells")
+      .update({
+        duty_description: value,
+        updated_at: new Date().toISOString(),
+      } as never)
+      .eq("id", shell.id);
+    setActiveShell({ ...shell, duty_description: value });
   };
 
   const handleAnalyze = async () => {
@@ -321,6 +370,13 @@ export function GenerateEpbDialog({
       }
     }
 
+    try {
+      await persistDutyDescription(shell);
+    } catch {
+      // non-fatal: fall back to the in-memory duty description below
+    }
+    const dutyDescription = dutyDraft.trim() || (shell.duty_description ?? "");
+
     const cycleYear = getActiveCycleYear(ratee.rank as Rank | null);
     let firstCompleted: string | null = null;
 
@@ -346,6 +402,7 @@ export function GenerateEpbDialog({
             selectedMPAs: [selection.mpaKey],
             customContext,
             customContextOptions: { statementCount: selection.sentenceCount },
+            dutyDescription,
             accomplishments: mpaRecords.map((r) => ({
               id: r.id,
               mpa: selection.mpaKey,
@@ -462,13 +519,72 @@ export function GenerateEpbDialog({
             <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8 sm:py-7">
               <div className="flex flex-col gap-5">
                 <div className="rounded-xl border bg-muted/20 p-4 sm:p-5">
-                  <p className="text-sm font-semibold">Before you start</p>
-                  <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
-                    Filling out the duty description first gives the AI better
-                    context for higher-quality statements. You can add it on the
-                    EPB workspace. Higher-Level Reviewer (HLR) is generated
-                    separately after you&apos;re happy with the MPAs.
-                  </p>
+                  <button
+                    type="button"
+                    onClick={handleToggleDuty}
+                    aria-expanded={showDuty}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-3 text-left",
+                      motionPressOnly
+                    )}
+                  >
+                    <span className="flex items-center gap-2">
+                      <ClipboardList className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="text-sm font-semibold">
+                        Duty description{" "}
+                        <span className="font-normal text-muted-foreground">
+                          (optional — improves quality)
+                        </span>
+                      </span>
+                    </span>
+                    <ChevronDown
+                      className={cn("size-4 text-muted-foreground", motionChevronOpen)}
+                      data-open={showDuty}
+                    />
+                  </button>
+
+                  {showDuty ? (
+                    <div className={cn("mt-3", motionEnter, motionEnterDurNormal)}>
+                      {dutyLoading ? (
+                        <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+                          <Loader2 className="size-4 animate-spin" />
+                          Loading current duty description…
+                        </div>
+                      ) : (
+                        <>
+                          <Textarea
+                            value={dutyDraft}
+                            onChange={(e) =>
+                              setDutyDraft(
+                                e.target.value.slice(
+                                  0,
+                                  MAX_DUTY_DESCRIPTION_CHARACTERS
+                                )
+                              )
+                            }
+                            rows={4}
+                            placeholder="e.g., Serves as NCOIC of a 12-person section; responsible for $2M in network assets supporting 500+ users across the wing."
+                            aria-label="Duty description"
+                            className={motionInputFocus}
+                          />
+                          <p className="mt-1 text-right text-xs text-muted-foreground tabular-nums">
+                            {dutyDraft.length}/{MAX_DUTY_DESCRIPTION_CHARACTERS}
+                          </p>
+                        </>
+                      )}
+                      <p className="mt-1 text-xs text-muted-foreground leading-snug">
+                        Saved to this EPB and used as context when writing every
+                        statement.
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
+                      Adding a duty description first gives the AI better context
+                      for higher-quality statements. Higher-Level Reviewer (HLR)
+                      is generated separately after you&apos;re happy with the
+                      MPAs.
+                    </p>
+                  )}
                 </div>
 
                 {readiness.warnings.length > 0 && (

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -395,8 +395,7 @@ export function GenerateEpbDialog({
   const chipLabel = (id: string): string => {
     const r = recordsById.get(id);
     if (!r) return id;
-    const detail = r.details.length > 42 ? `${r.details.slice(0, 42)}…` : r.details;
-    return `${r.action_verb} — ${detail}`;
+    return `${r.action_verb} — ${r.details}`;
   };
 
   const navigateToEpb = (firstMpa: string | null) => {
@@ -908,14 +907,16 @@ export function GenerateEpbDialog({
                                 {group.map((id) => (
                                   <span
                                     key={id}
-                                    className="inline-flex max-w-full items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs"
+                                    className="flex w-full items-start gap-1.5 rounded-md border bg-background px-2 py-1 text-xs"
                                   >
-                                    <span className="truncate">{chipLabel(id)}</span>
+                                    <span className="min-w-0 flex-1 whitespace-normal break-words leading-snug">
+                                      {chipLabel(id)}
+                                    </span>
                                     <button
                                       type="button"
                                       onClick={() => removeId(mpaKey, groupIdx, id)}
                                       aria-label={`Remove ${chipLabel(id)}`}
-                                      className="shrink-0 text-muted-foreground hover:text-destructive"
+                                      className="mt-0.5 shrink-0 text-muted-foreground hover:text-destructive"
                                     >
                                       <X className="size-3" />
                                     </button>

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -1,0 +1,823 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { useUserStore } from "@/stores/user-store";
+import { useEPBShellStore, type SelectedRatee } from "@/stores/epb-shell-store";
+import { handleUsageLimitResponse } from "@/stores/usage-limit-store";
+import { billableFetch } from "@/lib/fetch-with-retry";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/sonner";
+import { TokenCostBadge } from "@/components/billing/token-cost-badge";
+import { cn } from "@/lib/utils";
+import {
+  motionEnter,
+  motionEnterDurList,
+  motionListEnterStagger,
+  motionPressOnly,
+  motionSurfaceCard,
+} from "@/lib/motion/classes";
+import { getActiveCycleYear } from "@/lib/constants";
+import {
+  EPB_MODEL_PREFERENCE_STORAGE_KEY,
+  getStoredModelPreference,
+} from "@/lib/model-preferences";
+import { isSubstantialEpbStatement } from "@/lib/fuse-to-epb";
+import { createEpbShell } from "@/lib/epb-shell-create";
+import {
+  buildMpaCustomContext,
+  combineVersions,
+  editableToMpaSelections,
+  extractVersionArrays,
+  mpaLabel,
+  planToEditable,
+  type ConflictPolicy,
+  type EditablePlan,
+  type MpaRunStatus,
+} from "@/lib/generate-epb-run";
+import type { EpbPlan, PlanAccomplishmentRecord } from "@/lib/plan-epb";
+import type { EpbGenerationReadiness } from "@/lib/epb-generation-readiness";
+import { Analytics } from "@/lib/analytics";
+import type {
+  EPBShell,
+  EPBShellSection,
+  Rank,
+  WritingStyle,
+} from "@/types/database";
+import {
+  AlertTriangle,
+  Check,
+  CheckCircle2,
+  FileWarning,
+  Loader2,
+  Plus,
+  Sparkles,
+  X,
+} from "lucide-react";
+
+type DialogStep = "preflight" | "planning" | "review" | "generating" | "error";
+
+type ShellWithSections = EPBShell & { sections: EPBShellSection[] };
+
+const VERSION_COUNT = 3;
+/** Pace between MPA generations to stay under the burst limit (5 / 60s). */
+const PACING_MS = 1200;
+
+export interface GenerateEpbDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  ratee: SelectedRatee;
+  readiness: EpbGenerationReadiness;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function GenerateEpbDialog({
+  open,
+  onOpenChange,
+  ratee,
+  readiness,
+}: GenerateEpbDialogProps) {
+  const router = useRouter();
+  const supabase = createClient();
+  const { profile } = useUserStore();
+  const { setSelectedRatee, setSectionCollapsed, collapseAll } =
+    useEPBShellStore();
+
+  const [step, setStep] = useState<DialogStep>("preflight");
+  const [records, setRecords] = useState<PlanAccomplishmentRecord[]>([]);
+  const [editable, setEditable] = useState<EditablePlan>({});
+  const [rationaleByMpa, setRationaleByMpa] = useState<Record<string, string>>(
+    {}
+  );
+  const [activeShell, setActiveShell] = useState<ShellWithSections | null>(null);
+  const [conflictPolicy, setConflictPolicy] =
+    useState<ConflictPolicy>("overwrite");
+  const [runStatus, setRunStatus] = useState<Record<string, MpaRunStatus>>({});
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const model = getStoredModelPreference(EPB_MODEL_PREFERENCE_STORAGE_KEY);
+  const writingStyle: WritingStyle =
+    (profile?.writing_style as WritingStyle | undefined) || "personal";
+
+  const recordsById = new Map(records.map((r) => [r.id, r] as const));
+  const selections = editableToMpaSelections(editable);
+
+  const existingMpaText = new Map<string, string>();
+  for (const section of activeShell?.sections ?? []) {
+    existingMpaText.set(section.mpa, section.statement_text ?? "");
+  }
+  const conflictingMpas = selections
+    .map((s) => s.mpaKey)
+    .filter((mpa) => isSubstantialEpbStatement(existingMpaText.get(mpa)));
+
+  const resetLocal = () => {
+    setStep("preflight");
+    setRecords([]);
+    setEditable({});
+    setRationaleByMpa({});
+    setActiveShell(null);
+    setConflictPolicy("overwrite");
+    setRunStatus({});
+    setErrorMessage("");
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (step === "generating") return; // don't close mid-run
+    if (!next) resetLocal();
+    onOpenChange(next);
+  };
+
+  const findActiveShell = async (): Promise<ShellWithSections | null> => {
+    let query = supabase
+      .from("epb_shells")
+      .select(`*, sections:epb_shell_sections(*)`)
+      .neq("status", "archived")
+      .order("updated_at", { ascending: false });
+    query = ratee.isManagedMember
+      ? query.eq("team_member_id", ratee.id)
+      : query.eq("user_id", ratee.id).is("team_member_id", null);
+    const { data } = await query.limit(1).maybeSingle();
+    return (data as ShellWithSections | null) ?? null;
+  };
+
+  const handleAnalyze = async () => {
+    if (!profile) return;
+    setStep("planning");
+    setErrorMessage("");
+    try {
+      const cycleYear = getActiveCycleYear(ratee.rank as Rank | null);
+      const [shell, response] = await Promise.all([
+        findActiveShell().catch(() => null),
+        billableFetch("/api/plan-epb", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            rateeId: ratee.id,
+            isManagedMember: Boolean(ratee.isManagedMember),
+            rateeRank: ratee.rank,
+            rateeAfsc: ratee.afsc,
+            cycleYear,
+            model,
+          }),
+        }),
+      ]);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        if (handleUsageLimitResponse(errorData)) {
+          setStep("preflight");
+          return;
+        }
+        throw new Error(errorData.error || "Planning failed");
+      }
+
+      const data = (await response.json()) as {
+        plan: EpbPlan;
+        records: PlanAccomplishmentRecord[];
+      };
+      setActiveShell(shell);
+      setRecords(data.records ?? []);
+      setEditable(planToEditable(data.plan));
+      setRationaleByMpa(
+        Object.fromEntries(
+          data.plan.mpas.map((m) => [
+            m.mpaKey,
+            m.sentences.map((s) => s.rationale).filter(Boolean).join(" · "),
+          ])
+        )
+      );
+      setStep("review");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to analyze accomplishments"
+      );
+      setStep("error");
+    }
+  };
+
+  const updateMpa = (
+    mpaKey: string,
+    updater: (prev: { enabled: boolean; groups: string[][] }) => {
+      enabled: boolean;
+      groups: string[][];
+    }
+  ) => {
+    setEditable((prev) => ({ ...prev, [mpaKey]: updater(prev[mpaKey]) }));
+  };
+
+  const removeId = (mpaKey: string, groupIdx: number, id: string) =>
+    updateMpa(mpaKey, (prev) => ({
+      ...prev,
+      groups: prev.groups.map((g, i) =>
+        i === groupIdx ? g.filter((x) => x !== id) : g
+      ),
+    }));
+
+  const addId = (mpaKey: string, groupIdx: number, id: string) =>
+    updateMpa(mpaKey, (prev) => ({
+      ...prev,
+      groups: prev.groups.map((g, i) =>
+        i === groupIdx && !g.includes(id) ? [...g, id] : g
+      ),
+    }));
+
+  const removeGroup = (mpaKey: string, groupIdx: number) =>
+    updateMpa(mpaKey, (prev) => ({
+      ...prev,
+      groups: prev.groups.filter((_, i) => i !== groupIdx),
+    }));
+
+  const addGroup = (mpaKey: string) =>
+    updateMpa(mpaKey, (prev) =>
+      prev.groups.length >= 2 ? prev : { ...prev, groups: [...prev.groups, []] }
+    );
+
+  const toggleMpa = (mpaKey: string) =>
+    updateMpa(mpaKey, (prev) => ({ ...prev, enabled: !prev.enabled }));
+
+  const chipLabel = (id: string): string => {
+    const r = recordsById.get(id);
+    if (!r) return id;
+    const detail = r.details.length > 42 ? `${r.details.slice(0, 42)}…` : r.details;
+    return `${r.action_verb} — ${detail}`;
+  };
+
+  const navigateToEpb = (firstMpa: string | null) => {
+    setSelectedRatee(ratee);
+    collapseAll();
+    if (firstMpa) setSectionCollapsed(firstMpa, false);
+    if (profile) {
+      const storageValue = ratee.isManagedMember
+        ? `managed:${ratee.id}`
+        : ratee.id === profile.id
+          ? "self"
+          : ratee.id;
+      try {
+        localStorage.setItem(
+          `epb-selected-ratee-${profile.id}`,
+          JSON.stringify({ value: storageValue, ratee })
+        );
+      } catch {
+        // ignore quota / private mode
+      }
+    }
+    handleOpenChange(false);
+    router.push("/epb");
+  };
+
+  const handleGenerate = async () => {
+    if (!profile) return;
+    const runSelections = editableToMpaSelections(editable);
+    if (runSelections.length === 0) {
+      toast.error("Select at least one performance area to generate.");
+      return;
+    }
+
+    setStep("generating");
+    setRunStatus(
+      Object.fromEntries(runSelections.map((s) => [s.mpaKey, "queued"]))
+    );
+
+    let shell = activeShell;
+    if (!shell) {
+      try {
+        const result = await createEpbShell(supabase, {
+          ratee,
+          profileId: profile.id,
+        });
+        if (result.status === "active_exists" || result.status === "archived_conflict") {
+          throw new Error(
+            "Could not open an EPB shell for this cycle. Open EPB to resolve, then retry."
+          );
+        }
+        shell = result.shell as ShellWithSections;
+        setActiveShell(shell);
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error ? error.message : "Failed to create EPB shell"
+        );
+        setStep("error");
+        return;
+      }
+    }
+
+    const cycleYear = getActiveCycleYear(ratee.rank as Rank | null);
+    let firstCompleted: string | null = null;
+
+    for (const selection of runSelections) {
+      setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "generating" }));
+      try {
+        const mpaRecords = selection.accomplishmentIds
+          .map((id) => recordsById.get(id))
+          .filter((r): r is PlanAccomplishmentRecord => !!r);
+        const customContext = buildMpaCustomContext(mpaRecords);
+
+        const response = await billableFetch("/api/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            rateeId: ratee.id,
+            isManagedMember: Boolean(ratee.isManagedMember),
+            rateeRank: ratee.rank,
+            rateeAfsc: ratee.afsc,
+            cycleYear,
+            model,
+            writingStyle,
+            selectedMPAs: [selection.mpaKey],
+            customContext,
+            customContextOptions: { statementCount: selection.sentenceCount },
+            accomplishments: mpaRecords.map((r) => ({
+              id: r.id,
+              mpa: selection.mpaKey,
+              action_verb: r.action_verb,
+              details: r.details,
+              impact: r.impact,
+              metrics: r.metrics,
+            })),
+            requestClarifyingQuestions: false,
+            versionCount: VERSION_COUNT,
+          }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          if (handleUsageLimitResponse(errorData)) {
+            setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "failed" }));
+            break;
+          }
+          throw new Error(errorData.error || "Generation failed");
+        }
+
+        const result = await response.json();
+        const versions = combineVersions(
+          extractVersionArrays(result.statements?.[0]),
+          selection.sentenceCount
+        );
+        if (versions.length === 0) {
+          setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "failed" }));
+          continue;
+        }
+
+        const section = shell.sections?.find((s) => s.mpa === selection.mpaKey);
+        if (section) {
+          // Stage all versions for one-tap swap in the workspace.
+          await supabase.from("epb_saved_examples").insert(
+            versions.map((statement) => ({
+              shell_id: shell!.id,
+              section_id: section.id,
+              mpa: selection.mpaKey,
+              statement_text: statement,
+              created_by: profile.id,
+              created_by_name: profile.full_name,
+              created_by_rank: profile.rank,
+              note: "Generated by Generate EPB",
+            })) as never
+          );
+
+          const conflictStage =
+            conflictPolicy === "stage" &&
+            isSubstantialEpbStatement(existingMpaText.get(selection.mpaKey));
+
+          if (conflictStage) {
+            setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "staged" }));
+          } else {
+            await supabase
+              .from("epb_shell_sections")
+              .update({
+                statement_text: versions[0],
+                last_edited_by: profile.id,
+                updated_at: new Date().toISOString(),
+              } as never)
+              .eq("id", section.id);
+            setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "done" }));
+          }
+          if (!firstCompleted) firstCompleted = selection.mpaKey;
+        } else {
+          setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "failed" }));
+        }
+      } catch {
+        setRunStatus((prev) => ({ ...prev, [selection.mpaKey]: "failed" }));
+      }
+
+      await sleep(PACING_MS);
+    }
+
+    Analytics.generateCompleted(model, 0, runSelections.length);
+
+    const anySuccess = firstCompleted != null;
+    if (anySuccess) {
+      toast.success("EPB generated — opening your workspace");
+      navigateToEpb(firstCompleted);
+    } else {
+      setErrorMessage(
+        "No statements were generated. Check your accomplishments or API key and try again."
+      );
+      setStep("error");
+    }
+  };
+
+  const generateCost = selections.length;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        size="2xl"
+        className="flex max-h-[min(92vh,880px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl"
+        aria-describedby="generate-epb-desc"
+      >
+        {step === "preflight" && (
+          <>
+            <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
+              <DialogTitle className="text-xl">Generate EPB</DialogTitle>
+              <DialogDescription id="generate-epb-desc" className="text-sm leading-relaxed">
+                AI reviews all cycle accomplishments for{" "}
+                <span className="font-medium text-foreground">
+                  {ratee.rank} {ratee.fullName || "this member"}
+                </span>{" "}
+                and drafts statements for each performance area. You&apos;ll
+                review its selection before anything is generated.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8 sm:py-7">
+              <div className="flex flex-col gap-5">
+                <div className="rounded-xl border bg-muted/20 p-4 sm:p-5">
+                  <p className="text-sm font-semibold">Before you start</p>
+                  <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
+                    Filling out the duty description first gives the AI better
+                    context for higher-quality statements. You can add it on the
+                    EPB workspace. Higher-Level Reviewer (HLR) is generated
+                    separately after you&apos;re happy with the MPAs.
+                  </p>
+                </div>
+
+                {readiness.warnings.length > 0 && (
+                  <ul className="space-y-2">
+                    {readiness.warnings.map((warning, index) => (
+                      <li
+                        key={warning}
+                        className={cn(
+                          "flex items-start gap-2 rounded-lg border border-amber-400/40 bg-amber-50 px-3 py-2.5 text-sm text-amber-800 dark:bg-amber-950/30 dark:text-amber-200",
+                          motionEnter,
+                          motionEnterDurList
+                        )}
+                        style={motionListEnterStagger(index)}
+                      >
+                        <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                        <span className="leading-snug">{warning}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+
+            <DialogFooter className="shrink-0 gap-3 border-t bg-muted/20 px-6 py-4 sm:px-8 sm:justify-between">
+              <Button variant="outline" className="h-10 px-5" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleAnalyze} className={cn("h-10 px-5", motionPressOnly)}>
+                <Sparkles className="mr-2 size-4" />
+                Analyze accomplishments
+                <TokenCostBadge
+                  cost={1}
+                  compact
+                  className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
+                />
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === "planning" && (
+          <>
+            <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
+              <DialogTitle className="text-xl">Selecting your best work</DialogTitle>
+              <DialogDescription>
+                Analyzing accomplishments and grouping the ones that combine
+                into stronger statements…
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16">
+              <Loader2 className="size-10 animate-spin text-muted-foreground" />
+            </div>
+          </>
+        )}
+
+        {step === "review" && (
+          <>
+            <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
+              <DialogTitle className="text-xl">Review the AI&apos;s selection</DialogTitle>
+              <DialogDescription className="text-sm leading-relaxed">
+                Each sentence group becomes one statement (like accomplishments
+                are combined). Remove or add entries, or turn off an area.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8 sm:py-7">
+              <div className="flex flex-col gap-4">
+                {conflictingMpas.length > 0 && (
+                  <div className="rounded-xl border border-amber-400/40 bg-amber-50 p-4 dark:bg-amber-950/30">
+                    <div className="flex items-start gap-2">
+                      <FileWarning className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-300" />
+                      <div className="flex-1">
+                        <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+                          {conflictingMpas.length} area
+                          {conflictingMpas.length === 1 ? "" : "s"} already{" "}
+                          {conflictingMpas.length === 1 ? "has" : "have"} a statement
+                        </p>
+                        <p className="mt-0.5 text-xs text-amber-700/90 dark:text-amber-300/90">
+                          {conflictingMpas.map(mpaLabel).join(", ")}
+                        </p>
+                        <div
+                          className="mt-3 grid grid-cols-2 gap-2"
+                          role="group"
+                          aria-label="What to do with existing statements"
+                        >
+                          {(["overwrite", "stage"] as const).map((policy) => (
+                            <button
+                              key={policy}
+                              type="button"
+                              onClick={() => setConflictPolicy(policy)}
+                              aria-pressed={conflictPolicy === policy}
+                              className={cn(
+                                "h-10 rounded-lg border text-sm font-medium",
+                                motionPressOnly,
+                                conflictPolicy === policy
+                                  ? "border-primary bg-primary text-primary-foreground"
+                                  : "bg-background hover:bg-muted"
+                              )}
+                            >
+                              {policy === "overwrite"
+                                ? "Overwrite them"
+                                : "Keep & stage new"}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {selections.length === 0 && (
+                  <p className="rounded-lg border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+                    No performance areas selected. Enable at least one below.
+                  </p>
+                )}
+
+                {Object.keys(editable).map((mpaKey, index) => {
+                  const entry = editable[mpaKey];
+                  const usedIds = new Set(entry.groups.flat());
+                  const available = records.filter(
+                    (r) => !usedIds.has(r.id)
+                  );
+                  return (
+                    <section
+                      key={mpaKey}
+                      className={cn(
+                        "rounded-xl border bg-background p-4 sm:p-5",
+                        motionSurfaceCard,
+                        motionEnter,
+                        motionEnterDurList,
+                        !entry.enabled && "opacity-60"
+                      )}
+                      style={motionListEnterStagger(index)}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <label className="flex items-center gap-2.5">
+                          <Checkbox
+                            checked={entry.enabled}
+                            onCheckedChange={() => toggleMpa(mpaKey)}
+                            aria-label={`Include ${mpaLabel(mpaKey)}`}
+                          />
+                          <span className="text-sm font-semibold">
+                            {mpaLabel(mpaKey)}
+                          </span>
+                        </label>
+                        <Badge variant="outline" className="text-[10px]">
+                          {entry.groups.filter((g) => g.length > 0).length || 0} sentence
+                          {entry.groups.filter((g) => g.length > 0).length === 1
+                            ? ""
+                            : "s"}
+                        </Badge>
+                      </div>
+
+                      {rationaleByMpa[mpaKey] && (
+                        <p className="mt-2 text-xs italic text-muted-foreground leading-snug">
+                          {rationaleByMpa[mpaKey]}
+                        </p>
+                      )}
+
+                      {entry.enabled && (
+                        <div className="mt-3 space-y-3">
+                          {entry.groups.map((group, groupIdx) => (
+                            <div
+                              key={`${mpaKey}-g${groupIdx}`}
+                              className="rounded-lg border bg-muted/20 p-3"
+                            >
+                              <div className="mb-2 flex items-center justify-between">
+                                <span className="text-xs font-medium text-muted-foreground">
+                                  Sentence {groupIdx + 1}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() => removeGroup(mpaKey, groupIdx)}
+                                  className="text-xs text-muted-foreground hover:text-destructive"
+                                  aria-label={`Remove sentence ${groupIdx + 1}`}
+                                >
+                                  Remove
+                                </button>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                {group.map((id) => (
+                                  <span
+                                    key={id}
+                                    className="inline-flex max-w-full items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs"
+                                  >
+                                    <span className="truncate">{chipLabel(id)}</span>
+                                    <button
+                                      type="button"
+                                      onClick={() => removeId(mpaKey, groupIdx, id)}
+                                      aria-label={`Remove ${chipLabel(id)}`}
+                                      className="shrink-0 text-muted-foreground hover:text-destructive"
+                                    >
+                                      <X className="size-3" />
+                                    </button>
+                                  </span>
+                                ))}
+                                {group.length === 0 && (
+                                  <span className="text-xs text-muted-foreground">
+                                    Add an accomplishment to this sentence.
+                                  </span>
+                                )}
+                              </div>
+                              {available.length > 0 && (
+                                <div className="mt-2">
+                                  <Select
+                                    value=""
+                                    onValueChange={(id) => addId(mpaKey, groupIdx, id)}
+                                  >
+                                    <SelectTrigger
+                                      className="h-8 text-xs"
+                                      aria-label={`Add accomplishment to sentence ${groupIdx + 1}`}
+                                    >
+                                      <span className="flex items-center gap-1.5 text-muted-foreground">
+                                        <Plus className="size-3.5" />
+                                        Add accomplishment
+                                      </span>
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {available.map((r) => (
+                                        <SelectItem key={r.id} value={r.id}>
+                                          {chipLabel(r.id)}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                </div>
+                              )}
+                            </div>
+                          ))}
+                          {entry.groups.length < 2 && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 text-xs"
+                              onClick={() => addGroup(mpaKey)}
+                            >
+                              <Plus className="mr-1.5 size-3.5" />
+                              Add second sentence
+                            </Button>
+                          )}
+                        </div>
+                      )}
+                    </section>
+                  );
+                })}
+              </div>
+            </div>
+
+            <DialogFooter className="shrink-0 gap-3 border-t bg-muted/20 px-6 py-4 sm:px-8 sm:justify-between">
+              <Button variant="outline" className="h-10 px-5" onClick={() => setStep("preflight")}>
+                Back
+              </Button>
+              <Button
+                onClick={handleGenerate}
+                disabled={selections.length === 0}
+                className={cn("h-10 px-5", motionPressOnly)}
+              >
+                <Sparkles className="mr-2 size-4" />
+                Generate my EPB
+                <TokenCostBadge
+                  cost={generateCost}
+                  compact
+                  className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
+                />
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === "generating" && (
+          <>
+            <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
+              <DialogTitle className="text-xl">Generating your EPB</DialogTitle>
+              <DialogDescription>
+                Writing each performance area. This runs one area at a time —
+                hang tight.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8 sm:py-7">
+              <ul className="space-y-2.5">
+                {selections.map((selection) => {
+                  const status = runStatus[selection.mpaKey] ?? "queued";
+                  return (
+                    <li
+                      key={selection.mpaKey}
+                      className="flex items-center justify-between gap-3 rounded-lg border bg-background px-4 py-3"
+                    >
+                      <span className="text-sm font-medium">
+                        {mpaLabel(selection.mpaKey)}
+                      </span>
+                      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        {status === "queued" && "Queued"}
+                        {status === "generating" && (
+                          <>
+                            <Loader2 className="size-3.5 animate-spin" />
+                            Generating…
+                          </>
+                        )}
+                        {status === "done" && (
+                          <>
+                            <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
+                            Written
+                          </>
+                        )}
+                        {status === "staged" && (
+                          <>
+                            <Check className="size-4 text-green-600 dark:text-green-400" />
+                            Staged to examples
+                          </>
+                        )}
+                        {status === "failed" && (
+                          <span className="text-destructive">Failed</span>
+                        )}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </>
+        )}
+
+        {step === "error" && (
+          <>
+            <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
+              <DialogTitle className="text-xl">Something went wrong</DialogTitle>
+              <DialogDescription className="text-sm leading-relaxed">
+                {errorMessage}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-14 text-center">
+              <div className="flex size-16 items-center justify-center rounded-full bg-destructive/10">
+                <AlertTriangle className="size-8 text-destructive" />
+              </div>
+            </div>
+            <DialogFooter className="shrink-0 gap-3 border-t bg-muted/20 px-6 py-4 sm:px-8 sm:justify-between">
+              <Button variant="outline" className="h-10 px-5" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+              <Button
+                className={cn("h-10 px-5", motionPressOnly)}
+                onClick={() => setStep(records.length > 0 ? "review" : "preflight")}
+              >
+                Try again
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/epb/epb-assessment-history-dialog.tsx
+++ b/src/components/epb/epb-assessment-history-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { motionListRow } from "@/lib/motion/classes";
+import { formatDateTime } from "@/lib/format";
+import { EPBAssessmentDialog } from "./epb-assessment-dialog";
+import type { EPBAssessmentResult } from "@/lib/constants";
+import { ChevronRight, History, Loader2, ClipboardCheck } from "lucide-react";
+
+/** A persisted EPB assessment row (see migration 209_epb_assessments). */
+export interface EpbAssessmentRecord {
+  id: string;
+  shell_id: string;
+  user_id: string;
+  created_by: string;
+  rank: string | null;
+  afsc: string | null;
+  model: string | null;
+  cycle_year: number | null;
+  overall_strength: string | null;
+  form_used: string | null;
+  assessment: EPBAssessmentResult;
+  created_at: string;
+}
+
+interface EpbAssessmentHistoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  assessments: EpbAssessmentRecord[];
+  isLoading?: boolean;
+}
+
+function humanizeStrength(value: string | null): string {
+  if (!value) return "—";
+  return value
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function strengthBadgeClass(value: string | null): string {
+  switch (value) {
+    case "far_exceeds":
+    case "significantly_exceeds":
+      return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+    case "exceeds":
+      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
+    case "meets":
+      return "bg-slate-500/15 text-slate-700 dark:text-slate-300 border-slate-500/30";
+    case "does_not_meet":
+      return "bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/30";
+    default:
+      return "bg-muted text-muted-foreground border-muted";
+  }
+}
+
+export function EpbAssessmentHistoryDialog({
+  open,
+  onOpenChange,
+  assessments,
+  isLoading = false,
+}: EpbAssessmentHistoryDialogProps) {
+  const [selected, setSelected] = useState<EpbAssessmentRecord | null>(null);
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-lg max-h-[85vh] gap-0 overflow-hidden p-0">
+          <DialogHeader className="border-b bg-muted/30 px-6 py-4">
+            <div className="flex items-center gap-3">
+              <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10">
+                <History className="size-5 text-primary" />
+              </div>
+              <div>
+                <DialogTitle className="text-lg">Assessment history</DialogTitle>
+                <DialogDescription className="text-xs">
+                  Every AI performance review saved for this EPB. Open one to view
+                  the full report.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          {isLoading ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-16">
+              <Loader2 className="size-8 animate-spin text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">Loading assessments…</p>
+            </div>
+          ) : assessments.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+              <div className="flex size-14 items-center justify-center rounded-full bg-muted/50">
+                <ClipboardCheck className="size-7 text-muted-foreground" />
+              </div>
+              <p className="text-sm font-medium">No assessments yet</p>
+              <p className="max-w-xs text-xs text-muted-foreground leading-relaxed">
+                Run an AI Performance Review to create your first assessment. Each
+                one is saved here so you can track progress over time.
+              </p>
+            </div>
+          ) : (
+            <ScrollArea className="max-h-[calc(85vh-88px)]">
+              <ul className="divide-y">
+                {assessments.map((record) => (
+                  <li key={record.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(record)}
+                      className={cn(
+                        "flex w-full items-center gap-3 px-6 py-4 text-left",
+                        motionListRow
+                      )}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-medium">
+                            {formatDateTime(record.created_at)}
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "text-[10px]",
+                              strengthBadgeClass(record.overall_strength)
+                            )}
+                          >
+                            {humanizeStrength(record.overall_strength)}
+                          </Badge>
+                        </div>
+                        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                          {record.form_used || "AF Form 931/932"}
+                          {record.assessment?.overallSummary
+                            ? ` — ${record.assessment.overallSummary}`
+                            : ""}
+                        </p>
+                      </div>
+                      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </ScrollArea>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <EPBAssessmentDialog
+        isOpen={selected !== null}
+        onClose={() => setSelected(null)}
+        assessment={selected?.assessment ?? null}
+      />
+    </>
+  );
+}

--- a/src/components/epb/epb-shell-form.tsx
+++ b/src/components/epb/epb-shell-form.tsx
@@ -42,6 +42,10 @@ import {
 import { CyclePeriodLabel } from "@/components/evaluation/cycle-period-label";
 import type { EPBAssessmentResult } from "@/lib/constants";
 import { EPBAssessmentDialog } from "./epb-assessment-dialog";
+import {
+  EpbAssessmentHistoryDialog,
+  type EpbAssessmentRecord,
+} from "./epb-assessment-history-dialog";
 import { ArchiveEPBDialog } from "./archive-epb-dialog";
 import {
   FileText,
@@ -56,6 +60,7 @@ import {
   Archive,
   AlertTriangle,
   Rows2,
+  History,
 } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { createEpbShell } from "@/lib/epb-shell-create";
@@ -188,6 +193,11 @@ export function EPBShellForm({
   const [showAssessmentDialog, setShowAssessmentDialog] = useState(false);
   const [isAssessing, setIsAssessing] = useState(false);
   const [assessmentResult, setAssessmentResult] = useState<EPBAssessmentResult | null>(null);
+
+  // EPB Assessment history (permanent records attached to the shell)
+  const [showAssessmentHistory, setShowAssessmentHistory] = useState(false);
+  const [assessmentHistory, setAssessmentHistory] = useState<EpbAssessmentRecord[]>([]);
+  const [isLoadingAssessmentHistory, setIsLoadingAssessmentHistory] = useState(false);
   
   // EPB Archive state
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
@@ -1820,6 +1830,28 @@ export function EPBShellForm({
     }
   }, [currentShell, selectedRatee]);
 
+  // Open the permanent assessment history for this shell (fetch on demand).
+  const handleOpenAssessmentHistory = useCallback(async () => {
+    if (!currentShell) return;
+    setIsLoadingAssessmentHistory(true);
+    setShowAssessmentHistory(true);
+    try {
+      const { data, error } = await supabase
+        .from("epb_assessments")
+        .select("*")
+        .eq("shell_id", currentShell.id)
+        .order("created_at", { ascending: false });
+      if (error) throw error;
+      setAssessmentHistory((data ?? []) as unknown as EpbAssessmentRecord[]);
+    } catch (error) {
+      console.error("Failed to load assessment history:", error);
+      toast.error("Failed to load assessment history");
+      setAssessmentHistory([]);
+    } finally {
+      setIsLoadingAssessmentHistory(false);
+    }
+  }, [currentShell, supabase]);
+
   // Loading state
   if (isLoadingShell) {
     return (
@@ -2068,6 +2100,30 @@ export function EPBShellForm({
             </TooltipContent>
           </Tooltip>
         )}
+
+        {/* Assessment History Button */}
+        {currentShell && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleOpenAssessmentHistory}
+                className="h-8 px-3 text-sm gap-1.5"
+              >
+                <History className="size-3.5" />
+                <span className="hidden sm:inline">History</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="max-w-[280px]">
+              <p className="font-medium text-xs">Assessment history</p>
+              <p className="text-[10px] text-muted-foreground mt-0.5">
+                View every saved AI performance review for this EPB and reopen the
+                full report.
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        )}
         
         {/* Archive EPB Button - Only show for active shells with content */}
         {currentShell && currentShell.status !== 'archived' && (
@@ -2240,6 +2296,14 @@ export function EPBShellForm({
         onClose={() => setShowAssessmentDialog(false)}
         assessment={assessmentResult}
         isLoading={isAssessing}
+      />
+
+      {/* EPB Assessment History */}
+      <EpbAssessmentHistoryDialog
+        open={showAssessmentHistory}
+        onOpenChange={setShowAssessmentHistory}
+        assessments={assessmentHistory}
+        isLoading={isLoadingAssessmentHistory}
       />
 
       {/* EPB Archive Dialog */}

--- a/src/lib/__tests__/epb-generation-readiness.test.ts
+++ b/src/lib/__tests__/epb-generation-readiness.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateEpbGenerationReadiness,
+  getMpasWithExistingStatements,
+  MIN_ELIGIBLE_MPAS,
+  MIN_TOTAL_ACA_ENTRIES,
+} from "../epb-generation-readiness";
+import type {
+  Accomplishment,
+  AccomplishmentAssessmentScores,
+} from "@/types/database";
+
+function scores(
+  overall: number,
+  primaryMpa: string
+): AccomplishmentAssessmentScores {
+  return {
+    overall_score: overall,
+    primary_mpa: primaryMpa,
+    secondary_mpa: null,
+    mpa_relevancy: {
+      executing_mission: primaryMpa === "executing_mission" ? overall : 20,
+      leading_people: primaryMpa === "leading_people" ? overall : 20,
+      managing_resources: primaryMpa === "managing_resources" ? overall : 20,
+      improving_unit: primaryMpa === "improving_unit" ? overall : 20,
+    },
+    quality_indicators: {
+      action_clarity: overall,
+      impact_significance: overall,
+      metrics_quality: overall,
+      scope_definition: overall,
+    },
+  };
+}
+
+let idCounter = 0;
+function entry(overrides: Partial<Accomplishment> = {}): Accomplishment {
+  idCounter += 1;
+  const base: Accomplishment = {
+    id: `acc-${idCounter}`,
+    user_id: "u1",
+    created_by: "u1",
+    team_member_id: null,
+    date: "2026-03-01",
+    action_verb: "Led",
+    details: "did a thing",
+    impact: "improved things",
+    metrics: null,
+    mpa: "executing_mission",
+    tags: [],
+    cycle_year: 2026,
+    assessment_scores: null,
+    assessed_at: null,
+    assessment_model: null,
+    created_at: "2026-03-01T00:00:00.000Z",
+    updated_at: "2026-03-01T00:00:00.000Z",
+  };
+  return { ...base, ...overrides };
+}
+
+function assessed(
+  mpa: string,
+  overall: number,
+  overrides: Partial<Accomplishment> = {}
+): Accomplishment {
+  return entry({
+    mpa,
+    assessment_scores: scores(overall, mpa),
+    assessed_at: "2026-03-02T00:00:00.000Z",
+    updated_at: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  });
+}
+
+describe("evaluateEpbGenerationReadiness", () => {
+  it("blocks when there are too few entries", () => {
+    const result = evaluateEpbGenerationReadiness([
+      assessed("executing_mission", 80),
+    ]);
+    expect(result.canGenerate).toBe(false);
+    expect(result.reasons.join(" ")).toContain(
+      `at least ${MIN_TOTAL_ACA_ENTRIES}`
+    );
+  });
+
+  it("blocks when fewer than the minimum MPAs are covered", () => {
+    const result = evaluateEpbGenerationReadiness([
+      assessed("executing_mission", 80),
+      assessed("executing_mission", 75),
+      assessed("executing_mission", 70),
+    ]);
+    expect(result.canGenerate).toBe(false);
+    expect(result.reasons.join(" ")).toContain(
+      `at least ${MIN_ELIGIBLE_MPAS} performance areas`
+    );
+  });
+
+  it("allows generation with coverage across MPAs", () => {
+    const result = evaluateEpbGenerationReadiness([
+      assessed("executing_mission", 80),
+      assessed("executing_mission", 78),
+      assessed("leading_people", 72),
+    ]);
+    expect(result.canGenerate).toBe(true);
+    expect(result.reasons).toHaveLength(0);
+    expect(result.eligibleMpaKeys).toEqual(
+      expect.arrayContaining(["executing_mission", "leading_people"])
+    );
+  });
+
+  it("gates non-enlisted ratees when a rank is provided", () => {
+    const entries = [
+      assessed("executing_mission", 80),
+      assessed("leading_people", 78),
+      assessed("managing_resources", 72),
+    ];
+    expect(
+      evaluateEpbGenerationReadiness(entries, { rank: "Civilian" }).canGenerate
+    ).toBe(false);
+    expect(
+      evaluateEpbGenerationReadiness(entries, { rank: "SSgt" }).canGenerate
+    ).toBe(true);
+  });
+
+  it("warns about empty MPAs, unassessed, and stale entries without blocking", () => {
+    const result = evaluateEpbGenerationReadiness([
+      assessed("executing_mission", 80),
+      assessed("leading_people", 78),
+      // unassessed
+      entry({ mpa: "managing_resources" }),
+      // stale: edited well after assessment
+      assessed("executing_mission", 65, {
+        assessed_at: "2026-03-02T00:00:00.000Z",
+        updated_at: "2026-03-05T00:00:00.000Z",
+      }),
+    ]);
+
+    expect(result.canGenerate).toBe(true);
+    expect(result.unassessedCount).toBe(1);
+    expect(result.staleCount).toBe(1);
+    const warningText = result.warnings.join(" ");
+    expect(warningText).toContain("Improving the Unit"); // empty MPA
+    expect(warningText).toContain("no AI assessment");
+    expect(warningText).toContain("edited after assessment");
+  });
+
+  it("marks per-MPA strength using the portfolio quality floor", () => {
+    const result = evaluateEpbGenerationReadiness([
+      assessed("executing_mission", 85),
+      assessed("executing_mission", 82),
+      assessed("leading_people", 40),
+    ]);
+    expect(result.perMpa.executing_mission.isStrong).toBe(true);
+    expect(result.perMpa.leading_people.isStrong).toBe(false);
+    expect(result.perMpa.improving_unit.hasContent).toBe(false);
+  });
+});
+
+describe("getMpasWithExistingStatements", () => {
+  it("returns only MPAs whose section holds a substantial statement", () => {
+    const result = getMpasWithExistingStatements([
+      {
+        mpa: "executing_mission",
+        statement_text:
+          "Spearheaded a squadron-wide migration effort improving readiness across the unit.",
+      },
+      { mpa: "leading_people", statement_text: "" },
+      { mpa: "managing_resources", statement_text: "x" },
+    ]);
+    expect(result).toEqual(["executing_mission"]);
+  });
+});

--- a/src/lib/__tests__/generate-epb-run.test.ts
+++ b/src/lib/__tests__/generate-epb-run.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  planToEditable,
+  editableToMpaSelections,
+  buildMpaCustomContext,
+  combineVersions,
+  extractVersionArrays,
+} from "../generate-epb-run";
+import type { EpbPlan, PlanAccomplishmentRecord } from "../plan-epb";
+
+describe("planToEditable + editableToMpaSelections", () => {
+  const plan: EpbPlan = {
+    mpas: [
+      {
+        mpaKey: "executing_mission",
+        sentences: [
+          { accomplishmentIds: ["a", "b"], rationale: "combine" },
+          { accomplishmentIds: ["c"], rationale: "solo" },
+        ],
+      },
+      {
+        mpaKey: "leading_people",
+        sentences: [{ accomplishmentIds: ["d"], rationale: "" }],
+      },
+    ],
+  };
+
+  it("maps a plan to enabled editable groups", () => {
+    const editable = planToEditable(plan);
+    expect(editable.executing_mission.enabled).toBe(true);
+    expect(editable.executing_mission.groups).toEqual([["a", "b"], ["c"]]);
+    expect(editable.leading_people.groups).toEqual([["d"]]);
+  });
+
+  it("unions ids and derives sentence count from non-empty groups", () => {
+    const selections = editableToMpaSelections(planToEditable(plan));
+    const em = selections.find((s) => s.mpaKey === "executing_mission")!;
+    expect(em.accomplishmentIds).toEqual(["a", "b", "c"]);
+    expect(em.sentenceCount).toBe(2);
+    const lp = selections.find((s) => s.mpaKey === "leading_people")!;
+    expect(lp.sentenceCount).toBe(1);
+  });
+
+  it("skips disabled MPAs and empty groups", () => {
+    const editable = planToEditable(plan);
+    editable.executing_mission.enabled = false;
+    editable.leading_people.groups = [[]];
+    expect(editableToMpaSelections(editable)).toHaveLength(0);
+  });
+});
+
+describe("buildMpaCustomContext", () => {
+  it("formats records like the fuse flow", () => {
+    const records: PlanAccomplishmentRecord[] = [
+      {
+        id: "a",
+        taggedMpa: "executing_mission",
+        action_verb: "Led",
+        details: "migration",
+        impact: "zero downtime",
+        metrics: "50 servers",
+        overallScore: 80,
+        primaryMpa: "executing_mission",
+        mpaRelevancy: null,
+      },
+    ];
+    expect(buildMpaCustomContext(records)).toBe(
+      "Led: migration. Impact: zero downtime. Metrics: 50 servers"
+    );
+  });
+});
+
+describe("combineVersions", () => {
+  it("caps at sentence count and joins with proper separator", () => {
+    expect(
+      combineVersions([["First.", "Second."], ["Only"]], 2)
+    ).toEqual(["First. Second.", "Only"]);
+    expect(combineVersions([["First", "Second"]], 1)).toEqual(["First"]);
+    expect(combineVersions([["First", "Second"]], 2)).toEqual([
+      "First. Second",
+    ]);
+  });
+
+  it("drops empty versions", () => {
+    expect(combineVersions([[""], ["Real"]], 1)).toEqual(["Real"]);
+  });
+});
+
+describe("extractVersionArrays", () => {
+  it("prefers statementVersions, falls back to statements", () => {
+    expect(
+      extractVersionArrays({ statementVersions: [["a"], ["b"]] })
+    ).toEqual([["a"], ["b"]]);
+    expect(extractVersionArrays({ statements: ["a", "b"] })).toEqual([
+      ["a", "b"],
+    ]);
+    expect(extractVersionArrays(null)).toEqual([]);
+    expect(extractVersionArrays({})).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/generate-epb-run.test.ts
+++ b/src/lib/__tests__/generate-epb-run.test.ts
@@ -2,11 +2,29 @@ import { describe, it, expect } from "vitest";
 import {
   planToEditable,
   editableToMpaSelections,
+  editableFromRecords,
   buildMpaCustomContext,
   combineVersions,
   extractVersionArrays,
 } from "../generate-epb-run";
 import type { EpbPlan, PlanAccomplishmentRecord } from "../plan-epb";
+
+function record(
+  id: string,
+  taggedMpa: string
+): PlanAccomplishmentRecord {
+  return {
+    id,
+    taggedMpa,
+    action_verb: "Led",
+    details: "did a thing",
+    impact: null,
+    metrics: null,
+    overallScore: null,
+    primaryMpa: null,
+    mpaRelevancy: null,
+  };
+}
 
 describe("planToEditable + editableToMpaSelections", () => {
   const plan: EpbPlan = {
@@ -46,6 +64,23 @@ describe("planToEditable + editableToMpaSelections", () => {
     editable.executing_mission.enabled = false;
     editable.leading_people.groups = [[]];
     expect(editableToMpaSelections(editable)).toHaveLength(0);
+  });
+});
+
+describe("editableFromRecords", () => {
+  it("groups pre-selected records by tagged MPA (one group each)", () => {
+    const editable = editableFromRecords([
+      record("a", "executing_mission"),
+      record("b", "executing_mission"),
+      record("c", "leading_people"),
+      record("d", "miscellaneous"), // non-core → excluded
+    ]);
+    expect(Object.keys(editable).sort()).toEqual([
+      "executing_mission",
+      "leading_people",
+    ]);
+    expect(editable.executing_mission.groups).toEqual([["a", "b"]]);
+    expect(editable.leading_people.enabled).toBe(true);
   });
 });
 

--- a/src/lib/__tests__/plan-epb.test.ts
+++ b/src/lib/__tests__/plan-epb.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  chunkForPlanning,
+  mergeChunkPlans,
+  sanitizePlan,
+  toPlanRecord,
+  trimMergedPlan,
+  PLAN_FIELD_MAX_CHARS,
+  type EpbPlan,
+} from "../plan-epb";
+import { buildPlanEpbPrompt } from "../plan-epb-prompt";
+import type { Accomplishment } from "@/types/database";
+
+function acc(overrides: Partial<Accomplishment> = {}): Accomplishment {
+  return {
+    id: "a1",
+    user_id: "u1",
+    created_by: "u1",
+    team_member_id: null,
+    date: "2026-03-01",
+    action_verb: "Led",
+    details: "did a thing",
+    impact: "improved things",
+    metrics: "10%",
+    mpa: "executing_mission",
+    tags: [],
+    cycle_year: 2026,
+    assessment_scores: null,
+    assessed_at: null,
+    assessment_model: null,
+    created_at: "2026-03-01T00:00:00.000Z",
+    updated_at: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("toPlanRecord", () => {
+  it("maps fields and truncates long free text", () => {
+    const long = "x".repeat(PLAN_FIELD_MAX_CHARS + 50);
+    const rec = toPlanRecord(acc({ details: long }));
+    expect(rec.details.endsWith("…")).toBe(true);
+    expect(rec.details.length).toBe(PLAN_FIELD_MAX_CHARS + 1);
+    expect(rec.action_verb).toBe("Led");
+  });
+
+  it("prefers composed stewardship impact and surfaces scores", () => {
+    const rec = toPlanRecord(
+      acc({
+        impact: "plain",
+        stewardship_impact: { money: "$5k saved" },
+        assessment_scores: {
+          overall_score: 88,
+          primary_mpa: "leading_people",
+          secondary_mpa: null,
+          mpa_relevancy: {
+            executing_mission: 40,
+            leading_people: 88,
+            managing_resources: 20,
+            improving_unit: 15,
+          },
+          quality_indicators: {
+            action_clarity: 80,
+            impact_significance: 80,
+            metrics_quality: 80,
+            scope_definition: 80,
+          },
+        },
+      })
+    );
+    expect(rec.impact).toContain("$5k saved");
+    expect(rec.overallScore).toBe(88);
+    expect(rec.primaryMpa).toBe("leading_people");
+  });
+});
+
+describe("chunkForPlanning", () => {
+  it("splits into bounded chunks", () => {
+    const items = Array.from({ length: 7 }, (_, i) => i);
+    expect(chunkForPlanning(items, 3)).toEqual([
+      [0, 1, 2],
+      [3, 4, 5],
+      [6],
+    ]);
+  });
+});
+
+describe("sanitizePlan", () => {
+  const valid = new Set(["a", "b", "c"]);
+
+  it("drops unknown ids, empty groups, and non-core MPAs; caps at 2 sentences", () => {
+    const raw = {
+      mpas: [
+        {
+          mpaKey: "executing_mission",
+          sentences: [
+            { accomplishmentIds: ["a", "zzz", "a"], rationale: "combine" },
+            { accomplishmentIds: ["b"], rationale: "solo" },
+            { accomplishmentIds: ["c"], rationale: "third dropped" },
+          ],
+        },
+        { mpaKey: "miscellaneous", sentences: [{ accomplishmentIds: ["c"] }] },
+        { mpaKey: "leading_people", sentences: [{ accomplishmentIds: ["zzz"] }] },
+      ],
+    };
+    const plan = sanitizePlan(raw, valid);
+    expect(plan.mpas).toHaveLength(1);
+    const em = plan.mpas[0];
+    expect(em.mpaKey).toBe("executing_mission");
+    expect(em.sentences).toHaveLength(2);
+    expect(em.sentences[0].accomplishmentIds).toEqual(["a"]); // dedup + drop unknown
+  });
+
+  it("returns empty plan for malformed input", () => {
+    expect(sanitizePlan(null, valid)).toEqual({ mpas: [] });
+    expect(sanitizePlan({ mpas: "nope" }, valid)).toEqual({ mpas: [] });
+  });
+});
+
+describe("mergeChunkPlans + trimMergedPlan", () => {
+  it("concatenates per MPA then trims to strongest 2 groups", () => {
+    const plans: EpbPlan[] = [
+      {
+        mpas: [
+          {
+            mpaKey: "executing_mission",
+            sentences: [{ accomplishmentIds: ["a"], rationale: "" }],
+          },
+        ],
+      },
+      {
+        mpas: [
+          {
+            mpaKey: "executing_mission",
+            sentences: [
+              { accomplishmentIds: ["b"], rationale: "" },
+              { accomplishmentIds: ["c"], rationale: "" },
+            ],
+          },
+        ],
+      },
+    ];
+    const merged = mergeChunkPlans(plans);
+    expect(merged.mpas[0].sentences).toHaveLength(3);
+
+    const scoreById = new Map([
+      ["a", 90],
+      ["b", 30],
+      ["c", 70],
+    ]);
+    const trimmed = trimMergedPlan(merged, scoreById, 2);
+    const ids = trimmed.mpas[0].sentences.map((s) => s.accomplishmentIds[0]);
+    expect(ids).toEqual(["a", "c"]); // highest scores kept, "b" dropped
+  });
+});
+
+describe("buildPlanEpbPrompt", () => {
+  it("includes ids, rank tier guidance, and strict JSON instructions", () => {
+    const prompt = buildPlanEpbPrompt({
+      records: [toPlanRecord(acc({ id: "a1" }))],
+      rateeRank: "MSgt",
+      rateeAfsc: "3D0X2",
+    });
+    expect(prompt).toContain("id: a1");
+    expect(prompt).toContain("AF Form 932"); // senior tier note
+    expect(prompt).toContain('"mpaKey"');
+    expect(prompt).toContain("STRICT JSON");
+  });
+});

--- a/src/lib/billable-api.ts
+++ b/src/lib/billable-api.ts
@@ -3,6 +3,7 @@ import { useCreditsStore } from "@/stores/credits-store";
 /** POST endpoints that consume a prepaid AI call (default-key users). */
 export const BILLABLE_API_PATHS = [
   "/api/generate",
+  "/api/plan-epb",
   "/api/revise-selection",
   "/api/generate-war",
   "/api/generate-award",

--- a/src/lib/epb-generation-readiness.ts
+++ b/src/lib/epb-generation-readiness.ts
@@ -1,0 +1,182 @@
+import { ENTRY_MGAS, isEnlisted } from "@/lib/constants";
+import {
+  ACA_PORTFOLIO_MPA_KEYS,
+  PORTFOLIO_QUALITY_FLOOR,
+  buildCyclePortfolio,
+  type AcaPortfolioMpaKey,
+} from "@/lib/cycle-portfolio";
+import { isAssessmentStale } from "@/lib/assessment-coaching";
+import { isSubstantialEpbStatement } from "@/lib/fuse-to-epb";
+import type { Accomplishment, EPBShellSection, Rank } from "@/types/database";
+
+/**
+ * Gate + guidance for the one-shot "Generate EPB" flow.
+ *
+ * This is intentionally content-based (not "1-2 selected per MPA"): the LLM
+ * planning step decides the real per-sentence selection and combinations. Here
+ * we only stop obviously-too-thin runs and surface non-blocking cautions.
+ */
+
+/** At least this many core MPAs must have >= 1 entry to attempt a full EPB. */
+export const MIN_ELIGIBLE_MPAS = 2;
+/** At least this many ACA-tagged entries across the cycle. */
+export const MIN_TOTAL_ACA_ENTRIES = 3;
+
+export interface MpaReadiness {
+  mpaKey: AcaPortfolioMpaKey;
+  label: string;
+  entryCount: number;
+  assessedCount: number;
+  /** Has at least one entry to generate from. */
+  hasContent: boolean;
+  /** Assessed and averaging at/above the portfolio quality floor. */
+  isStrong: boolean;
+}
+
+export interface EpbGenerationReadiness {
+  /** Overall gate for showing/enabling the Generate EPB action. */
+  canGenerate: boolean;
+  /** Blocking reasons (ratee-neutral) when canGenerate is false. */
+  reasons: string[];
+  /** Non-blocking cautions worth surfacing before generation. */
+  warnings: string[];
+  perMpa: Record<AcaPortfolioMpaKey, MpaReadiness>;
+  /** Core MPAs that have at least one entry (what we will generate). */
+  eligibleMpaKeys: AcaPortfolioMpaKey[];
+  totalAcaEntries: number;
+  assessedCount: number;
+  unassessedCount: number;
+  staleCount: number;
+}
+
+export interface ReadinessOptions {
+  /** Ratee rank; when provided, non-enlisted ratees are gated out (v1 is EPB-only). */
+  rank?: Rank | string | null;
+}
+
+function labelFor(mpaKey: AcaPortfolioMpaKey): string {
+  return ENTRY_MGAS.find((m) => m.key === mpaKey)?.label ?? mpaKey;
+}
+
+function isAcaEntry(entry: Accomplishment): boolean {
+  return (ACA_PORTFOLIO_MPA_KEYS as readonly string[]).includes(entry.mpa);
+}
+
+export function evaluateEpbGenerationReadiness(
+  entries: Accomplishment[],
+  options: ReadinessOptions = {}
+): EpbGenerationReadiness {
+  const portfolio = buildCyclePortfolio(entries);
+  const acaEntries = entries.filter(isAcaEntry);
+
+  const perMpa = {} as Record<AcaPortfolioMpaKey, MpaReadiness>;
+  const eligibleMpaKeys: AcaPortfolioMpaKey[] = [];
+
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const stat = portfolio.mpaStats[mpaKey];
+    const isStrong =
+      stat.assessedCount > 0 &&
+      stat.avgOverall !== null &&
+      stat.avgOverall >= PORTFOLIO_QUALITY_FLOOR;
+
+    perMpa[mpaKey] = {
+      mpaKey,
+      label: labelFor(mpaKey),
+      entryCount: stat.entryCount,
+      assessedCount: stat.assessedCount,
+      hasContent: stat.entryCount > 0,
+      isStrong,
+    };
+
+    if (stat.entryCount > 0) {
+      eligibleMpaKeys.push(mpaKey);
+    }
+  }
+
+  let unassessedCount = 0;
+  let staleCount = 0;
+  for (const entry of acaEntries) {
+    if (entry.assessment_scores === null) {
+      unassessedCount++;
+    } else if (isAssessmentStale(entry.assessed_at, entry.updated_at)) {
+      staleCount++;
+    }
+  }
+  const assessedCount = acaEntries.length - unassessedCount;
+
+  const reasons: string[] = [];
+
+  const rankProvided =
+    options.rank !== undefined && options.rank !== null && options.rank !== "";
+  if (rankProvided && !isEnlisted(options.rank!)) {
+    reasons.push(
+      "Full EPB generation is available for enlisted ratees only right now."
+    );
+  }
+
+  if (acaEntries.length < MIN_TOTAL_ACA_ENTRIES) {
+    reasons.push(
+      `Add at least ${MIN_TOTAL_ACA_ENTRIES} accomplishments this cycle before generating a full EPB (currently ${acaEntries.length}).`
+    );
+  }
+
+  if (eligibleMpaKeys.length < MIN_ELIGIBLE_MPAS) {
+    reasons.push(
+      `Cover at least ${MIN_ELIGIBLE_MPAS} performance areas before generating (currently ${eligibleMpaKeys.length}).`
+    );
+  }
+
+  const warnings: string[] = [];
+  const emptyMpas = ACA_PORTFOLIO_MPA_KEYS.filter(
+    (key) => perMpa[key].entryCount === 0
+  );
+  if (emptyMpas.length > 0) {
+    warnings.push(
+      `No entries for ${emptyMpas
+        .map((key) => perMpa[key].label)
+        .join(", ")} — ${
+        emptyMpas.length === 1 ? "that section" : "those sections"
+      } will be left blank.`
+    );
+  }
+
+  if (unassessedCount > 0) {
+    warnings.push(
+      `${unassessedCount} ${
+        unassessedCount === 1 ? "entry has" : "entries have"
+      } no AI assessment yet — they can still be used, but scoring won't guide selection.`
+    );
+  }
+
+  if (staleCount > 0) {
+    warnings.push(
+      `${staleCount} ${
+        staleCount === 1 ? "entry was" : "entries were"
+      } edited after assessment — re-assess for the most accurate selection.`
+    );
+  }
+
+  return {
+    canGenerate: reasons.length === 0,
+    reasons,
+    warnings,
+    perMpa,
+    eligibleMpaKeys,
+    totalAcaEntries: acaEntries.length,
+    assessedCount,
+    unassessedCount,
+    staleCount,
+  };
+}
+
+/**
+ * MPA keys whose shell section already holds a real statement worth protecting.
+ * Drives the overwrite-vs-stage prompt before a full generation writes sections.
+ */
+export function getMpasWithExistingStatements(
+  sections: Pick<EPBShellSection, "mpa" | "statement_text">[]
+): string[] {
+  return sections
+    .filter((s) => isSubstantialEpbStatement(s.statement_text))
+    .map((s) => s.mpa);
+}

--- a/src/lib/generate-epb-run.ts
+++ b/src/lib/generate-epb-run.ts
@@ -1,0 +1,146 @@
+import { ENTRY_MGAS } from "@/lib/constants";
+import {
+  ACA_PORTFOLIO_MPA_KEYS,
+  type AcaPortfolioMpaKey,
+} from "@/lib/cycle-portfolio";
+import type { EpbPlan, PlanAccomplishmentRecord } from "@/lib/plan-epb";
+
+/** Live status for each MPA while the one-shot EPB generation runs. */
+export type MpaRunStatus =
+  | "queued"
+  | "generating"
+  | "done"
+  | "staged"
+  | "failed"
+  | "skipped";
+
+/** How to handle MPAs whose shell section already has a real statement. */
+export type ConflictPolicy = "overwrite" | "stage";
+
+/** Editable form of the AI plan the user reviews before generating. */
+export interface EditableMpaPlan {
+  enabled: boolean;
+  /** Each inner array is one sentence group (accomplishment ids to combine). */
+  groups: string[][];
+}
+export type EditablePlan = Record<string, EditableMpaPlan>;
+
+export interface MpaSelection {
+  mpaKey: AcaPortfolioMpaKey;
+  /** Unique accomplishment ids across all groups for this MPA. */
+  accomplishmentIds: string[];
+  /** 1 or 2 — drives statementCount for /api/generate. */
+  sentenceCount: 1 | 2;
+}
+
+export function mpaLabel(key: string): string {
+  return ENTRY_MGAS.find((m) => m.key === key)?.label ?? key;
+}
+
+function isAcaMpaKey(mpa: string): mpa is AcaPortfolioMpaKey {
+  return (ACA_PORTFOLIO_MPA_KEYS as readonly string[]).includes(mpa);
+}
+
+/** Convert an AI plan into the editable structure (core MPAs, enabled). */
+export function planToEditable(plan: EpbPlan): EditablePlan {
+  const editable: EditablePlan = {};
+  for (const selection of plan.mpas) {
+    if (!isAcaMpaKey(selection.mpaKey)) continue;
+    editable[selection.mpaKey] = {
+      enabled: true,
+      groups: selection.sentences
+        .map((s) => [...s.accomplishmentIds])
+        .filter((ids) => ids.length > 0),
+    };
+  }
+  return editable;
+}
+
+/**
+ * Reduce the editable plan to per-MPA generation selections: enabled MPAs with
+ * at least one non-empty group, unioned ids, and sentence count = number of
+ * non-empty groups (capped at two).
+ */
+export function editableToMpaSelections(editable: EditablePlan): MpaSelection[] {
+  const selections: MpaSelection[] = [];
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const entry = editable[mpaKey];
+    if (!entry || !entry.enabled) continue;
+
+    const nonEmptyGroups = entry.groups.filter((g) => g.length > 0);
+    if (nonEmptyGroups.length === 0) continue;
+
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const group of nonEmptyGroups) {
+      for (const id of group) {
+        if (!seen.has(id)) {
+          seen.add(id);
+          ids.push(id);
+        }
+      }
+    }
+
+    selections.push({
+      mpaKey,
+      accomplishmentIds: ids,
+      sentenceCount: nonEmptyGroups.length >= 2 ? 2 : 1,
+    });
+  }
+  return selections;
+}
+
+/**
+ * Fused free-text for one MPA's selected accomplishments — matches the format
+ * the single-statement fuse flow sends as `customContext` to /api/generate.
+ */
+export function buildMpaCustomContext(
+  records: PlanAccomplishmentRecord[]
+): string {
+  return records
+    .map((r) => {
+      const impact = r.impact ? `. Impact: ${r.impact}` : "";
+      const metrics = r.metrics ? `. Metrics: ${r.metrics}` : "";
+      return `${r.action_verb}: ${r.details}${impact}${metrics}`;
+    })
+    .join("\n\n");
+}
+
+/**
+ * Combine each version's sentence array into a single statement string, capped
+ * at the MPA's sentence count. Mirrors the fuse-to-epb combine behavior.
+ */
+export function combineVersions(
+  versionArrays: string[][],
+  sentenceCount: number
+): string[] {
+  const combine = (statements: string[]): string | null => {
+    const capped = statements.slice(0, sentenceCount).filter(Boolean);
+    if (capped.length === 0) return null;
+    if (capped.length === 1) return capped[0];
+    const separator = capped[0].trim().endsWith(".") ? " " : ". ";
+    return `${capped[0]}${separator}${capped[1]}`;
+  };
+  return versionArrays
+    .map(combine)
+    .filter((s): s is string => !!s && s.trim().length > 0);
+}
+
+/** Extract version arrays from an /api/generate response item. */
+export function extractVersionArrays(mpaResult: unknown): string[][] {
+  if (!mpaResult || typeof mpaResult !== "object") return [];
+  const item = mpaResult as {
+    statementVersions?: unknown;
+    statements?: unknown;
+  };
+  if (
+    Array.isArray(item.statementVersions) &&
+    item.statementVersions.length > 0
+  ) {
+    return item.statementVersions as string[][];
+  }
+  if (Array.isArray(item.statements) && item.statements.length > 0) {
+    return [item.statements as string[]];
+  }
+  return [];
+}

--- a/src/lib/generate-epb-run.ts
+++ b/src/lib/generate-epb-run.ts
@@ -57,6 +57,29 @@ export function planToEditable(plan: EpbPlan): EditablePlan {
 }
 
 /**
+ * Build an editable plan directly from pre-selected accomplishment records,
+ * grouping by each entry's tagged MPA (one sentence group per MPA). Used when
+ * the user already picked accomplishments on /entries and skips AI selection.
+ */
+export function editableFromRecords(
+  records: PlanAccomplishmentRecord[]
+): EditablePlan {
+  const byMpa: Record<string, string[]> = {};
+  for (const record of records) {
+    if (!isAcaMpaKey(record.taggedMpa)) continue;
+    (byMpa[record.taggedMpa] ??= []).push(record.id);
+  }
+  const editable: EditablePlan = {};
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const ids = byMpa[mpaKey];
+    if (ids && ids.length > 0) {
+      editable[mpaKey] = { enabled: true, groups: [ids] };
+    }
+  }
+  return editable;
+}
+
+/**
  * Reduce the editable plan to per-MPA generation selections: enabled MPAs with
  * at least one non-empty group, unioned ids, and sentence count = number of
  * non-empty groups (capped at two).

--- a/src/lib/plan-epb-prompt.ts
+++ b/src/lib/plan-epb-prompt.ts
@@ -37,6 +37,8 @@ export interface BuildPlanEpbPromptArgs {
   records: PlanAccomplishmentRecord[];
   rateeRank: Rank | string | null;
   rateeAfsc?: string | null;
+  /** Ratee duty description — context for how accomplishments map to the role. */
+  dutyDescription?: string | null;
   /** True when the input is one of several chunks (selection still per-MPA). */
   isChunked?: boolean;
 }
@@ -47,7 +49,7 @@ export interface BuildPlanEpbPromptArgs {
  * a single statement sentence. Returns strict JSON only.
  */
 export function buildPlanEpbPrompt(args: BuildPlanEpbPromptArgs): string {
-  const { records, rateeRank, rateeAfsc, isChunked } = args;
+  const { records, rateeRank, rateeAfsc, dutyDescription, isChunked } = args;
   const tier = getRubricTierForRank(rateeRank);
   const tierNote =
     tier === "senior"
@@ -58,13 +60,17 @@ export function buildPlanEpbPrompt(args: BuildPlanEpbPromptArgs): string {
     .map((record, index) => `[#${index + 1}]\n${formatRecord(record)}`)
     .join("\n\n");
 
+  const dutyBlock = dutyDescription?.trim()
+    ? `\nDUTY DESCRIPTION (use to judge relevance and MPA fit):\n${dutyDescription.trim()}\n`
+    : "";
+
   return `You are an expert U.S. Air Force EPB writer planning which accomplishments to turn into performance statements.
 
 RATEE
 - Rank: ${rateeRank ?? "unknown"}
 - AFSC: ${rateeAfsc ?? "unknown"}
 - ${tierNote}
-
+${dutyBlock}
 CORE MPAS (only these):
 ${mpaReference()}
 

--- a/src/lib/plan-epb-prompt.ts
+++ b/src/lib/plan-epb-prompt.ts
@@ -1,0 +1,105 @@
+import { ENTRY_MGAS, getRubricTierForRank } from "@/lib/constants";
+import { ACA_PORTFOLIO_MPA_KEYS } from "@/lib/cycle-portfolio";
+import {
+  PLAN_MAX_SENTENCES_PER_MPA,
+  type PlanAccomplishmentRecord,
+} from "@/lib/plan-epb";
+import type { Rank } from "@/types/database";
+
+function mpaReference(): string {
+  return ACA_PORTFOLIO_MPA_KEYS.map((key) => {
+    const label = ENTRY_MGAS.find((m) => m.key === key)?.label ?? key;
+    return `- ${key} (${label})`;
+  }).join("\n");
+}
+
+function formatRecord(record: PlanAccomplishmentRecord): string {
+  const rel = record.mpaRelevancy
+    ? ACA_PORTFOLIO_MPA_KEYS.map(
+        (key) => `${key}=${record.mpaRelevancy![key]}`
+      ).join(", ")
+    : "n/a";
+  const lines = [
+    `id: ${record.id}`,
+    `tagged_mpa: ${record.taggedMpa}`,
+    `action_verb: ${record.action_verb}`,
+    `details: ${record.details}`,
+    `impact: ${record.impact ?? "(none)"}`,
+    `metrics: ${record.metrics ?? "(none)"}`,
+    `overall_score: ${record.overallScore ?? "unassessed"}`,
+    `primary_mpa: ${record.primaryMpa ?? "n/a"}`,
+    `mpa_relevancy: ${rel}`,
+  ];
+  return lines.map((l) => `  ${l}`).join("\n");
+}
+
+export interface BuildPlanEpbPromptArgs {
+  records: PlanAccomplishmentRecord[];
+  rateeRank: Rank | string | null;
+  rateeAfsc?: string | null;
+  /** True when the input is one of several chunks (selection still per-MPA). */
+  isChunked?: boolean;
+}
+
+/**
+ * Prompt for the EPB planning step. The model selects the strongest
+ * accomplishments per core MPA and groups the ones that should be COMBINED into
+ * a single statement sentence. Returns strict JSON only.
+ */
+export function buildPlanEpbPrompt(args: BuildPlanEpbPromptArgs): string {
+  const { records, rateeRank, rateeAfsc, isChunked } = args;
+  const tier = getRubricTierForRank(rateeRank);
+  const tierNote =
+    tier === "senior"
+      ? "This ratee is a senior NCO (AF Form 932) — weight scope, leadership, and unit-level impact."
+      : "This ratee is junior enlisted (AF Form 931) — weight job proficiency, initiative, and quantified results.";
+
+  const recordBlock = records
+    .map((record, index) => `[#${index + 1}]\n${formatRecord(record)}`)
+    .join("\n\n");
+
+  return `You are an expert U.S. Air Force EPB writer planning which accomplishments to turn into performance statements.
+
+RATEE
+- Rank: ${rateeRank ?? "unknown"}
+- AFSC: ${rateeAfsc ?? "unknown"}
+- ${tierNote}
+
+CORE MPAS (only these):
+${mpaReference()}
+
+YOUR TASK
+For each core MPA, choose the accomplishments that will produce the strongest 1-2 performance statements, and GROUP the accomplishments that should be combined into a single sentence.
+
+SELECTION RULES
+1. Prioritize higher overall_score and higher mpa_relevancy for the target MPA, but DO NOT simply filter by score.
+2. Combine "like" accomplishments (same effort/initiative recurring across the cycle) into ONE sentence group so their metrics accumulate (man-hours, dollars saved, counts). A low-scoring entry on its own can be valuable when combined.
+3. A sentence group may contain a single accomplishment when it stands strongly on its own.
+4. Prefer the accomplishment's tagged_mpa, but you may place an entry under its primary_mpa when relevancy clearly favors it.
+5. Output at most ${PLAN_MAX_SENTENCES_PER_MPA} sentence groups per MPA. Omit an MPA entirely if nothing fits.
+6. Only use accomplishment ids from the list below. Never invent ids.
+${
+  isChunked
+    ? "7. This is a partial batch of the ratee's accomplishments; select from what is provided. Results are merged later."
+    : ""
+}
+
+ACCOMPLISHMENTS
+${recordBlock}
+
+OUTPUT
+Return STRICT JSON only, no prose, matching exactly:
+{
+  "mpas": [
+    {
+      "mpaKey": "<one of the core MPA keys>",
+      "sentences": [
+        {
+          "accomplishmentIds": ["<id>", "..."],
+          "rationale": "<one short line on why these, and why combined>"
+        }
+      ]
+    }
+  ]
+}`;
+}

--- a/src/lib/plan-epb.ts
+++ b/src/lib/plan-epb.ts
@@ -1,0 +1,203 @@
+import { composeImpactString } from "@/lib/stewardship-impact";
+import {
+  ACA_PORTFOLIO_MPA_KEYS,
+  type AcaPortfolioMpaKey,
+} from "@/lib/cycle-portfolio";
+import type {
+  Accomplishment,
+  AccomplishmentMPARelevancy,
+} from "@/types/database";
+
+/**
+ * Data contract for the "Generate EPB" planning step.
+ *
+ * The LLM inspects every cycle accomplishment (with its ACA scores) and returns,
+ * per core MPA, up to two "sentence groups". Each group is the set of
+ * accomplishments to combine into ONE statement sentence. This is where the
+ * "combine like accomplishments even if individually low-scoring" intelligence
+ * lives — we do not pattern-match on the server.
+ */
+
+/** Max accomplishments per LLM planning chunk (keeps payloads well under limits). */
+export const PLAN_CHUNK_MAX_ENTRIES = 35;
+/** Trim long free-text so a chunk payload stays bounded. */
+export const PLAN_FIELD_MAX_CHARS = 400;
+/** EPB MPAs are two sentences max. */
+export const PLAN_MAX_SENTENCES_PER_MPA = 2;
+
+export interface PlanSentenceGroup {
+  /** Accomplishment ids to combine into ONE sentence. */
+  accomplishmentIds: string[];
+  /** One-line, ratee-neutral rationale. */
+  rationale: string;
+}
+
+export interface PlanMpaSelection {
+  mpaKey: AcaPortfolioMpaKey;
+  sentences: PlanSentenceGroup[];
+}
+
+export interface EpbPlan {
+  mpas: PlanMpaSelection[];
+}
+
+/** Compact accomplishment record sent to the planning model. */
+export interface PlanAccomplishmentRecord {
+  id: string;
+  taggedMpa: string;
+  action_verb: string;
+  details: string;
+  impact: string | null;
+  metrics: string | null;
+  overallScore: number | null;
+  primaryMpa: string | null;
+  mpaRelevancy: AccomplishmentMPARelevancy | null;
+}
+
+function truncate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.length <= PLAN_FIELD_MAX_CHARS) return trimmed;
+  return `${trimmed.slice(0, PLAN_FIELD_MAX_CHARS)}…`;
+}
+
+function isAcaMpaKey(mpa: string): mpa is AcaPortfolioMpaKey {
+  return (ACA_PORTFOLIO_MPA_KEYS as readonly string[]).includes(mpa);
+}
+
+/** Shape one accomplishment into the compact planning record. */
+export function toPlanRecord(a: Accomplishment): PlanAccomplishmentRecord {
+  const scores = a.assessment_scores;
+  return {
+    id: a.id,
+    taggedMpa: a.mpa,
+    action_verb: a.action_verb,
+    details: truncate(a.details) ?? "",
+    impact: truncate(composeImpactString(a.stewardship_impact) || a.impact),
+    metrics: truncate(a.metrics),
+    overallScore: scores?.overall_score ?? null,
+    primaryMpa: scores?.primary_mpa ?? null,
+    mpaRelevancy: scores?.mpa_relevancy ?? null,
+  };
+}
+
+/** Keep only ACA-taggable accomplishments and map to planning records. */
+export function toPlanRecords(
+  entries: Accomplishment[]
+): PlanAccomplishmentRecord[] {
+  return entries.filter((e) => isAcaMpaKey(e.mpa)).map(toPlanRecord);
+}
+
+/** Split records into chunks the model can handle in a single call. */
+export function chunkForPlanning<T>(
+  records: T[],
+  maxPerChunk: number = PLAN_CHUNK_MAX_ENTRIES
+): T[][] {
+  const size = Math.max(1, Math.floor(maxPerChunk));
+  const chunks: T[][] = [];
+  for (let i = 0; i < records.length; i += size) {
+    chunks.push(records.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/** Merge per-chunk plans into one candidate plan (concat sentences per MPA). */
+export function mergeChunkPlans(plans: EpbPlan[]): EpbPlan {
+  const byMpa = new Map<AcaPortfolioMpaKey, PlanSentenceGroup[]>();
+  for (const plan of plans) {
+    for (const selection of plan.mpas) {
+      if (!isAcaMpaKey(selection.mpaKey)) continue;
+      const existing = byMpa.get(selection.mpaKey) ?? [];
+      existing.push(...selection.sentences);
+      byMpa.set(selection.mpaKey, existing);
+    }
+  }
+  return {
+    mpas: ACA_PORTFOLIO_MPA_KEYS.filter((key) => byMpa.has(key)).map((key) => ({
+      mpaKey: key,
+      sentences: byMpa.get(key)!,
+    })),
+  };
+}
+
+/**
+ * Validate/normalize a raw model plan against the known accomplishment ids:
+ * drop unknown ids, drop empty groups, cap sentences per MPA, dedupe ids within
+ * a group, and keep only the four core MPA keys.
+ */
+export function sanitizePlan(raw: unknown, validIds: Set<string>): EpbPlan {
+  const mpas: PlanMpaSelection[] = [];
+  const rawMpas =
+    raw && typeof raw === "object" && Array.isArray((raw as { mpas?: unknown }).mpas)
+      ? ((raw as { mpas: unknown[] }).mpas)
+      : [];
+
+  for (const rawSelection of rawMpas) {
+    if (!rawSelection || typeof rawSelection !== "object") continue;
+    const mpaKey = (rawSelection as { mpaKey?: unknown }).mpaKey;
+    if (typeof mpaKey !== "string" || !isAcaMpaKey(mpaKey)) continue;
+
+    const rawSentences = Array.isArray(
+      (rawSelection as { sentences?: unknown }).sentences
+    )
+      ? ((rawSelection as { sentences: unknown[] }).sentences)
+      : [];
+
+    const sentences: PlanSentenceGroup[] = [];
+    for (const rawSentence of rawSentences) {
+      if (sentences.length >= PLAN_MAX_SENTENCES_PER_MPA) break;
+      if (!rawSentence || typeof rawSentence !== "object") continue;
+      const rawIds = (rawSentence as { accomplishmentIds?: unknown })
+        .accomplishmentIds;
+      if (!Array.isArray(rawIds)) continue;
+
+      const seen = new Set<string>();
+      const ids: string[] = [];
+      for (const id of rawIds) {
+        if (typeof id === "string" && validIds.has(id) && !seen.has(id)) {
+          seen.add(id);
+          ids.push(id);
+        }
+      }
+      if (ids.length === 0) continue;
+
+      const rationaleRaw = (rawSentence as { rationale?: unknown }).rationale;
+      sentences.push({
+        accomplishmentIds: ids,
+        rationale: typeof rationaleRaw === "string" ? rationaleRaw.trim() : "",
+      });
+    }
+
+    if (sentences.length > 0) {
+      mpas.push({ mpaKey, sentences });
+    }
+  }
+
+  return { mpas };
+}
+
+/**
+ * When a plan was merged from multiple chunks it can exceed two sentences per
+ * MPA. Keep the strongest groups (highest summed accomplishment score, then
+ * larger combined groups) so we stay within the two-sentence EPB structure.
+ */
+export function trimMergedPlan(
+  plan: EpbPlan,
+  scoreById: Map<string, number>,
+  maxSentences: number = PLAN_MAX_SENTENCES_PER_MPA
+): EpbPlan {
+  const groupScore = (group: PlanSentenceGroup): number =>
+    group.accomplishmentIds.reduce((sum, id) => sum + (scoreById.get(id) ?? 0), 0);
+
+  return {
+    mpas: plan.mpas.map((selection) => {
+      if (selection.sentences.length <= maxSentences) return selection;
+      const ranked = [...selection.sentences].sort((a, b) => {
+        const diff = groupScore(b) - groupScore(a);
+        if (diff !== 0) return diff;
+        return b.accomplishmentIds.length - a.accomplishmentIds.length;
+      });
+      return { ...selection, sentences: ranked.slice(0, maxSentences) };
+    }),
+  };
+}

--- a/src/lib/usage-tracker.ts
+++ b/src/lib/usage-tracker.ts
@@ -21,6 +21,7 @@ export const DEFAULT_KEY_MODEL = DEFAULT_APP_MODEL_ID;
 
 export type BillableAction =
   | "generate"
+  | "plan_epb"
   | "revise_selection"
   | "generate_war"
   | "generate_award"

--- a/supabase/migrations/209_epb_assessments.sql
+++ b/supabase/migrations/209_epb_assessments.sql
@@ -1,0 +1,55 @@
+-- Permanent history of AI EPB assessments, attached to each EPB shell.
+-- Every /api/assess-epb run is recorded so members can revisit past reports
+-- as their statements/accomplishments evolve.
+
+CREATE TABLE IF NOT EXISTS epb_assessments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shell_id UUID NOT NULL REFERENCES epb_shells(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE, -- ratee (shell owner)
+  created_by UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE, -- who ran it
+  rank TEXT,
+  afsc TEXT,
+  model TEXT,
+  cycle_year INTEGER,
+  overall_strength TEXT, -- proficiency level for list display
+  form_used TEXT,        -- "AF Form 931" / "AF Form 932"
+  assessment JSONB NOT NULL, -- full EPBAssessmentResult
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Fast newest-first lookup per shell
+CREATE INDEX IF NOT EXISTS idx_epb_assessments_shell_created
+  ON epb_assessments(shell_id, created_at DESC);
+
+-- RLS: access mirrors EPB shell access (owner, creator, or shared user)
+ALTER TABLE epb_assessments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view assessments for accessible shells"
+  ON epb_assessments FOR SELECT
+  USING (
+    shell_id IN (
+      SELECT id FROM epb_shells
+      WHERE user_id = auth.uid() OR created_by = auth.uid()
+      UNION
+      SELECT shell_id FROM epb_shell_shares
+      WHERE shared_with_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can create assessments for accessible shells"
+  ON epb_assessments FOR INSERT
+  WITH CHECK (
+    created_by = auth.uid()
+    AND shell_id IN (
+      SELECT id FROM epb_shells
+      WHERE user_id = auth.uid() OR created_by = auth.uid()
+      UNION
+      SELECT shell_id FROM epb_shell_shares
+      WHERE shared_with_id = auth.uid()
+    )
+  );
+
+-- Permanent record: no UPDATE/DELETE policies (immutable to app users).
+
+COMMENT ON TABLE epb_assessments IS 'Permanent history of AI EPB (ACA) assessment reports per shell';
+COMMENT ON COLUMN epb_assessments.assessment IS 'Full EPBAssessmentResult JSON (overall + category breakdown + recommendations)';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

The "one-click Generate EPB" flow: from a cycle's assessed accomplishments, produce all MPA statements (excl. duty history / HLR) into the EPB shell, after a quick user review of the AI's selection. This PR lands the **tested backend foundation**; the UI/orchestration follow.

## Design (Plan → Review → Generate)

1. **Readiness** gate from existing assessments + `cycle-portfolio` (content-based, not "1–2 per MPA").
2. **`/api/plan-epb`**: sends every cycle accomplishment (with ACA scores, chunked) to the LLM, which returns per-MPA **sentence groups** — the accomplishments to *combine into one sentence* (so like-accomplishments accumulate metrics even if individually low-scoring). Server merges chunks and trims to ≤2 sentences/MPA.
3. **Review UI** (next): user edits the AI selection; optional duty-description preflight.
4. **Orchestrator** (next): sequenced per-MPA `/api/generate` (3 versions each, idempotency, burst-aware), writes top version to the section + stages all 3 to `epb_saved_examples`; per-MPA status in `/epb`. Existing sections with a substantial statement trigger an **overwrite-vs-stage** prompt.
5. **HLR** stays the existing post-step; **no re-assessment** (consumes existing `assessment_scores`, warns on stale/unassessed).

## In this PR (tested)

- `src/lib/epb-generation-readiness.ts` — `evaluateEpbGenerationReadiness()` + `getMpasWithExistingStatements()` (+ 7 unit tests).
- `src/lib/plan-epb.ts` — types + pure helpers: `toPlanRecords`, `chunkForPlanning`, `mergeChunkPlans`, `sanitizePlan`, `trimMergedPlan` (+ 7 unit tests).
- `src/lib/plan-epb-prompt.ts` — rank-aware planning prompt (strict JSON contract).
- `src/app/api/plan-epb/route.ts` — billable route (`plan_epb`), RLS-enforced load, PII scan, chunked LLM selection, merge/trim, refund on empty.
- Wiring: `plan_epb` in `BillableAction`; `/api/plan-epb` in `BILLABLE_API_PATHS`.

## Verification

`npx vitest run` on the new suites → **14 passed**. `npx tsc --noEmit` clean. `eslint` clean on changed files. No DB migration needed (`consume_credit` action is free-form text).

## Still to build (tracked)

Review dialog, `/entries` entry point (readiness-gated, no selection required), client orchestrator + shell writes, per-MPA status UI, optional HLR follow-up, upfront cost display. End-to-end generation testing needs an LLM API key in the environment.

Base branch note: this is independent of the env-setup/auth PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd3257f3-8c9b-44c4-b706-b7f63a9e00a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd3257f3-8c9b-44c4-b706-b7f63a9e00a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

