### PR TITLE
feat(epb): smart two-sentence MPA assignment with ARI LLM grouping

### DIFF
--- a/plans/020-epb-stash-best-fit-allocation.md
+++ b/plans/020-epb-stash-best-fit-allocation.md
@@ -1,0 +1,83 @@
+# Plan 020: Allocate stashed EPB leftovers by best MPA fit, not ACA key order
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat bb577bd..HEAD -- src/lib/assign-epb-sentences.ts src/lib/__tests__/assign-epb-sentences.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none (landed on `cursor/epb-smart-mpa-assignment-21bc` / PR #17)
+- **Category**: bug
+- **Planned at**: commit `bb577bd`, 2026-08-11
+
+## Why this matters
+
+Pass 2/3 cross-fill walks `ACA_PORTFOLIO_MPA_KEYS` in fixed order (Executing the Mission first). A leftover that scores 45% EM / 90% Improving the Unit is claimed by EM before IU can see it, so later MPAs stay empty or weak. Users with EM-heavy cycles get worse balance than the score data allows.
+
+## Current state
+
+- `src/lib/assign-epb-sentences.ts` — home claims + stash/pop assignment
+- Pass 2 currently:
+
+```typescript
+for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+  const current = byMpa.get(mpaKey) ?? [];
+  const need = PLAN_MAX_SENTENCES_PER_MPA - current.length;
+  if (need <= 0) continue;
+  takeFromStash(mpaKey, need, MIN_CROSS_FILL_RELEVANCY);
+}
+```
+
+- Order source: `src/lib/cycle-portfolio.ts` `ACA_PORTFOLIO_MPA_KEYS` = EM → LP → MR → IU
+- Tests live in `src/lib/__tests__/assign-epb-sentences.test.ts` (follow that file’s `record()` / `rel()` helpers)
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests   | `npm run test -- src/lib/__tests__/assign-epb-sentences.test.ts` | all pass |
+| Lint    | `npx eslint src/lib/assign-epb-sentences.ts` | 0 errors |
+
+## Steps
+
+1. **Add a characterization test** that fails on greedy order: one leftover with EM=45 / IU=90, EM already has 2 home sentences, IU has 0. Expect IU to receive the leftover, not EM.
+2. **Replace Pass 2/3 greedy loops** with a best-fit allocator, e.g.:
+   - Build open slots: each MPA with `need = 2 - sentences.length` slots
+   - For each stash record, score every open MPA (`relevancyForMpa`)
+   - Repeatedly assign the (record, mpa) pair with the highest score ≥ active floor, clustering same-verb fills into the same sentence group when the MPA still needs that slot
+   - Run once at `MIN_CROSS_FILL_RELEVANCY`, then again at `MIN_DESPERATE_CROSS_FILL_RELEVANCY` for remaining needs
+3. Keep home-claim Pass 1 unchanged (tagged MPA only).
+4. Keep “each id used at most once” invariant (already tested).
+5. Run the test command above; add 1–2 more cases for ties (prefer scarcer MPA / higher overallScore).
+
+## Done criteria
+
+- [ ] New test proves IU (or LP) wins a leftover that scores higher there than on EM
+- [ ] `npm run test -- src/lib/__tests__/assign-epb-sentences.test.ts` passes
+- [ ] No change to `/api/generate` or dialog UI in this plan
+
+## STOP conditions
+
+- If product owners insist fixed ACA narrative order must win over scores — STOP and report; do not silently reintroduce greedy EM-first.
+- If clustering-by-verb during multi-slot fill becomes ambiguous across MPAs — keep one-record-per-pop first, then layer clustering.
+
+## Out of scope
+
+- Soft-home / mis-tag reassignment (plan 021)
+- Unassessed synthetic scores (plan 022)
+- Deleting unused LLM plan helpers (plan 023)
+
+## Maintenance
+
+Any future change to `ACA_PORTFOLIO_MPA_KEYS` order must not reintroduce priority bias in cross-fill.

--- a/plans/021-epb-soft-home-misfile-claims.md
+++ b/plans/021-epb-soft-home-misfile-claims.md
@@ -1,0 +1,65 @@
+# Plan 021: Soft-home claims when tagged MPA fit is clearly wrong
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat bb577bd..HEAD -- src/lib/assign-epb-sentences.ts src/lib/cycle-portfolio.ts`
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: plans/020-epb-stash-best-fit-allocation.md (soft; can parallelize if tests stay isolated)
+- **Category**: direction
+- **Planned at**: commit `bb577bd`, 2026-08-11
+
+## Why this matters
+
+Pass 1 hard-claims every tagged entry for its home MPA even when `mpa_relevancy` says it belongs elsewhere (e.g. tagged Executing the Mission at 15%, Leading People at 95%). That burns a sentence slot on weak home fit and starves the true MPA. Portfolio already has a misfile gap constant for this signal.
+
+## Current state
+
+- Home filter in `assignEpbSentenceGroups`:
+
+```typescript
+const home = usable.filter(
+  (r) => r.taggedMpa === mpaKey && !used.has(r.id)
+);
+```
+
+- Misfile gap: `PORTFOLIO_MISFILE_GAP` in `src/lib/cycle-portfolio.ts` (primary relevancy exceeds tagged by ≥20)
+- Records already carry `primaryMpa` + `mpaRelevancy` via `toPlanRecord`
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests   | `npm run test -- src/lib/__tests__/assign-epb-sentences.test.ts` | all pass |
+
+## Steps
+
+1. Add test: EM-tagged record with EM=15 / LP=95 and a weak LP-tagged record → after assignment, the strong record should land under Leading People (or stash for LP), not occupy an EM sentence when EM has better true-home options.
+2. Before Pass 1 claims, mark “misfiled” records: `relevancy(primary) - relevancy(tagged) >= PORTFOLIO_MISFILE_GAP` (import the shared constant — do not invent a new gap).
+3. Misfiled records skip hard home claim and enter the stash (or soft-home to `primaryMpa` if that MPA still needs slots). Prefer stash + best-fit (020) if 020 has landed.
+4. Surface rationale text so review UI explains “reassigned from tagged X (fit Y%)”.
+5. Do **not** change user-visible tags on the accomplishment row — only planning assignment.
+
+## Done criteria
+
+- [ ] Misfiled high-LP entry is not locked into a weak EM sentence when LP needs it
+- [ ] Uses `PORTFOLIO_MISFILE_GAP`, not a one-off number
+- [ ] Assignment tests cover misfile + non-misfile controls
+
+## STOP conditions
+
+- If product decides tagged MPA must always win regardless of scores — STOP; document as rejected.
+- Do not rewrite `assessment_scores` or DB `mpa` columns.
+
+## Out of scope
+
+- UI to retag accomplishments
+- Changing assessment prompt thresholds

--- a/plans/022-epb-unassessed-and-review-empty-mpas.md
+++ b/plans/022-epb-unassessed-and-review-empty-mpas.md
@@ -1,0 +1,70 @@
+# Plan 022: Unassessed cross-fill policy + show empty MPAs in Generate EPB review
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat bb577bd..HEAD -- src/lib/assign-epb-sentences.ts src/lib/generate-epb-run.ts src/lib/epb-generation-readiness.ts src/components/entries/generate-epb-dialog.tsx`
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `bb577bd`, 2026-08-11
+
+## Why this matters
+
+1. Unassessed leftovers get `relevancyForMpa = 0` for non-home MPAs, so cross-fill never runs — yet readiness warns that empty tagged areas “will try to fill from scores.”
+2. Review UI only lists MPAs present in the plan (`Object.keys(editable)`), so an empty area cannot be manually filled in-dialog.
+
+## Current state
+
+```typescript
+// assign-epb-sentences.ts — unassessed non-home → 0
+return record.taggedMpa === mpaKey ? UNASSESSED_HOME_RELEVANCY : 0;
+```
+
+```typescript
+// generate-epb-run.ts planToEditable — only planned MPAs
+for (const selection of plan.mpas) { ... }
+```
+
+Readiness warning already promises cross-fill (`epb-generation-readiness.ts`).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests   | `npm run test -- src/lib/__tests__/assign-epb-sentences.test.ts src/lib/__tests__/generate-epb-run.test.ts src/lib/__tests__/epb-generation-readiness.test.ts` | all pass |
+| Doctor  | `npx react-doctor@latest --verbose --scope changed` | no new errors; note score |
+
+## Steps
+
+1. **Policy (pick A, document in code comment)**:
+   - **A (recommended)**: unassessed non-home score = `Math.min(UNASSESSED_HOME_RELEVANCY - 15, MIN_DESPERATE_CROSS_FILL_RELEVANCY)` only when *all* stash candidates for an empty MPA are unassessed; otherwise keep 0 so assessed scores win.
+   - Or **B**: keep score 0 and change readiness warning to say empty areas need assessments to cross-fill.
+2. Implement the chosen policy + tests.
+3. Update `planToEditable` (or dialog init) to seed all four `ACA_PORTFOLIO_MPA_KEYS` with `{ enabled: false, groups: [[]] }` when missing so review can enable/add groups.
+4. Ensure generate still skips disabled/empty groups (`editableToMpaSelections` already does).
+
+## Done criteria
+
+- [ ] Warning text and assignment behavior agree
+- [ ] Review shows all four core MPAs (disabled if empty)
+- [ ] Tests cover unassessed cross-fill (or explicit non-fill) and seeded editable keys
+- [ ] React Doctor changed-scope has no new error-severity findings
+
+## STOP conditions
+
+- Do not invent LLM calls for unassessed planning.
+- Do not use `useEffect` (repo rule).
+
+## Out of scope
+
+- Auto-running assessment before Generate EPB
+- Soft-home misfile (021)

--- a/plans/023-retire-llm-plan-epb-helpers.md
+++ b/plans/023-retire-llm-plan-epb-helpers.md
@@ -1,0 +1,58 @@
+# Plan 023: Retire unused LLM plan-epb helpers after deterministic assignment
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat bb577bd..HEAD -- src/lib/plan-epb.ts src/lib/plan-epb-prompt.ts src/app/api/plan-epb/route.ts src/lib/__tests__/plan-epb.test.ts`
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none (only after PR #17 merge confidence)
+- **Category**: tech-debt
+- **Planned at**: commit `bb577bd`, 2026-08-11
+
+## Why this matters
+
+`/api/plan-epb` is now score-only (`assignEpbSentenceGroups`). Chunking, merge/trim, sanitize-from-LLM-JSON, and `buildPlanEpbPrompt` remain tested dead code. Keeping them invites accidental reintroduction of billed LLM planning.
+
+## Current state
+
+- Live route: `src/app/api/plan-epb/route.ts` calls `assignEpbSentenceGroups` only
+- Still present: `chunkForPlanning`, `mergeChunkPlans`, `sanitizePlan`, `trimMergedPlan` in `plan-epb.ts`; full `plan-epb-prompt.ts`; tests in `plan-epb.test.ts`
+- Still needed: `toPlanRecord(s)`, `EpbPlan` types, `PLAN_MAX_SENTENCES_PER_MPA`, `sanitizePlan` only if any other caller remains
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Grep    | `rg "buildPlanEpbPrompt|chunkForPlanning|mergeChunkPlans|trimMergedPlan|sanitizePlan" src` | only tests / files you intentionally keep |
+| Tests   | `npm run test -- src/lib/__tests__/plan-epb.test.ts src/lib/__tests__/assign-epb-sentences.test.ts` | all pass |
+
+## Steps
+
+1. `rg` for each helper; if unused outside tests, delete `plan-epb-prompt.ts` and unused exports from `plan-epb.ts`.
+2. Slim `plan-epb.test.ts` to `toPlanRecord` / types still in use (or delete obsolete cases).
+3. Keep `sanitizePlan` **only** if another route still needs it; otherwise delete.
+4. Confirm `/api/plan-epb` and `assign-epb-sentences` imports still typecheck.
+
+## Done criteria
+
+- [ ] No dead LLM prompt module left unless a caller exists
+- [ ] Tests updated; suite green
+- [ ] BILLABLE path for `/api/plan-epb` remains absent (`src/lib/billable-api.ts`)
+
+## STOP conditions
+
+- If a non-test production caller of `buildPlanEpbPrompt` appears — STOP and report; do not delete.
+- Do not remove `assignEpbSentenceGroups` or `toPlanRecords`.
+
+## Out of scope
+
+- Changing assignment algorithm behavior
+- Billing system refactors beyond confirming plan-epb stays non-billable

--- a/plans/023-retire-llm-plan-epb-helpers.md
+++ b/plans/023-retire-llm-plan-epb-helpers.md
@@ -1,4 +1,4 @@
-# Plan 023: Retire unused LLM plan-epb helpers after deterministic assignment
+# Plan 023: Retire unused LLM *chunk/merge* helpers (keep ARI grouping prompt)
 
 > **Executor instructions**: Follow this plan step by step. Run every
 > verification command and confirm the expected result before moving to the
@@ -6,7 +6,7 @@
 > report — do not improvise. When done, update the status row for this plan
 > in `plans/README.md`.
 >
-> **Drift check (run first)**: `git diff --stat bb577bd..HEAD -- src/lib/plan-epb.ts src/lib/plan-epb-prompt.ts src/app/api/plan-epb/route.ts src/lib/__tests__/plan-epb.test.ts`
+> **Drift check (run first)**: `git diff --stat e94007a..HEAD -- src/lib/plan-epb.ts src/lib/plan-epb-prompt.ts src/app/api/plan-epb/route.ts src/lib/__tests__/plan-epb.test.ts`
 
 ## Status
 
@@ -15,44 +15,43 @@
 - **Risk**: LOW
 - **Depends on**: none (only after PR #17 merge confidence)
 - **Category**: tech-debt
-- **Planned at**: commit `bb577bd`, 2026-08-11
+- **Planned at**: commit `e94007a`, 2026-08-11
 
 ## Why this matters
 
-`/api/plan-epb` is now score-only (`assignEpbSentenceGroups`). Chunking, merge/trim, sanitize-from-LLM-JSON, and `buildPlanEpbPrompt` remain tested dead code. Keeping them invites accidental reintroduction of billed LLM planning.
+Planning is hybrid again: score pools + **LLM ARI grouping** via `buildGroupEpbPrompt`. Old multi-chunk helpers (`chunkForPlanning`, `mergeChunkPlans`, `trimMergedPlan`) may still be unused. Do **not** delete `buildGroupEpbPrompt` / `sanitizePlan` / allocation helpers.
 
 ## Current state
 
-- Live route: `src/app/api/plan-epb/route.ts` calls `assignEpbSentenceGroups` only
-- Still present: `chunkForPlanning`, `mergeChunkPlans`, `sanitizePlan`, `trimMergedPlan` in `plan-epb.ts`; full `plan-epb-prompt.ts`; tests in `plan-epb.test.ts`
-- Still needed: `toPlanRecord(s)`, `EpbPlan` types, `PLAN_MAX_SENTENCES_PER_MPA`, `sanitizePlan` only if any other caller remains
+- Live route: `allocateEpbCandidatePools` → `buildGroupEpbPrompt` → `sanitizePlan` / `constrainPlanToPools`
+- Possibly dead: `chunkForPlanning`, `mergeChunkPlans`, `trimMergedPlan` if no callers outside tests
+- **Keep**: `buildGroupEpbPrompt`, `sanitizePlan`, `toPlanRecords`, `assign-epb-sentences` allocation
 
 ## Commands you will need
 
 | Purpose | Command | Expected on success |
 |---------|---------|---------------------|
-| Grep    | `rg "buildPlanEpbPrompt|chunkForPlanning|mergeChunkPlans|trimMergedPlan|sanitizePlan" src` | only tests / files you intentionally keep |
+| Grep    | `rg "chunkForPlanning|mergeChunkPlans|trimMergedPlan|buildPlanEpbPrompt|buildGroupEpbPrompt" src` | group prompt + sanitize used by route; chunk/merge only if still needed |
 | Tests   | `npm run test -- src/lib/__tests__/plan-epb.test.ts src/lib/__tests__/assign-epb-sentences.test.ts` | all pass |
 
 ## Steps
 
-1. `rg` for each helper; if unused outside tests, delete `plan-epb-prompt.ts` and unused exports from `plan-epb.ts`.
-2. Slim `plan-epb.test.ts` to `toPlanRecord` / types still in use (or delete obsolete cases).
-3. Keep `sanitizePlan` **only** if another route still needs it; otherwise delete.
-4. Confirm `/api/plan-epb` and `assign-epb-sentences` imports still typecheck.
+1. `rg` each helper. Delete only unused chunk/merge/trim if production has zero callers.
+2. Keep `buildGroupEpbPrompt` and its verb-matching prohibition + USO cumulative example.
+3. Slim tests accordingly; do not remove ARI grouping coverage.
+4. Confirm `/api/plan-epb` remains in `BILLABLE_API_PATHS` (grouping uses LLM).
 
 ## Done criteria
 
-- [ ] No dead LLM prompt module left unless a caller exists
-- [ ] Tests updated; suite green
-- [ ] BILLABLE path for `/api/plan-epb` remains absent (`src/lib/billable-api.ts`)
+- [ ] No deletion of ARI grouping prompt or allocation module
+- [ ] Dead chunk/merge path removed or documented as kept
+- [ ] Tests green
 
 ## STOP conditions
 
-- If a non-test production caller of `buildPlanEpbPrompt` appears — STOP and report; do not delete.
-- Do not remove `assignEpbSentenceGroups` or `toPlanRecords`.
+- If `buildGroupEpbPrompt` appears unused — STOP and report (regression); do not "clean up" by deleting it.
+- Do not reintroduce verb-string clustering.
 
 ## Out of scope
 
-- Changing assignment algorithm behavior
-- Billing system refactors beyond confirming plan-epb stays non-billable
+- Changing allocation thresholds or grouping prompt semantics

--- a/plans/README.md
+++ b/plans/README.md
@@ -35,6 +35,21 @@ Recommended order: **005 → 006 → 007 → 008** (DONE). Hardening wave: **009
 
 **Supervisor session contract:** Initial = private expectations guide (Format → Save → Copy/Print/Share). Midterm/Final = private ACA settings + evidence list → Generate outline brief (`content`) → Save → Copy/Print; Share only the guide for in-app ratees. Never auto-share. Never predict promotion/stratification.
 
+### Generate EPB score-based assignment (PR #17 follow-ups)
+
+Default selection after the smart two-sentence / stash-pop ship (`bb577bd`). Desperate underfill + non-billable `/api/plan-epb` were fixed in-branch; these plans cover remaining leverage.
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|------|-------|----------|--------|------------|--------|
+| 020  | Allocate stashed leftovers by best MPA fit (not ACA key order) | P1 | M | — | TODO |
+| 021  | Soft-home claims when tagged MPA fit is clearly wrong | P2 | M | 020 soft | TODO |
+| 022  | Unassessed cross-fill policy + show empty MPAs in review | P2 | S | — | TODO |
+| 023  | Retire unused LLM plan-epb helpers | P3 | S | PR #17 merge confidence | TODO |
+
+Recommended order: **020 → 022** (parallel OK) → **021** → **023**.
+
+**Considered and rejected / fixed in-branch:** desperate fill only for empty MPAs (widened to underfilled); phantom credit debit on Plan my EPB (`/api/plan-epb` removed from `BILLABLE_API_PATHS`).
+
 ### Auth signup/login series (prior pass — complete)
 
 | Plan | Title | Priority | Effort | Depends on | Status |

--- a/plans/README.md
+++ b/plans/README.md
@@ -48,7 +48,7 @@ Default selection after the smart two-sentence / stash-pop ship (`bb577bd`). Des
 
 Recommended order: **020 → 022** (parallel OK) → **021** → **023**.
 
-**Considered and rejected / fixed in-branch:** desperate fill only for empty MPAs (widened to underfilled); phantom credit debit on Plan my EPB (`/api/plan-epb` removed from `BILLABLE_API_PATHS`).
+**Considered and rejected / fixed in-branch:** desperate fill only for empty MPAs (widened to underfilled); phantom credit debit on Plan my EPB (re-billed only when LLM grouping runs); **verb-string clustering for combine/split** (users aren't consistent — LLM judges action→result→impact similarity instead; scores only allocate candidate pools).
 
 ### Auth signup/login series (prior pass — complete)
 

--- a/src/app/api/plan-epb/route.ts
+++ b/src/app/api/plan-epb/route.ts
@@ -1,16 +1,43 @@
 import { createClient } from "@/lib/supabase/server";
+import { generateText } from "ai";
 import { NextResponse } from "next/server";
-import { assignEpbSentenceGroups } from "@/lib/assign-epb-sentences";
-import { isCivilian, isEnlisted } from "@/lib/constants";
-import { toPlanRecords, type PlanAccomplishmentRecord } from "@/lib/plan-epb";
+import { getDecryptedApiKeys } from "@/app/actions/api-keys";
+import { getModelProvider } from "@/lib/llm-provider";
+import {
+  cacheBillableJson,
+  createBillableRequestContext,
+  getReplayedBillableResponse,
+  handleBillableLLMError,
+  refundAndError,
+  type BillableRequestContext,
+} from "@/lib/billing/billable-request";
 import { handleLLMError } from "@/lib/llm-error-handler";
+import { enforceUsageGate } from "@/lib/usage-gate";
+import { DEFAULT_APP_MODEL_ID, isCivilian, isEnlisted } from "@/lib/constants";
+import { resolveRequestedModel } from "@/app/actions/ai-models";
+import { checkAndTrackUsage } from "@/lib/usage-tracker";
+import { scanAccomplishmentsForLLM } from "@/lib/sensitive-data-scanner";
+import { normalizeStewardshipImpact } from "@/lib/stewardship-impact";
+import {
+  allocateEpbCandidatePools,
+  poolsToFallbackPlan,
+} from "@/lib/assign-epb-sentences";
+import { buildGroupEpbPrompt } from "@/lib/plan-epb-prompt";
+import {
+  sanitizePlan,
+  toPlanRecords,
+  type EpbPlan,
+  type PlanAccomplishmentRecord,
+} from "@/lib/plan-epb";
+import { ACA_PORTFOLIO_MPA_KEYS } from "@/lib/cycle-portfolio";
 import type { Accomplishment, Rank } from "@/types/database";
 
 /**
- * Score-based EPB planning (no LLM). Assigns up to two sentence groups per
- * core MPA via home claims + stash/pop cross-fill from assessment relevancy.
+ * Hybrid EPB planning:
+ * 1) Score-based candidate pools per MPA (home + stash/pop cross-fill)
+ * 2) LLM groups each pool by action→result→impact similarity (not verb match)
  */
-export const maxDuration = 30;
+export const maxDuration = 90;
 
 interface PlanEpbRequest {
   rateeId: string;
@@ -20,9 +47,45 @@ interface PlanEpbRequest {
   cycleYear: number;
   model?: string;
   dutyDescription?: string;
+  /** When set, only these accomplishment ids are considered (preselect on /entries). */
+  accomplishmentIds?: string[];
+}
+
+function parseGroupJson(text: string, validIds: Set<string>): EpbPlan {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error("No JSON found in grouping response");
+  return sanitizePlan(JSON.parse(match[0]), validIds);
+}
+
+/** Drop any id the model moved outside its allocated pool. */
+function constrainPlanToPools(
+  plan: EpbPlan,
+  pools: Record<string, string[]>
+): EpbPlan {
+  const allowed = new Map(
+    ACA_PORTFOLIO_MPA_KEYS.map((key) => [key, new Set(pools[key] ?? [])])
+  );
+  return {
+    mpas: plan.mpas
+      .map((selection) => {
+        const allow = allowed.get(selection.mpaKey);
+        if (!allow) return null;
+        const sentences = selection.sentences
+          .map((s) => ({
+            ...s,
+            accomplishmentIds: s.accomplishmentIds.filter((id) => allow.has(id)),
+          }))
+          .filter((s) => s.accomplishmentIds.length > 0);
+        if (sentences.length === 0) return null;
+        return { ...selection, sentences };
+      })
+      .filter((s): s is NonNullable<typeof s> => !!s),
+  };
 }
 
 export async function POST(request: Request) {
+  let modelId: string | undefined;
+  let billableCtx: BillableRequestContext | null = null;
   try {
     const supabase = await createClient();
     const {
@@ -37,7 +100,11 @@ export async function POST(request: Request) {
       rateeId,
       isManagedMember = false,
       rateeRank,
+      rateeAfsc,
       cycleYear,
+      model = DEFAULT_APP_MODEL_ID,
+      dutyDescription,
+      accomplishmentIds,
     } = body;
 
     if (!rateeId || !rateeRank || !cycleYear) {
@@ -53,8 +120,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // Load the ratee's cycle accomplishments. RLS restricts rows to those the
-    // caller may read, so this doubles as the authorization check.
     let query = supabase
       .from("accomplishments")
       .select("*")
@@ -71,7 +136,12 @@ export async function POST(request: Request) {
       );
     }
 
-    const accomplishments = (rows ?? []) as Accomplishment[];
+    let accomplishments = (rows ?? []) as Accomplishment[];
+    if (accomplishmentIds?.length) {
+      const allow = new Set(accomplishmentIds);
+      accomplishments = accomplishments.filter((a) => allow.has(a.id));
+    }
+
     const records: PlanAccomplishmentRecord[] = toPlanRecords(accomplishments);
     if (records.length === 0) {
       return NextResponse.json(
@@ -80,8 +150,11 @@ export async function POST(request: Request) {
       );
     }
 
-    const plan = assignEpbSentenceGroups(records);
-    if (plan.mpas.length === 0) {
+    const pools = allocateEpbCandidatePools(records);
+    const poolIds = new Set(
+      ACA_PORTFOLIO_MPA_KEYS.flatMap((key) => pools[key])
+    );
+    if (poolIds.size === 0) {
       return NextResponse.json(
         {
           error:
@@ -91,8 +164,104 @@ export async function POST(request: Request) {
       );
     }
 
-    return NextResponse.json({ plan, records });
+    const scan = scanAccomplishmentsForLLM(
+      accomplishments
+        .filter((a) => poolIds.has(a.id))
+        .map((a) => {
+          const stewardship = normalizeStewardshipImpact(a.stewardship_impact);
+          return {
+            details: a.details,
+            impact: a.impact,
+            metrics: a.metrics,
+            stewardship_time: stewardship.time,
+            stewardship_money: stewardship.money,
+            stewardship_resources: stewardship.resources,
+            stewardship_outcome: stewardship.outcome,
+          };
+        })
+    );
+    if (scan.blocked) {
+      return NextResponse.json(
+        {
+          error:
+            "One or more accomplishments contain sensitive data (PII, CUI, or classification markings) that cannot be sent to AI providers. Remove it before generating.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const userKeys = await getDecryptedApiKeys();
+    modelId = await resolveRequestedModel(model, "generate");
+
+    billableCtx = {
+      ...(await createBillableRequestContext(request, user.id)),
+      usageCheck: null,
+    };
+    const replayed = await getReplayedBillableResponse(billableCtx);
+    if (replayed) return replayed;
+
+    const usageCheck = await checkAndTrackUsage(
+      user.id,
+      "plan_epb",
+      modelId,
+      userKeys,
+      billableCtx.idempotencyKey
+    );
+    billableCtx.usageCheck = usageCheck;
+    if (!usageCheck.allowed) {
+      return enforceUsageGate(usageCheck);
+    }
+
+    const modelProvider = getModelProvider(
+      usageCheck.effectiveModel,
+      userKeys,
+      usageCheck.tracking
+    );
+
+    const recordsById = new Map(records.map((r) => [r.id, r] as const));
+    const prompt = buildGroupEpbPrompt({
+      pools,
+      recordsById,
+      rateeRank,
+      rateeAfsc,
+      dutyDescription,
+    });
+
+    let plan: EpbPlan;
+    try {
+      const { text } = await generateText({
+        model: modelProvider,
+        prompt,
+        temperature: 0.2,
+        maxOutputTokens: 2000,
+      });
+      plan = constrainPlanToPools(parseGroupJson(text, poolIds), pools);
+    } catch {
+      // LLM unavailable / bad JSON — still return a usable score-ranked plan.
+      plan = poolsToFallbackPlan(pools, records);
+    }
+
+    if (plan.mpas.length === 0) {
+      return refundAndError(
+        billableCtx,
+        {
+          error:
+            "The planner could not group statements from these accomplishments. Add or strengthen entries and try again.",
+        },
+        { status: 422 }
+      );
+    }
+
+    return cacheBillableJson(billableCtx, { plan, records, pools }, usageCheck);
   } catch (error) {
-    return handleLLMError(error, "POST /api/plan-epb");
+    if (billableCtx) {
+      return handleBillableLLMError(
+        error,
+        "POST /api/plan-epb",
+        modelId,
+        billableCtx
+      );
+    }
+    return handleLLMError(error, "POST /api/plan-epb", modelId);
   }
 }

--- a/src/app/api/plan-epb/route.ts
+++ b/src/app/api/plan-epb/route.ts
@@ -1,37 +1,16 @@
 import { createClient } from "@/lib/supabase/server";
-import { generateText } from "ai";
 import { NextResponse } from "next/server";
-import { getDecryptedApiKeys } from "@/app/actions/api-keys";
-import { getModelProvider } from "@/lib/llm-provider";
-import {
-  cacheBillableJson,
-  createBillableRequestContext,
-  getReplayedBillableResponse,
-  handleBillableLLMError,
-  refundAndError,
-  type BillableRequestContext,
-} from "@/lib/billing/billable-request";
+import { assignEpbSentenceGroups } from "@/lib/assign-epb-sentences";
+import { isCivilian, isEnlisted } from "@/lib/constants";
+import { toPlanRecords, type PlanAccomplishmentRecord } from "@/lib/plan-epb";
 import { handleLLMError } from "@/lib/llm-error-handler";
-import { enforceUsageGate } from "@/lib/usage-gate";
-import { DEFAULT_APP_MODEL_ID, isCivilian, isEnlisted } from "@/lib/constants";
-import { resolveRequestedModel } from "@/app/actions/ai-models";
-import { checkAndTrackUsage } from "@/lib/usage-tracker";
-import { scanAccomplishmentsForLLM } from "@/lib/sensitive-data-scanner";
-import { normalizeStewardshipImpact } from "@/lib/stewardship-impact";
-import { buildPlanEpbPrompt } from "@/lib/plan-epb-prompt";
-import {
-  chunkForPlanning,
-  mergeChunkPlans,
-  sanitizePlan,
-  toPlanRecords,
-  trimMergedPlan,
-  type EpbPlan,
-  type PlanAccomplishmentRecord,
-} from "@/lib/plan-epb";
 import type { Accomplishment, Rank } from "@/types/database";
 
-// Planning fires one LLM call per chunk; allow generous time for large cycles.
-export const maxDuration = 90;
+/**
+ * Score-based EPB planning (no LLM). Assigns up to two sentence groups per
+ * core MPA via home claims + stash/pop cross-fill from assessment relevancy.
+ */
+export const maxDuration = 30;
 
 interface PlanEpbRequest {
   rateeId: string;
@@ -43,15 +22,7 @@ interface PlanEpbRequest {
   dutyDescription?: string;
 }
 
-function parsePlanJson(text: string, validIds: Set<string>): EpbPlan {
-  const match = text.match(/\{[\s\S]*\}/);
-  if (!match) throw new Error("No JSON found in planning response");
-  return sanitizePlan(JSON.parse(match[0]), validIds);
-}
-
 export async function POST(request: Request) {
-  let modelId: string | undefined;
-  let billableCtx: BillableRequestContext | null = null;
   try {
     const supabase = await createClient();
     const {
@@ -66,10 +37,7 @@ export async function POST(request: Request) {
       rateeId,
       isManagedMember = false,
       rateeRank,
-      rateeAfsc,
       cycleYear,
-      model = DEFAULT_APP_MODEL_ID,
-      dutyDescription,
     } = body;
 
     if (!rateeId || !rateeRank || !cycleYear) {
@@ -112,108 +80,19 @@ export async function POST(request: Request) {
       );
     }
 
-    // Block before any data reaches the LLM if PII/CUI is detected.
-    const scan = scanAccomplishmentsForLLM(
-      accomplishments.map((a) => {
-        const stewardship = normalizeStewardshipImpact(a.stewardship_impact);
-        return {
-          details: a.details,
-          impact: a.impact,
-          metrics: a.metrics,
-          stewardship_time: stewardship.time,
-          stewardship_money: stewardship.money,
-          stewardship_resources: stewardship.resources,
-          stewardship_outcome: stewardship.outcome,
-        };
-      })
-    );
-    if (scan.blocked) {
+    const plan = assignEpbSentenceGroups(records);
+    if (plan.mpas.length === 0) {
       return NextResponse.json(
         {
           error:
-            "One or more accomplishments contain sensitive data (PII, CUI, or classification markings) that cannot be sent to AI providers. Remove it before generating.",
-        },
-        { status: 400 }
-      );
-    }
-
-    const userKeys = await getDecryptedApiKeys();
-    modelId = await resolveRequestedModel(model, "generate");
-
-    billableCtx = {
-      ...(await createBillableRequestContext(request, user.id)),
-      usageCheck: null,
-    };
-    const replayed = await getReplayedBillableResponse(billableCtx);
-    if (replayed) return replayed;
-
-    const usageCheck = await checkAndTrackUsage(
-      user.id,
-      "plan_epb",
-      modelId,
-      userKeys,
-      billableCtx.idempotencyKey
-    );
-    billableCtx.usageCheck = usageCheck;
-    if (!usageCheck.allowed) {
-      return enforceUsageGate(usageCheck);
-    }
-
-    const modelProvider = getModelProvider(
-      usageCheck.effectiveModel,
-      userKeys,
-      usageCheck.tracking
-    );
-
-    const validIds = new Set(records.map((r) => r.id));
-    const chunks = chunkForPlanning(records);
-
-    const chunkPlans = await Promise.all(
-      chunks.map(async (chunk) => {
-        const prompt = buildPlanEpbPrompt({
-          records: chunk,
-          rateeRank,
-          rateeAfsc,
-          dutyDescription,
-          isChunked: chunks.length > 1,
-        });
-        const { text } = await generateText({
-          model: modelProvider,
-          prompt,
-          temperature: 0.2,
-          maxOutputTokens: 2000,
-        });
-        return parsePlanJson(text, validIds);
-      })
-    );
-
-    const merged = mergeChunkPlans(chunkPlans);
-    const scoreById = new Map(
-      records.map((r) => [r.id, r.overallScore ?? 0] as const)
-    );
-    const plan = trimMergedPlan(merged, scoreById);
-
-    if (plan.mpas.length === 0) {
-      return refundAndError(
-        billableCtx,
-        {
-          error:
-            "The planner could not select statements from these accomplishments. Add or strengthen entries and try again.",
+            "Could not select statements from these accomplishments. Add or strengthen entries and try again.",
         },
         { status: 422 }
       );
     }
 
-    return cacheBillableJson(billableCtx, { plan, records }, usageCheck);
+    return NextResponse.json({ plan, records });
   } catch (error) {
-    if (billableCtx) {
-      return handleBillableLLMError(
-        error,
-        "POST /api/plan-epb",
-        modelId,
-        billableCtx
-      );
-    }
-    return handleLLMError(error, "POST /api/plan-epb", modelId);
+    return handleLLMError(error, "POST /api/plan-epb");
   }
 }

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -49,7 +49,7 @@ import {
 import { isSubstantialEpbStatement } from "@/lib/fuse-to-epb";
 import { createEpbShell } from "@/lib/epb-shell-create";
 import {
-  buildMpaCustomContext,
+  buildGroupedMpaContexts,
   combineVersions,
   editableFromRecords,
   editableToMpaSelections,
@@ -477,6 +477,11 @@ export function GenerateEpbDialog({
           .map((id) => recordsById.get(id))
           .filter((r): r is PlanAccomplishmentRecord => !!r);
 
+        const { customContext, customContext2 } = buildGroupedMpaContexts(
+          selection.groups,
+          recordsById
+        );
+
         const response = await billableFetch("/api/generate", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -489,8 +494,11 @@ export function GenerateEpbDialog({
             model,
             writingStyle,
             selectedMPAs: [selection.mpaKey],
-            customContext: buildMpaCustomContext(mpaRecords),
-            customContextOptions: { statementCount: selection.sentenceCount },
+            customContext,
+            customContextOptions: {
+              statementCount: selection.sentenceCount,
+              ...(customContext2 ? { customContext2 } : {}),
+            },
             dutyDescription,
             accomplishments: mpaRecords.map((r) => ({
               id: r.id,
@@ -596,12 +604,12 @@ export function GenerateEpbDialog({
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
               <DialogTitle className="text-xl">Generate EPB</DialogTitle>
               <DialogDescription id="generate-epb-desc" className="text-sm leading-relaxed">
-                AI reviews all cycle accomplishments for{" "}
+                We pick the strongest accomplishments for{" "}
                 <span className="font-medium text-foreground">
                   {ratee.rank} {ratee.fullName || "this member"}
                 </span>{" "}
-                and drafts statements for each performance area. You&apos;ll
-                review its selection before anything is generated.
+                using assessment MPA fit scores — up to two sentences per
+                performance area — then you review before anything is generated.
               </DialogDescription>
             </DialogHeader>
 
@@ -614,8 +622,8 @@ export function GenerateEpbDialog({
                       {preselectedRecords.length === 1 ? "" : "s"}
                     </p>
                     <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
-                      We&apos;ll skip AI selection and generate straight from these,
-                      grouped by their performance area.
+                      Top MPA-fit entries become up to two sentences per area;
+                      leftovers can fill gaps in under-covered areas.
                     </p>
                   </div>
                 )}
@@ -734,30 +742,20 @@ export function GenerateEpbDialog({
               </Button>
               {isPreselected ? (
                 <Button
-                  onClick={handleGenerate}
+                  onClick={() => setStep("review")}
                   disabled={selections.length === 0}
                   className={cn("h-10 px-5", motionPressOnly)}
                 >
-                  <Sparkles className="mr-2 size-4" />
-                  Generate my EPB
-                  <TokenCostBadge
-                    cost={generateCost}
-                    compact
-                    className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
-                  />
+                  <ClipboardList className="mr-2 size-4" />
+                  Review plan
                 </Button>
               ) : (
                 <Button
                   onClick={handleAnalyze}
                   className={cn("h-10 px-5", motionPressOnly)}
                 >
-                  <Sparkles className="mr-2 size-4" />
-                  Analyze accomplishments
-                  <TokenCostBadge
-                    cost={1}
-                    compact
-                    className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
-                  />
+                  <ClipboardList className="mr-2 size-4" />
+                  Plan my EPB
                 </Button>
               )}
             </DialogFooter>
@@ -769,7 +767,7 @@ export function GenerateEpbDialog({
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
               <DialogTitle className="text-xl">Selecting your best work</DialogTitle>
               <DialogDescription>
-                Analyzing accomplishments and grouping the ones that combine
+                Ranking accomplishments by MPA fit and grouping related ones
                 into stronger statements…
               </DialogDescription>
             </DialogHeader>
@@ -782,10 +780,11 @@ export function GenerateEpbDialog({
         {step === "review" && (
           <>
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
-              <DialogTitle className="text-xl">Review the AI&apos;s selection</DialogTitle>
+              <DialogTitle className="text-xl">Review the selection</DialogTitle>
               <DialogDescription className="text-sm leading-relaxed">
-                Each sentence group becomes one statement (like accomplishments
-                are combined). Remove or add entries, or turn off an area.
+                Each sentence group becomes one statement (related accomplishments
+                are combined). Up to two sentences per area — remove or add
+                entries, or turn off an area.
               </DialogDescription>
             </DialogHeader>
 

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -51,7 +51,6 @@ import { createEpbShell } from "@/lib/epb-shell-create";
 import {
   buildGroupedMpaContexts,
   combineVersions,
-  editableFromRecords,
   editableToMpaSelections,
   extractVersionArrays,
   mpaLabel,
@@ -142,9 +141,7 @@ export function GenerateEpbDialog({
   const [records, setRecords] = useState<PlanAccomplishmentRecord[]>(
     () => preselectedRecords
   );
-  const [editable, setEditable] = useState<EditablePlan>(() =>
-    isPreselected ? editableFromRecords(preselectedRecords) : {}
-  );
+  const [editable, setEditable] = useState<EditablePlan>(() => ({}));
   const [rationaleByMpa, setRationaleByMpa] = useState<Record<string, string>>(
     {}
   );
@@ -305,7 +302,7 @@ export function GenerateEpbDialog({
       const shell = await findActiveShell().catch(() => null);
       setActiveShell(shell);
       const dutyDescription = dutyDraft.trim() || shell?.duty_description || "";
-      const response = await fetch("/api/plan-epb", {
+      const response = await billableFetch("/api/plan-epb", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -314,6 +311,11 @@ export function GenerateEpbDialog({
           rateeRank: ratee.rank,
           rateeAfsc: ratee.afsc,
           cycleYear,
+          model,
+          dutyDescription,
+          ...(isPreselected
+            ? { accomplishmentIds: preselectedRecords.map((r) => r.id) }
+            : {}),
         }),
       });
 
@@ -602,12 +604,13 @@ export function GenerateEpbDialog({
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
               <DialogTitle className="text-xl">Generate EPB</DialogTitle>
               <DialogDescription id="generate-epb-desc" className="text-sm leading-relaxed">
-                We pick the strongest accomplishments for{" "}
+                We rank accomplishments for{" "}
                 <span className="font-medium text-foreground">
                   {ratee.rank} {ratee.fullName || "this member"}
                 </span>{" "}
-                using assessment MPA fit scores — up to two sentences per
-                performance area — then you review before anything is generated.
+                by MPA fit scores, then AI groups the same efforts together
+                (even when wording differs) so metrics can accumulate — up to
+                two sentences per performance area.
               </DialogDescription>
             </DialogHeader>
 
@@ -620,8 +623,9 @@ export function GenerateEpbDialog({
                       {preselectedRecords.length === 1 ? "" : "s"}
                     </p>
                     <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
-                      Top MPA-fit entries become up to two sentences per area;
-                      leftovers can fill gaps in under-covered areas.
+                      AI will decide which describe the same effort (combine +
+                      accumulate metrics) vs distinct work (separate sentences),
+                      then fill gaps across performance areas using MPA fit scores.
                     </p>
                   </div>
                 )}
@@ -738,24 +742,18 @@ export function GenerateEpbDialog({
               <Button variant="outline" className="h-10 px-5" onClick={() => handleOpenChange(false)}>
                 Cancel
               </Button>
-              {isPreselected ? (
-                <Button
-                  onClick={() => setStep("review")}
-                  disabled={selections.length === 0}
-                  className={cn("h-10 px-5", motionPressOnly)}
-                >
-                  <ClipboardList className="mr-2 size-4" />
-                  Review plan
-                </Button>
-              ) : (
-                <Button
-                  onClick={handleAnalyze}
-                  className={cn("h-10 px-5", motionPressOnly)}
-                >
-                  <ClipboardList className="mr-2 size-4" />
-                  Plan my EPB
-                </Button>
-              )}
+              <Button
+                onClick={handleAnalyze}
+                className={cn("h-10 px-5", motionPressOnly)}
+              >
+                <Sparkles className="mr-2 size-4" />
+                Plan my EPB
+                <TokenCostBadge
+                  cost={1}
+                  compact
+                  className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
+                />
+              </Button>
             </DialogFooter>
           </>
         )}
@@ -765,8 +763,8 @@ export function GenerateEpbDialog({
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
               <DialogTitle className="text-xl">Selecting your best work</DialogTitle>
               <DialogDescription>
-                Ranking accomplishments by MPA fit and grouping related ones
-                into stronger statements…
+                Ranking by MPA fit, then grouping the same efforts together so
+                related metrics can accumulate…
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16">
@@ -780,9 +778,9 @@ export function GenerateEpbDialog({
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
               <DialogTitle className="text-xl">Review the selection</DialogTitle>
               <DialogDescription className="text-sm leading-relaxed">
-                Each sentence group becomes one statement (related accomplishments
-                are combined). Up to two sentences per area — remove or add
-                entries, or turn off an area.
+                Each sentence group becomes one statement. Entries in the same
+                group are treated as one effort (metrics accumulate). Different
+                groups stay separate — up to two sentences per area.
               </DialogDescription>
             </DialogHeader>
 

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -305,7 +305,7 @@ export function GenerateEpbDialog({
       const shell = await findActiveShell().catch(() => null);
       setActiveShell(shell);
       const dutyDescription = dutyDraft.trim() || shell?.duty_description || "";
-      const response = await billableFetch("/api/plan-epb", {
+      const response = await fetch("/api/plan-epb", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -314,8 +314,6 @@ export function GenerateEpbDialog({
           rateeRank: ratee.rank,
           rateeAfsc: ratee.afsc,
           cycleYear,
-          model,
-          dutyDescription,
         }),
       });
 

--- a/src/lib/__tests__/assign-epb-sentences.test.ts
+++ b/src/lib/__tests__/assign-epb-sentences.test.ts
@@ -204,6 +204,38 @@ describe("assignEpbSentenceGroups", () => {
     ).toHaveLength(2);
   });
 
+  it("desperately fills a second sentence when stash scores between 25 and 39", () => {
+    const plan = assignEpbSentenceGroups([
+      record({
+        id: "lp1",
+        taggedMpa: "leading_people",
+        action_verb: "Mentored",
+        primaryMpa: "leading_people",
+        mpaRelevancy: rel(20, 80),
+      }),
+      record({
+        id: "em1",
+        action_verb: "Led",
+        mpaRelevancy: rel(95, 20),
+      }),
+      record({
+        id: "em2",
+        action_verb: "Built",
+        mpaRelevancy: rel(90, 20),
+      }),
+      record({
+        id: "em3",
+        action_verb: "Directed",
+        mpaRelevancy: rel(70, 35), // below normal floor, above desperate
+      }),
+    ]);
+
+    const lp = plan.mpas.find((m) => m.mpaKey === "leading_people")!;
+    expect(lp.sentences).toHaveLength(2);
+    expect(lp.sentences[0]!.accomplishmentIds).toEqual(["lp1"]);
+    expect(lp.sentences[1]!.accomplishmentIds).toEqual(["em3"]);
+  });
+
   it("uses each accomplishment at most once", () => {
     const plan = assignEpbSentenceGroups([
       record({ id: "a", action_verb: "Led", mpaRelevancy: rel(90, 88) }),

--- a/src/lib/__tests__/assign-epb-sentences.test.ts
+++ b/src/lib/__tests__/assign-epb-sentences.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import {
+  assignEpbSentenceGroups,
+  clusterByActionVerb,
+  MIN_CROSS_FILL_RELEVANCY,
+  relevancyForMpa,
+  UNASSESSED_HOME_RELEVANCY,
+} from "../assign-epb-sentences";
+import type { PlanAccomplishmentRecord } from "../plan-epb";
+import type { AccomplishmentMPARelevancy } from "@/types/database";
+
+function rel(
+  executing_mission: number,
+  leading_people: number,
+  managing_resources = 20,
+  improving_unit = 20
+): AccomplishmentMPARelevancy {
+  return {
+    executing_mission,
+    leading_people,
+    managing_resources,
+    improving_unit,
+  };
+}
+
+function record(
+  overrides: Partial<PlanAccomplishmentRecord> & { id: string }
+): PlanAccomplishmentRecord {
+  return {
+    taggedMpa: "executing_mission",
+    action_verb: "Led",
+    details: "did a thing",
+    impact: null,
+    metrics: null,
+    overallScore: 70,
+    primaryMpa: "executing_mission",
+    mpaRelevancy: rel(70, 20),
+    ...overrides,
+  };
+}
+
+describe("relevancyForMpa", () => {
+  it("reads assessed relevancy and falls back for unassessed home tags", () => {
+    const assessed = record({
+      id: "a",
+      mpaRelevancy: rel(90, 40),
+    });
+    expect(relevancyForMpa(assessed, "executing_mission")).toBe(90);
+    expect(relevancyForMpa(assessed, "leading_people")).toBe(40);
+
+    const unassessed = record({
+      id: "b",
+      taggedMpa: "leading_people",
+      mpaRelevancy: null,
+    });
+    expect(relevancyForMpa(unassessed, "leading_people")).toBe(
+      UNASSESSED_HOME_RELEVANCY
+    );
+    expect(relevancyForMpa(unassessed, "executing_mission")).toBe(0);
+  });
+});
+
+describe("clusterByActionVerb", () => {
+  it("groups same verbs and ranks clusters by best MPA fit", () => {
+    const clusters = clusterByActionVerb(
+      [
+        record({ id: "1", action_verb: "Led", mpaRelevancy: rel(60, 10) }),
+        record({ id: "2", action_verb: "Led", mpaRelevancy: rel(80, 10) }),
+        record({ id: "3", action_verb: "Built", mpaRelevancy: rel(95, 10) }),
+      ],
+      "executing_mission"
+    );
+    expect(clusters).toHaveLength(2);
+    expect(clusters[0]!.map((r) => r.id)).toEqual(["3"]);
+    expect(clusters[1]!.map((r) => r.id)).toEqual(["2", "1"]);
+  });
+});
+
+describe("assignEpbSentenceGroups", () => {
+  it("takes the two strongest distinct ARIs for a rich MPA and stashes the rest", () => {
+    // User example: 5 EM entries — best distinct verbs become 2 sentences.
+    const plan = assignEpbSentenceGroups([
+      record({
+        id: "1",
+        action_verb: "Managed",
+        mpaRelevancy: rel(60, 45),
+        overallScore: 60,
+      }),
+      record({
+        id: "2",
+        action_verb: "Led",
+        mpaRelevancy: rel(78, 50),
+        overallScore: 78,
+      }),
+      record({
+        id: "3",
+        action_verb: "Built",
+        mpaRelevancy: rel(88, 55),
+        overallScore: 88,
+      }),
+      record({
+        id: "4",
+        action_verb: "Tracked",
+        mpaRelevancy: rel(40, 30),
+        overallScore: 40,
+      }),
+      record({
+        id: "5",
+        action_verb: "Directed",
+        mpaRelevancy: rel(90, 70),
+        overallScore: 90,
+      }),
+    ]);
+
+    const em = plan.mpas.find((m) => m.mpaKey === "executing_mission")!;
+    expect(em.sentences).toHaveLength(2);
+    expect(em.sentences[0]!.accomplishmentIds).toEqual(["5"]);
+    expect(em.sentences[1]!.accomplishmentIds).toEqual(["3"]);
+
+    // Leftovers with strong Leading People fit fill that empty MPA.
+    const lp = plan.mpas.find((m) => m.mpaKey === "leading_people");
+    expect(lp).toBeDefined();
+    expect(lp!.sentences.length).toBeGreaterThanOrEqual(1);
+    const lpIds = lp!.sentences.flatMap((s) => s.accomplishmentIds);
+    expect(lpIds).toContain("2"); // 50% LP — above cross-fill floor
+    expect(lpIds).not.toContain("5");
+    expect(lpIds).not.toContain("3");
+  });
+
+  it("combines cumulative same-verb home entries into one sentence then pops stash for the second", () => {
+    const plan = assignEpbSentenceGroups([
+      // Leading People: two cumulative "Mentored" entries → 1 sentence
+      record({
+        id: "lp1",
+        taggedMpa: "leading_people",
+        action_verb: "Mentored",
+        primaryMpa: "leading_people",
+        mpaRelevancy: rel(30, 82),
+        overallScore: 82,
+      }),
+      record({
+        id: "lp2",
+        taggedMpa: "leading_people",
+        action_verb: "Mentored",
+        primaryMpa: "leading_people",
+        mpaRelevancy: rel(25, 75),
+        overallScore: 75,
+      }),
+      // Executing Mission leftovers that also score well for Leading People
+      record({
+        id: "em1",
+        action_verb: "Led",
+        mpaRelevancy: rel(92, 68),
+        overallScore: 92,
+      }),
+      record({
+        id: "em2",
+        action_verb: "Built",
+        mpaRelevancy: rel(85, 62),
+        overallScore: 85,
+      }),
+      record({
+        id: "em3",
+        action_verb: "Directed",
+        mpaRelevancy: rel(80, 58),
+        overallScore: 80,
+      }),
+    ]);
+
+    const lp = plan.mpas.find((m) => m.mpaKey === "leading_people")!;
+    expect(lp.sentences).toHaveLength(2);
+    expect(lp.sentences[0]!.accomplishmentIds.sort()).toEqual(["lp1", "lp2"]);
+    // EM home claims took em1+em2; leftover em3 (still ≥ cross-fill floor for LP) fills sentence 2
+    expect(lp.sentences[1]!.accomplishmentIds).toEqual(["em3"]);
+
+    const em = plan.mpas.find((m) => m.mpaKey === "executing_mission")!;
+    expect(em.sentences).toHaveLength(2);
+    expect(em.sentences[0]!.accomplishmentIds).toEqual(["em1"]);
+    expect(em.sentences[1]!.accomplishmentIds).toEqual(["em2"]);
+  });
+
+  it("does not cross-fill with weak relevancy below the floor", () => {
+    const plan = assignEpbSentenceGroups([
+      record({
+        id: "em1",
+        action_verb: "Led",
+        mpaRelevancy: rel(90, MIN_CROSS_FILL_RELEVANCY - 1),
+      }),
+      record({
+        id: "em2",
+        action_verb: "Built",
+        mpaRelevancy: rel(85, 10),
+      }),
+      record({
+        id: "em3",
+        action_verb: "Directed",
+        mpaRelevancy: rel(80, 5),
+      }),
+    ]);
+
+    expect(plan.mpas.map((m) => m.mpaKey)).toEqual(["executing_mission"]);
+    expect(
+      plan.mpas.find((m) => m.mpaKey === "executing_mission")!.sentences
+    ).toHaveLength(2);
+  });
+
+  it("uses each accomplishment at most once", () => {
+    const plan = assignEpbSentenceGroups([
+      record({ id: "a", action_verb: "Led", mpaRelevancy: rel(90, 88) }),
+      record({ id: "b", action_verb: "Built", mpaRelevancy: rel(70, 65) }),
+      record({ id: "c", action_verb: "Drove", mpaRelevancy: rel(60, 55) }),
+      record({
+        id: "d",
+        taggedMpa: "leading_people",
+        action_verb: "Coached",
+        mpaRelevancy: rel(40, 80),
+      }),
+    ]);
+    const allIds = plan.mpas.flatMap((m) =>
+      m.sentences.flatMap((s) => s.accomplishmentIds)
+    );
+    expect(new Set(allIds).size).toBe(allIds.length);
+  });
+});

--- a/src/lib/__tests__/assign-epb-sentences.test.ts
+++ b/src/lib/__tests__/assign-epb-sentences.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
+  allocateEpbCandidatePools,
   assignEpbSentenceGroups,
-  clusterByActionVerb,
+  MAX_CANDIDATES_PER_MPA,
   MIN_CROSS_FILL_RELEVANCY,
+  poolsToFallbackPlan,
   relevancyForMpa,
+  TARGET_CANDIDATES_PER_MPA,
   UNASSESSED_HOME_RELEVANCY,
 } from "../assign-epb-sentences";
 import type { PlanAccomplishmentRecord } from "../plan-epb";
@@ -60,130 +63,47 @@ describe("relevancyForMpa", () => {
   });
 });
 
-describe("clusterByActionVerb", () => {
-  it("groups same verbs and ranks clusters by best MPA fit", () => {
-    const clusters = clusterByActionVerb(
-      [
-        record({ id: "1", action_verb: "Led", mpaRelevancy: rel(60, 10) }),
-        record({ id: "2", action_verb: "Led", mpaRelevancy: rel(80, 10) }),
-        record({ id: "3", action_verb: "Built", mpaRelevancy: rel(95, 10) }),
-      ],
-      "executing_mission"
+describe("allocateEpbCandidatePools", () => {
+  it("keeps strongest home candidates and stashes overflow for cross-fill", () => {
+    const many = Array.from({ length: MAX_CANDIDATES_PER_MPA + 3 }, (_, i) =>
+      record({
+        id: `em${i}`,
+        action_verb: i % 2 === 0 ? "Volunteered" : "Spent",
+        details:
+          i % 2 === 0
+            ? `Volunteered at the USO for 4 hours day ${i}`
+            : `Spent 4 hours serving veterans at the USO day ${i}`,
+        mpaRelevancy: rel(95 - i, 50 + (i % 3)),
+        overallScore: 95 - i,
+      })
     );
-    expect(clusters).toHaveLength(2);
-    expect(clusters[0]!.map((r) => r.id)).toEqual(["3"]);
-    expect(clusters[1]!.map((r) => r.id)).toEqual(["2", "1"]);
-  });
-});
+    // LP needs fill from EM leftovers that score well for LP
+    const lpHome = record({
+      id: "lp1",
+      taggedMpa: "leading_people",
+      action_verb: "Mentored",
+      primaryMpa: "leading_people",
+      mpaRelevancy: rel(20, 80),
+    });
 
-describe("assignEpbSentenceGroups", () => {
-  it("takes the two strongest distinct ARIs for a rich MPA and stashes the rest", () => {
-    // User example: 5 EM entries — best distinct verbs become 2 sentences.
-    const plan = assignEpbSentenceGroups([
-      record({
-        id: "1",
-        action_verb: "Managed",
-        mpaRelevancy: rel(60, 45),
-        overallScore: 60,
-      }),
-      record({
-        id: "2",
-        action_verb: "Led",
-        mpaRelevancy: rel(78, 50),
-        overallScore: 78,
-      }),
-      record({
-        id: "3",
-        action_verb: "Built",
-        mpaRelevancy: rel(88, 55),
-        overallScore: 88,
-      }),
-      record({
-        id: "4",
-        action_verb: "Tracked",
-        mpaRelevancy: rel(40, 30),
-        overallScore: 40,
-      }),
-      record({
-        id: "5",
-        action_verb: "Directed",
-        mpaRelevancy: rel(90, 70),
-        overallScore: 90,
-      }),
-    ]);
-
-    const em = plan.mpas.find((m) => m.mpaKey === "executing_mission")!;
-    expect(em.sentences).toHaveLength(2);
-    expect(em.sentences[0]!.accomplishmentIds).toEqual(["5"]);
-    expect(em.sentences[1]!.accomplishmentIds).toEqual(["3"]);
-
-    // Leftovers with strong Leading People fit fill that empty MPA.
-    const lp = plan.mpas.find((m) => m.mpaKey === "leading_people");
-    expect(lp).toBeDefined();
-    expect(lp!.sentences.length).toBeGreaterThanOrEqual(1);
-    const lpIds = lp!.sentences.flatMap((s) => s.accomplishmentIds);
-    expect(lpIds).toContain("2"); // 50% LP — above cross-fill floor
-    expect(lpIds).not.toContain("5");
-    expect(lpIds).not.toContain("3");
+    const pools = allocateEpbCandidatePools([...many, lpHome]);
+    expect(pools.executing_mission).toHaveLength(MAX_CANDIDATES_PER_MPA);
+    expect(pools.leading_people.length).toBeGreaterThanOrEqual(
+      TARGET_CANDIDATES_PER_MPA
+    );
+    expect(pools.leading_people).toContain("lp1");
+    // Cross-filled from stash (overflow beyond MAX)
+    const cross = pools.leading_people.filter((id) => id !== "lp1");
+    expect(cross.length).toBeGreaterThan(0);
+    for (const id of cross) {
+      expect(pools.executing_mission).not.toContain(id);
+    }
   });
 
-  it("combines cumulative same-verb home entries into one sentence then pops stash for the second", () => {
-    const plan = assignEpbSentenceGroups([
-      // Leading People: two cumulative "Mentored" entries → 1 sentence
-      record({
-        id: "lp1",
-        taggedMpa: "leading_people",
-        action_verb: "Mentored",
-        primaryMpa: "leading_people",
-        mpaRelevancy: rel(30, 82),
-        overallScore: 82,
-      }),
-      record({
-        id: "lp2",
-        taggedMpa: "leading_people",
-        action_verb: "Mentored",
-        primaryMpa: "leading_people",
-        mpaRelevancy: rel(25, 75),
-        overallScore: 75,
-      }),
-      // Executing Mission leftovers that also score well for Leading People
+  it("does not cross-fill below the normal floor when desperate is not needed", () => {
+    const pools = allocateEpbCandidatePools([
       record({
         id: "em1",
-        action_verb: "Led",
-        mpaRelevancy: rel(92, 68),
-        overallScore: 92,
-      }),
-      record({
-        id: "em2",
-        action_verb: "Built",
-        mpaRelevancy: rel(85, 62),
-        overallScore: 85,
-      }),
-      record({
-        id: "em3",
-        action_verb: "Directed",
-        mpaRelevancy: rel(80, 58),
-        overallScore: 80,
-      }),
-    ]);
-
-    const lp = plan.mpas.find((m) => m.mpaKey === "leading_people")!;
-    expect(lp.sentences).toHaveLength(2);
-    expect(lp.sentences[0]!.accomplishmentIds.sort()).toEqual(["lp1", "lp2"]);
-    // EM home claims took em1+em2; leftover em3 (still ≥ cross-fill floor for LP) fills sentence 2
-    expect(lp.sentences[1]!.accomplishmentIds).toEqual(["em3"]);
-
-    const em = plan.mpas.find((m) => m.mpaKey === "executing_mission")!;
-    expect(em.sentences).toHaveLength(2);
-    expect(em.sentences[0]!.accomplishmentIds).toEqual(["em1"]);
-    expect(em.sentences[1]!.accomplishmentIds).toEqual(["em2"]);
-  });
-
-  it("does not cross-fill with weak relevancy below the floor", () => {
-    const plan = assignEpbSentenceGroups([
-      record({
-        id: "em1",
-        action_verb: "Led",
         mpaRelevancy: rel(90, MIN_CROSS_FILL_RELEVANCY - 1),
       }),
       record({
@@ -191,54 +111,14 @@ describe("assignEpbSentenceGroups", () => {
         action_verb: "Built",
         mpaRelevancy: rel(85, 10),
       }),
-      record({
-        id: "em3",
-        action_verb: "Directed",
-        mpaRelevancy: rel(80, 5),
-      }),
     ]);
-
-    expect(plan.mpas.map((m) => m.mpaKey)).toEqual(["executing_mission"]);
-    expect(
-      plan.mpas.find((m) => m.mpaKey === "executing_mission")!.sentences
-    ).toHaveLength(2);
+    expect(pools.executing_mission.sort()).toEqual(["em1", "em2"]);
+    expect(pools.leading_people).toEqual([]);
   });
 
-  it("desperately fills a second sentence when stash scores between 25 and 39", () => {
-    const plan = assignEpbSentenceGroups([
-      record({
-        id: "lp1",
-        taggedMpa: "leading_people",
-        action_verb: "Mentored",
-        primaryMpa: "leading_people",
-        mpaRelevancy: rel(20, 80),
-      }),
-      record({
-        id: "em1",
-        action_verb: "Led",
-        mpaRelevancy: rel(95, 20),
-      }),
-      record({
-        id: "em2",
-        action_verb: "Built",
-        mpaRelevancy: rel(90, 20),
-      }),
-      record({
-        id: "em3",
-        action_verb: "Directed",
-        mpaRelevancy: rel(70, 35), // below normal floor, above desperate
-      }),
-    ]);
-
-    const lp = plan.mpas.find((m) => m.mpaKey === "leading_people")!;
-    expect(lp.sentences).toHaveLength(2);
-    expect(lp.sentences[0]!.accomplishmentIds).toEqual(["lp1"]);
-    expect(lp.sentences[1]!.accomplishmentIds).toEqual(["em3"]);
-  });
-
-  it("uses each accomplishment at most once", () => {
-    const plan = assignEpbSentenceGroups([
-      record({ id: "a", action_verb: "Led", mpaRelevancy: rel(90, 88) }),
+  it("uses each accomplishment at most once across pools", () => {
+    const pools = allocateEpbCandidatePools([
+      record({ id: "a", mpaRelevancy: rel(90, 88) }),
       record({ id: "b", action_verb: "Built", mpaRelevancy: rel(70, 65) }),
       record({ id: "c", action_verb: "Drove", mpaRelevancy: rel(60, 55) }),
       record({
@@ -248,9 +128,56 @@ describe("assignEpbSentenceGroups", () => {
         mpaRelevancy: rel(40, 80),
       }),
     ]);
-    const allIds = plan.mpas.flatMap((m) =>
-      m.sentences.flatMap((s) => s.accomplishmentIds)
-    );
+    const allIds = Object.values(pools).flat();
     expect(new Set(allIds).size).toBe(allIds.length);
+  });
+});
+
+describe("poolsToFallbackPlan / assignEpbSentenceGroups", () => {
+  it("falls back to top-score singleton groups without verb clustering", () => {
+    // Same verb, different efforts — fallback must NOT merge by verb.
+    const records = [
+      record({
+        id: "uso",
+        action_verb: "Volunteered",
+        details: "Volunteered at the USO for 4 hours",
+        mpaRelevancy: rel(90, 20),
+        overallScore: 90,
+      }),
+      record({
+        id: "pt",
+        action_verb: "Volunteered",
+        details: "Volunteered to lead squadron PT for 12 Airmen",
+        mpaRelevancy: rel(80, 20),
+        overallScore: 80,
+      }),
+      record({
+        id: "net",
+        action_verb: "Led",
+        details: "Led network migration",
+        mpaRelevancy: rel(70, 20),
+        overallScore: 70,
+      }),
+    ];
+    const plan = assignEpbSentenceGroups(records);
+    const em = plan.mpas.find((m) => m.mpaKey === "executing_mission")!;
+    expect(em.sentences).toHaveLength(2);
+    expect(em.sentences[0]!.accomplishmentIds).toEqual(["uso"]);
+    expect(em.sentences[1]!.accomplishmentIds).toEqual(["pt"]);
+    // Third stays out of fallback (only 2 sentences) — not verb-merged into either
+    expect(
+      em.sentences.flatMap((s) => s.accomplishmentIds)
+    ).not.toContain("net");
+  });
+
+  it("poolsToFallbackPlan mirrors assignEpbSentenceGroups", () => {
+    const records = [
+      record({ id: "a", mpaRelevancy: rel(90, 20) }),
+      record({ id: "b", action_verb: "Built", mpaRelevancy: rel(80, 20) }),
+    ];
+    const pools = allocateEpbCandidatePools(records);
+    expect(poolsToFallbackPlan(pools, records)).toEqual(
+      assignEpbSentenceGroups(records)
+    );
   });
 });

--- a/src/lib/__tests__/epb-generation-readiness.test.ts
+++ b/src/lib/__tests__/epb-generation-readiness.test.ts
@@ -83,16 +83,18 @@ describe("evaluateEpbGenerationReadiness", () => {
     );
   });
 
-  it("blocks when fewer than the minimum MPAs are covered", () => {
+  it("allows a single labeled MPA when enough entries exist for cross-fill", () => {
     const result = evaluateEpbGenerationReadiness([
       assessed("executing_mission", 80),
       assessed("executing_mission", 75),
       assessed("executing_mission", 70),
     ]);
-    expect(result.canGenerate).toBe(false);
-    expect(result.reasons.join(" ")).toContain(
-      `at least ${MIN_ELIGIBLE_MPAS} performance areas`
-    );
+    expect(result.canGenerate).toBe(true);
+    expect(result.reasons).toHaveLength(0);
+    expect(result.warnings.join(" ")).toMatch(/No entries tagged/i);
+    // Compatibility export still documents the floor, but labeled multi-MPA
+    // coverage is no longer a hard gate (MIN_ELIGIBLE_MPAS === 1).
+    expect(MIN_ELIGIBLE_MPAS).toBe(1);
   });
 
   it("allows generation with coverage across MPAs", () => {

--- a/src/lib/__tests__/generate-epb-run.test.ts
+++ b/src/lib/__tests__/generate-epb-run.test.ts
@@ -4,14 +4,29 @@ import {
   editableToMpaSelections,
   editableFromRecords,
   buildMpaCustomContext,
+  buildGroupedMpaContexts,
   combineVersions,
   extractVersionArrays,
 } from "../generate-epb-run";
 import type { EpbPlan, PlanAccomplishmentRecord } from "../plan-epb";
+import type { AccomplishmentMPARelevancy } from "@/types/database";
+
+function rel(
+  executing_mission: number,
+  leading_people: number
+): AccomplishmentMPARelevancy {
+  return {
+    executing_mission,
+    leading_people,
+    managing_resources: 20,
+    improving_unit: 20,
+  };
+}
 
 function record(
   id: string,
-  taggedMpa: string
+  taggedMpa: string,
+  extras: Partial<PlanAccomplishmentRecord> = {}
 ): PlanAccomplishmentRecord {
   return {
     id,
@@ -20,9 +35,10 @@ function record(
     details: "did a thing",
     impact: null,
     metrics: null,
-    overallScore: null,
-    primaryMpa: null,
+    overallScore: 70,
+    primaryMpa: taggedMpa,
     mpaRelevancy: null,
+    ...extras,
   };
 }
 
@@ -50,13 +66,15 @@ describe("planToEditable + editableToMpaSelections", () => {
     expect(editable.leading_people.groups).toEqual([["d"]]);
   });
 
-  it("unions ids and derives sentence count from non-empty groups", () => {
+  it("preserves groups and derives sentence count from non-empty groups", () => {
     const selections = editableToMpaSelections(planToEditable(plan));
     const em = selections.find((s) => s.mpaKey === "executing_mission")!;
     expect(em.accomplishmentIds).toEqual(["a", "b", "c"]);
+    expect(em.groups).toEqual([["a", "b"], ["c"]]);
     expect(em.sentenceCount).toBe(2);
     const lp = selections.find((s) => s.mpaKey === "leading_people")!;
     expect(lp.sentenceCount).toBe(1);
+    expect(lp.groups).toEqual([["d"]]);
   });
 
   it("skips disabled MPAs and empty groups", () => {
@@ -68,19 +86,27 @@ describe("planToEditable + editableToMpaSelections", () => {
 });
 
 describe("editableFromRecords", () => {
-  it("groups pre-selected records by tagged MPA (one group each)", () => {
+  it("assigns up to two sentence groups via score-based planning", () => {
     const editable = editableFromRecords([
-      record("a", "executing_mission"),
-      record("b", "executing_mission"),
-      record("c", "leading_people"),
+      record("a", "executing_mission", {
+        action_verb: "Led",
+        mpaRelevancy: rel(90, 20),
+      }),
+      record("b", "executing_mission", {
+        action_verb: "Built",
+        mpaRelevancy: rel(85, 20),
+      }),
+      record("c", "leading_people", {
+        action_verb: "Mentored",
+        mpaRelevancy: rel(20, 80),
+      }),
       record("d", "miscellaneous"), // non-core → excluded
     ]);
-    expect(Object.keys(editable).sort()).toEqual([
-      "executing_mission",
-      "leading_people",
-    ]);
-    expect(editable.executing_mission.groups).toEqual([["a", "b"]]);
+    expect(editable.executing_mission.groups).toHaveLength(2);
+    expect(editable.executing_mission.groups[0]).toEqual(["a"]);
+    expect(editable.executing_mission.groups[1]).toEqual(["b"]);
     expect(editable.leading_people.enabled).toBe(true);
+    expect(editable.leading_people.groups).toEqual([["c"]]);
   });
 });
 
@@ -102,6 +128,30 @@ describe("buildMpaCustomContext", () => {
     expect(buildMpaCustomContext(records)).toBe(
       "Led: migration. Impact: zero downtime. Metrics: 50 servers"
     );
+  });
+});
+
+describe("buildGroupedMpaContexts", () => {
+  it("splits sentence groups into customContext and customContext2", () => {
+    const byId = new Map(
+      [
+        record("a", "executing_mission", {
+          action_verb: "Led",
+          details: "first",
+        }),
+        record("b", "executing_mission", {
+          action_verb: "Built",
+          details: "second",
+        }),
+      ].map((r) => [r.id, r] as const)
+    );
+    expect(buildGroupedMpaContexts([["a"], ["b"]], byId)).toEqual({
+      customContext: "Led: first",
+      customContext2: "Built: second",
+    });
+    expect(buildGroupedMpaContexts([["a"]], byId)).toEqual({
+      customContext: "Led: first",
+    });
   });
 });
 

--- a/src/lib/__tests__/generate-epb-run.test.ts
+++ b/src/lib/__tests__/generate-epb-run.test.ts
@@ -129,6 +129,25 @@ describe("buildMpaCustomContext", () => {
       "Led: migration. Impact: zero downtime. Metrics: 50 servers"
     );
   });
+
+  it("prefixes multi-entry groups with cumulative-effort instructions", () => {
+    const text = buildMpaCustomContext([
+      record("a", "executing_mission", {
+        action_verb: "Volunteered",
+        details: "at the USO for 4 hours",
+        metrics: "4 hrs",
+      }),
+      record("b", "executing_mission", {
+        action_verb: "Spent",
+        details: "4 hours serving veterans at the USO",
+        metrics: "4 hrs",
+      }),
+    ]);
+    expect(text).toContain("SAME CUMULATIVE EFFORT");
+    expect(text).toContain("ACCUMULATE metrics");
+    expect(text).toContain("Volunteered: at the USO for 4 hours");
+    expect(text).toContain("Spent: 4 hours serving veterans at the USO");
+  });
 });
 
 describe("buildGroupedMpaContexts", () => {

--- a/src/lib/__tests__/plan-epb.test.ts
+++ b/src/lib/__tests__/plan-epb.test.ts
@@ -164,5 +164,7 @@ describe("buildPlanEpbPrompt", () => {
     expect(prompt).toContain("AF Form 932"); // senior tier note
     expect(prompt).toContain('"mpaKey"');
     expect(prompt).toContain("STRICT JSON");
+    expect(prompt).toMatch(/DO NOT USE VERB MATCHING/i);
+    expect(prompt).toContain("USO");
   });
 });

--- a/src/lib/assign-epb-sentences.ts
+++ b/src/lib/assign-epb-sentences.ts
@@ -10,28 +10,31 @@ import {
 } from "@/lib/plan-epb";
 
 /**
- * Deterministic EPB sentence assignment.
+ * Score-based candidate allocation for Generate EPB.
  *
- * Per core MPA we want up to two sentence groups. Home (tagged) accomplishments
- * claim first: the strongest distinct action clusters become sentences; weaker
- * leftovers are stashed. Underfilled MPAs then pop from the stash using that
- * MPA's relevancy score — so a cycle heavy in Executing the Mission can still
- * fill Leading People when entries scored well on both.
+ * Decides WHICH accomplishments belong to WHICH MPA (home claims + stash/pop
+ * cross-fill). It does NOT decide combine-vs-split — that requires LLM judgment
+ * of action → result → impact similarity (users won't use consistent verbs).
  */
 
 /** Minimum mpa_relevancy to borrow a stashed entry into another MPA. */
 export const MIN_CROSS_FILL_RELEVANCY = 40;
-/** Last-resort cross-fill floor when an MPA still needs another sentence. */
+/** Last-resort cross-fill floor when an MPA still needs candidates. */
 export const MIN_DESPERATE_CROSS_FILL_RELEVANCY = 25;
 /** Synthetic home score when an entry has never been assessed. */
 export const UNASSESSED_HOME_RELEVANCY = 55;
+/**
+ * Max candidates parked on one MPA before leftovers go to the stash.
+ * High enough for the LLM to find two strong (possibly cumulative) sentences.
+ */
+export const MAX_CANDIDATES_PER_MPA = 6;
+/** Prefer at least this many candidates per MPA before cross-fill stops. */
+export const TARGET_CANDIDATES_PER_MPA = 2;
+
+export type EpbCandidatePools = Record<AcaPortfolioMpaKey, string[]>;
 
 function isAcaMpaKey(mpa: string): mpa is AcaPortfolioMpaKey {
   return (ACA_PORTFOLIO_MPA_KEYS as readonly string[]).includes(mpa);
-}
-
-function normalizeVerb(verb: string): string {
-  return verb.trim().toLowerCase();
 }
 
 /** Relevancy of a record for a target MPA (0–100). */
@@ -43,7 +46,6 @@ export function relevancyForMpa(
     const score = record.mpaRelevancy[mpaKey];
     return typeof score === "number" ? score : 0;
   }
-  // Unassessed: keep with tagged MPA so they still participate in home claims.
   return record.taggedMpa === mpaKey ? UNASSESSED_HOME_RELEVANCY : 0;
 }
 
@@ -63,159 +65,119 @@ export function sortByMpaRelevancy(
   });
 }
 
-/**
- * Cluster by action verb so recurring/cumulative work combines into one
- * sentence (metrics accumulate). Different verbs → different sentence groups.
- * Clusters are ordered by their best member's score for the target MPA.
- */
-export function clusterByActionVerb(
-  records: PlanAccomplishmentRecord[],
-  mpaKey: AcaPortfolioMpaKey
-): PlanAccomplishmentRecord[][] {
-  const byVerb = new Map<string, PlanAccomplishmentRecord[]>();
-  for (const record of records) {
-    const key = normalizeVerb(record.action_verb) || `__id:${record.id}`;
-    const bucket = byVerb.get(key);
-    if (bucket) bucket.push(record);
-    else byVerb.set(key, [record]);
-  }
-
-  const clusters = [...byVerb.values()].map((cluster) =>
-    sortByMpaRelevancy(cluster, mpaKey)
-  );
-
-  clusters.sort((a, b) => {
-    const aBest = relevancyForMpa(a[0]!, mpaKey);
-    const bBest = relevancyForMpa(b[0]!, mpaKey);
-    if (bBest !== aBest) return bBest - aBest;
-    const aSum = a.reduce((sum, r) => sum + relevancyForMpa(r, mpaKey), 0);
-    const bSum = b.reduce((sum, r) => sum + relevancyForMpa(r, mpaKey), 0);
-    return bSum - aSum;
-  });
-
-  return clusters;
-}
-
-function groupsFromClusters(
-  clusters: PlanAccomplishmentRecord[][],
-  maxSentences: number,
-  mpaKey: AcaPortfolioMpaKey
-): { groups: PlanSentenceGroup[]; leftovers: PlanAccomplishmentRecord[] } {
-  const take = clusters.slice(0, maxSentences);
-  const rest = clusters.slice(maxSentences);
-  const groups: PlanSentenceGroup[] = take.map((cluster) => ({
-    accomplishmentIds: cluster.map((r) => r.id),
-    rationale:
-      cluster.length > 1
-        ? `Combined ${cluster.length} related "${cluster[0]!.action_verb}" entries (${relevancyForMpa(cluster[0]!, mpaKey)}% ${mpaKey} fit)`
-        : `Strong solo entry (${relevancyForMpa(cluster[0]!, mpaKey)}% ${mpaKey} fit)`,
-  }));
-  return { groups, leftovers: rest.flat() };
-}
-
-function claimFromPool(
-  pool: PlanAccomplishmentRecord[],
-  mpaKey: AcaPortfolioMpaKey,
-  need: number,
-  minScore: number
-): { groups: PlanSentenceGroup[]; usedIds: Set<string> } {
-  if (need <= 0 || pool.length === 0) {
-    return { groups: [], usedIds: new Set() };
-  }
-  const eligible = sortByMpaRelevancy(
-    pool.filter((r) => relevancyForMpa(r, mpaKey) >= minScore),
-    mpaKey
-  );
-  if (eligible.length === 0) {
-    return { groups: [], usedIds: new Set() };
-  }
-  const clusters = clusterByActionVerb(eligible, mpaKey);
-  const { groups } = groupsFromClusters(clusters, need, mpaKey);
-  const usedIds = new Set(groups.flatMap((g) => g.accomplishmentIds));
-  return { groups, usedIds };
+function emptyPools(): EpbCandidatePools {
+  return {
+    executing_mission: [],
+    leading_people: [],
+    managing_resources: [],
+    improving_unit: [],
+  };
 }
 
 /**
- * Assign up to two sentence groups per core MPA using home claims + stash/pop
- * cross-fill. Each accomplishment is used at most once.
+ * Allocate accomplishment ids to core MPAs by assessment fit.
+ * Home (tagged) entries claim first up to MAX_CANDIDATES_PER_MPA; leftovers
+ * stash and fill under-covered MPAs by that MPA's relevancy score.
  */
-export function assignEpbSentenceGroups(
+export function allocateEpbCandidatePools(
   records: PlanAccomplishmentRecord[]
-): EpbPlan {
+): EpbCandidatePools {
   const usable = records.filter((r) => isAcaMpaKey(r.taggedMpa));
   const used = new Set<string>();
-  const byMpa = new Map<AcaPortfolioMpaKey, PlanSentenceGroup[]>();
+  const pools = emptyPools();
   const stash: PlanAccomplishmentRecord[] = [];
 
-  // Pass 1 — home claims by tagged MPA. Top action clusters become sentences;
-  // remaining home entries go to the stash for cross-MPA fill.
   for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
-    const home = usable.filter(
-      (r) => r.taggedMpa === mpaKey && !used.has(r.id)
-    );
-    if (home.length === 0) {
-      byMpa.set(mpaKey, []);
-      continue;
-    }
-    const clusters = clusterByActionVerb(home, mpaKey);
-    const { groups, leftovers } = groupsFromClusters(
-      clusters,
-      PLAN_MAX_SENTENCES_PER_MPA,
+    const home = sortByMpaRelevancy(
+      usable.filter((r) => r.taggedMpa === mpaKey && !used.has(r.id)),
       mpaKey
     );
-    byMpa.set(mpaKey, groups);
-    for (const group of groups) {
-      for (const id of group.accomplishmentIds) used.add(id);
-    }
-    stash.push(...leftovers);
+    const keep = home.slice(0, MAX_CANDIDATES_PER_MPA);
+    const leftover = home.slice(MAX_CANDIDATES_PER_MPA);
+    pools[mpaKey] = keep.map((r) => r.id);
+    for (const r of keep) used.add(r.id);
+    stash.push(...leftover);
   }
 
-  // Anything somehow unused (shouldn't happen for tagged ACA) joins the stash.
   for (const record of usable) {
     if (!used.has(record.id) && !stash.some((s) => s.id === record.id)) {
       stash.push(record);
     }
   }
 
-  const takeFromStash = (
-    mpaKey: AcaPortfolioMpaKey,
-    need: number,
-    minScore: number
-  ) => {
-    const { groups, usedIds } = claimFromPool(stash, mpaKey, need, minScore);
-    if (groups.length === 0) return;
-    const existing = byMpa.get(mpaKey) ?? [];
-    byMpa.set(mpaKey, [...existing, ...groups]);
-    for (const id of usedIds) {
-      used.add(id);
-      const idx = stash.findIndex((r) => r.id === id);
+  const takeFromStash = (mpaKey: AcaPortfolioMpaKey, need: number, minScore: number) => {
+    if (need <= 0) return;
+    const eligible = sortByMpaRelevancy(
+      stash.filter((r) => relevancyForMpa(r, mpaKey) >= minScore),
+      mpaKey
+    ).slice(0, need);
+    for (const record of eligible) {
+      pools[mpaKey].push(record.id);
+      used.add(record.id);
+      const idx = stash.findIndex((r) => r.id === record.id);
       if (idx >= 0) stash.splice(idx, 1);
     }
   };
 
-  // Pass 2 — fill second sentences (and empty MPAs) from stash when score fits.
   for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
-    const current = byMpa.get(mpaKey) ?? [];
-    const need = PLAN_MAX_SENTENCES_PER_MPA - current.length;
-    if (need <= 0) continue;
-    takeFromStash(mpaKey, need, MIN_CROSS_FILL_RELEVANCY);
+    const need = TARGET_CANDIDATES_PER_MPA - pools[mpaKey].length;
+    if (need > 0) takeFromStash(mpaKey, need, MIN_CROSS_FILL_RELEVANCY);
   }
 
-  // Pass 3 — desperate fill for still-underfilled MPAs at a lower score floor
-  // (covers both empty areas and MPAs stuck at a single sentence).
   for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
-    const current = byMpa.get(mpaKey) ?? [];
-    const need = PLAN_MAX_SENTENCES_PER_MPA - current.length;
-    if (need <= 0) continue;
-    takeFromStash(mpaKey, need, MIN_DESPERATE_CROSS_FILL_RELEVANCY);
+    const need = TARGET_CANDIDATES_PER_MPA - pools[mpaKey].length;
+    if (need > 0) takeFromStash(mpaKey, need, MIN_DESPERATE_CROSS_FILL_RELEVANCY);
   }
 
-  return {
-    mpas: ACA_PORTFOLIO_MPA_KEYS.filter(
-      (key) => (byMpa.get(key) ?? []).length > 0
-    ).map((mpaKey) => ({
-      mpaKey,
-      sentences: byMpa.get(mpaKey)!,
-    })),
-  };
+  // Cap after cross-fill so no MPA balloons.
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    if (pools[mpaKey].length > MAX_CANDIDATES_PER_MPA) {
+      pools[mpaKey] = pools[mpaKey].slice(0, MAX_CANDIDATES_PER_MPA);
+    }
+  }
+
+  return pools;
+}
+
+/**
+ * Offline fallback when the LLM grouping step is unavailable: park the top
+ * relevancy ids as singleton sentence groups (no verb/ARI combine). Prefer the
+ * LLM path in production so cumulative efforts can merge.
+ */
+export function poolsToFallbackPlan(
+  pools: EpbCandidatePools,
+  records: PlanAccomplishmentRecord[]
+): EpbPlan {
+  const byId = new Map(records.map((r) => [r.id, r] as const));
+  const mpas: EpbPlan["mpas"] = [];
+
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const ids = pools[mpaKey];
+    if (ids.length === 0) continue;
+    const ranked = sortByMpaRelevancy(
+      ids.map((id) => byId.get(id)).filter((r): r is PlanAccomplishmentRecord => !!r),
+      mpaKey
+    );
+    const sentences: PlanSentenceGroup[] = ranked
+      .slice(0, PLAN_MAX_SENTENCES_PER_MPA)
+      .map((r) => ({
+        accomplishmentIds: [r.id],
+        rationale: `Strong ${mpaKey} candidate (${relevancyForMpa(r, mpaKey)}% fit) — combine step skipped`,
+      }));
+    if (sentences.length > 0) {
+      mpas.push({ mpaKey, sentences });
+    }
+  }
+
+  return { mpas };
+}
+
+/**
+ * @deprecated Prefer allocateEpbCandidatePools + LLM ARI grouping.
+ * Fallback-only: score pools → singleton sentence groups.
+ */
+export function assignEpbSentenceGroups(
+  records: PlanAccomplishmentRecord[]
+): EpbPlan {
+  return poolsToFallbackPlan(allocateEpbCandidatePools(records), records);
 }

--- a/src/lib/assign-epb-sentences.ts
+++ b/src/lib/assign-epb-sentences.ts
@@ -1,0 +1,219 @@
+import {
+  ACA_PORTFOLIO_MPA_KEYS,
+  type AcaPortfolioMpaKey,
+} from "@/lib/cycle-portfolio";
+import {
+  PLAN_MAX_SENTENCES_PER_MPA,
+  type EpbPlan,
+  type PlanAccomplishmentRecord,
+  type PlanSentenceGroup,
+} from "@/lib/plan-epb";
+
+/**
+ * Deterministic EPB sentence assignment.
+ *
+ * Per core MPA we want up to two sentence groups. Home (tagged) accomplishments
+ * claim first: the strongest distinct action clusters become sentences; weaker
+ * leftovers are stashed. Underfilled MPAs then pop from the stash using that
+ * MPA's relevancy score — so a cycle heavy in Executing the Mission can still
+ * fill Leading People when entries scored well on both.
+ */
+
+/** Minimum mpa_relevancy to borrow a stashed entry into another MPA. */
+export const MIN_CROSS_FILL_RELEVANCY = 40;
+/** Last-resort cross-fill floor when an MPA would otherwise stay empty. */
+export const MIN_DESPERATE_CROSS_FILL_RELEVANCY = 25;
+/** Synthetic home score when an entry has never been assessed. */
+export const UNASSESSED_HOME_RELEVANCY = 55;
+
+function isAcaMpaKey(mpa: string): mpa is AcaPortfolioMpaKey {
+  return (ACA_PORTFOLIO_MPA_KEYS as readonly string[]).includes(mpa);
+}
+
+function normalizeVerb(verb: string): string {
+  return verb.trim().toLowerCase();
+}
+
+/** Relevancy of a record for a target MPA (0–100). */
+export function relevancyForMpa(
+  record: PlanAccomplishmentRecord,
+  mpaKey: AcaPortfolioMpaKey
+): number {
+  if (record.mpaRelevancy) {
+    const score = record.mpaRelevancy[mpaKey];
+    return typeof score === "number" ? score : 0;
+  }
+  // Unassessed: keep with tagged MPA so they still participate in home claims.
+  return record.taggedMpa === mpaKey ? UNASSESSED_HOME_RELEVANCY : 0;
+}
+
+function overallTieBreak(record: PlanAccomplishmentRecord): number {
+  return record.overallScore ?? 0;
+}
+
+/** Sort strongest → weakest for a target MPA. */
+export function sortByMpaRelevancy(
+  records: PlanAccomplishmentRecord[],
+  mpaKey: AcaPortfolioMpaKey
+): PlanAccomplishmentRecord[] {
+  return [...records].sort((a, b) => {
+    const diff = relevancyForMpa(b, mpaKey) - relevancyForMpa(a, mpaKey);
+    if (diff !== 0) return diff;
+    return overallTieBreak(b) - overallTieBreak(a);
+  });
+}
+
+/**
+ * Cluster by action verb so recurring/cumulative work combines into one
+ * sentence (metrics accumulate). Different verbs → different sentence groups.
+ * Clusters are ordered by their best member's score for the target MPA.
+ */
+export function clusterByActionVerb(
+  records: PlanAccomplishmentRecord[],
+  mpaKey: AcaPortfolioMpaKey
+): PlanAccomplishmentRecord[][] {
+  const byVerb = new Map<string, PlanAccomplishmentRecord[]>();
+  for (const record of records) {
+    const key = normalizeVerb(record.action_verb) || `__id:${record.id}`;
+    const bucket = byVerb.get(key);
+    if (bucket) bucket.push(record);
+    else byVerb.set(key, [record]);
+  }
+
+  const clusters = [...byVerb.values()].map((cluster) =>
+    sortByMpaRelevancy(cluster, mpaKey)
+  );
+
+  clusters.sort((a, b) => {
+    const aBest = relevancyForMpa(a[0]!, mpaKey);
+    const bBest = relevancyForMpa(b[0]!, mpaKey);
+    if (bBest !== aBest) return bBest - aBest;
+    const aSum = a.reduce((sum, r) => sum + relevancyForMpa(r, mpaKey), 0);
+    const bSum = b.reduce((sum, r) => sum + relevancyForMpa(r, mpaKey), 0);
+    return bSum - aSum;
+  });
+
+  return clusters;
+}
+
+function groupsFromClusters(
+  clusters: PlanAccomplishmentRecord[][],
+  maxSentences: number,
+  mpaKey: AcaPortfolioMpaKey
+): { groups: PlanSentenceGroup[]; leftovers: PlanAccomplishmentRecord[] } {
+  const take = clusters.slice(0, maxSentences);
+  const rest = clusters.slice(maxSentences);
+  const groups: PlanSentenceGroup[] = take.map((cluster) => ({
+    accomplishmentIds: cluster.map((r) => r.id),
+    rationale:
+      cluster.length > 1
+        ? `Combined ${cluster.length} related "${cluster[0]!.action_verb}" entries (${relevancyForMpa(cluster[0]!, mpaKey)}% ${mpaKey} fit)`
+        : `Strong solo entry (${relevancyForMpa(cluster[0]!, mpaKey)}% ${mpaKey} fit)`,
+  }));
+  return { groups, leftovers: rest.flat() };
+}
+
+function claimFromPool(
+  pool: PlanAccomplishmentRecord[],
+  mpaKey: AcaPortfolioMpaKey,
+  need: number,
+  minScore: number
+): { groups: PlanSentenceGroup[]; usedIds: Set<string> } {
+  if (need <= 0 || pool.length === 0) {
+    return { groups: [], usedIds: new Set() };
+  }
+  const eligible = sortByMpaRelevancy(
+    pool.filter((r) => relevancyForMpa(r, mpaKey) >= minScore),
+    mpaKey
+  );
+  if (eligible.length === 0) {
+    return { groups: [], usedIds: new Set() };
+  }
+  const clusters = clusterByActionVerb(eligible, mpaKey);
+  const { groups } = groupsFromClusters(clusters, need, mpaKey);
+  const usedIds = new Set(groups.flatMap((g) => g.accomplishmentIds));
+  return { groups, usedIds };
+}
+
+/**
+ * Assign up to two sentence groups per core MPA using home claims + stash/pop
+ * cross-fill. Each accomplishment is used at most once.
+ */
+export function assignEpbSentenceGroups(
+  records: PlanAccomplishmentRecord[]
+): EpbPlan {
+  const usable = records.filter((r) => isAcaMpaKey(r.taggedMpa));
+  const used = new Set<string>();
+  const byMpa = new Map<AcaPortfolioMpaKey, PlanSentenceGroup[]>();
+  const stash: PlanAccomplishmentRecord[] = [];
+
+  // Pass 1 — home claims by tagged MPA. Top action clusters become sentences;
+  // remaining home entries go to the stash for cross-MPA fill.
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const home = usable.filter(
+      (r) => r.taggedMpa === mpaKey && !used.has(r.id)
+    );
+    if (home.length === 0) {
+      byMpa.set(mpaKey, []);
+      continue;
+    }
+    const clusters = clusterByActionVerb(home, mpaKey);
+    const { groups, leftovers } = groupsFromClusters(
+      clusters,
+      PLAN_MAX_SENTENCES_PER_MPA,
+      mpaKey
+    );
+    byMpa.set(mpaKey, groups);
+    for (const group of groups) {
+      for (const id of group.accomplishmentIds) used.add(id);
+    }
+    stash.push(...leftovers);
+  }
+
+  // Anything somehow unused (shouldn't happen for tagged ACA) joins the stash.
+  for (const record of usable) {
+    if (!used.has(record.id) && !stash.some((s) => s.id === record.id)) {
+      stash.push(record);
+    }
+  }
+
+  const takeFromStash = (
+    mpaKey: AcaPortfolioMpaKey,
+    need: number,
+    minScore: number
+  ) => {
+    const { groups, usedIds } = claimFromPool(stash, mpaKey, need, minScore);
+    if (groups.length === 0) return;
+    const existing = byMpa.get(mpaKey) ?? [];
+    byMpa.set(mpaKey, [...existing, ...groups]);
+    for (const id of usedIds) {
+      used.add(id);
+      const idx = stash.findIndex((r) => r.id === id);
+      if (idx >= 0) stash.splice(idx, 1);
+    }
+  };
+
+  // Pass 2 — fill second sentences (and empty MPAs) from stash when score fits.
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const current = byMpa.get(mpaKey) ?? [];
+    const need = PLAN_MAX_SENTENCES_PER_MPA - current.length;
+    if (need <= 0) continue;
+    takeFromStash(mpaKey, need, MIN_CROSS_FILL_RELEVANCY);
+  }
+
+  // Pass 3 — desperate fill for still-empty MPAs at a lower score floor.
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const current = byMpa.get(mpaKey) ?? [];
+    if (current.length > 0) continue;
+    takeFromStash(mpaKey, PLAN_MAX_SENTENCES_PER_MPA, MIN_DESPERATE_CROSS_FILL_RELEVANCY);
+  }
+
+  return {
+    mpas: ACA_PORTFOLIO_MPA_KEYS.filter(
+      (key) => (byMpa.get(key) ?? []).length > 0
+    ).map((mpaKey) => ({
+      mpaKey,
+      sentences: byMpa.get(mpaKey)!,
+    })),
+  };
+}

--- a/src/lib/assign-epb-sentences.ts
+++ b/src/lib/assign-epb-sentences.ts
@@ -21,7 +21,7 @@ import {
 
 /** Minimum mpa_relevancy to borrow a stashed entry into another MPA. */
 export const MIN_CROSS_FILL_RELEVANCY = 40;
-/** Last-resort cross-fill floor when an MPA would otherwise stay empty. */
+/** Last-resort cross-fill floor when an MPA still needs another sentence. */
 export const MIN_DESPERATE_CROSS_FILL_RELEVANCY = 25;
 /** Synthetic home score when an entry has never been assessed. */
 export const UNASSESSED_HOME_RELEVANCY = 55;
@@ -201,11 +201,13 @@ export function assignEpbSentenceGroups(
     takeFromStash(mpaKey, need, MIN_CROSS_FILL_RELEVANCY);
   }
 
-  // Pass 3 — desperate fill for still-empty MPAs at a lower score floor.
+  // Pass 3 — desperate fill for still-underfilled MPAs at a lower score floor
+  // (covers both empty areas and MPAs stuck at a single sentence).
   for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
     const current = byMpa.get(mpaKey) ?? [];
-    if (current.length > 0) continue;
-    takeFromStash(mpaKey, PLAN_MAX_SENTENCES_PER_MPA, MIN_DESPERATE_CROSS_FILL_RELEVANCY);
+    const need = PLAN_MAX_SENTENCES_PER_MPA - current.length;
+    if (need <= 0) continue;
+    takeFromStash(mpaKey, need, MIN_DESPERATE_CROSS_FILL_RELEVANCY);
   }
 
   return {

--- a/src/lib/billable-api.ts
+++ b/src/lib/billable-api.ts
@@ -3,7 +3,6 @@ import { useCreditsStore } from "@/stores/credits-store";
 /** POST endpoints that consume a prepaid AI call (default-key users). */
 export const BILLABLE_API_PATHS = [
   "/api/generate",
-  "/api/plan-epb",
   "/api/revise-selection",
   "/api/generate-war",
   "/api/generate-award",

--- a/src/lib/billable-api.ts
+++ b/src/lib/billable-api.ts
@@ -3,6 +3,7 @@ import { useCreditsStore } from "@/stores/credits-store";
 /** POST endpoints that consume a prepaid AI call (default-key users). */
 export const BILLABLE_API_PATHS = [
   "/api/generate",
+  "/api/plan-epb",
   "/api/revise-selection",
   "/api/generate-war",
   "/api/generate-award",

--- a/src/lib/epb-generation-readiness.ts
+++ b/src/lib/epb-generation-readiness.ts
@@ -12,15 +12,18 @@ import type { Accomplishment, EPBShellSection, Rank } from "@/types/database";
 /**
  * Gate + guidance for the one-shot "Generate EPB" flow.
  *
- * This is intentionally content-based (not "1-2 selected per MPA"): the LLM
- * planning step decides the real per-sentence selection and combinations. Here
- * we only stop obviously-too-thin runs and surface non-blocking cautions.
+ * Content-based only — we do **not** require 2 labeled entries per MPA.
+ * Score-based assignment can cross-fill empty labeled areas from leftovers that
+ * scored well on that MPA. Here we only stop obviously-too-thin runs.
  */
 
-/** At least this many core MPAs must have >= 1 entry to attempt a full EPB. */
-export const MIN_ELIGIBLE_MPAS = 2;
 /** At least this many ACA-tagged entries across the cycle. */
 export const MIN_TOTAL_ACA_ENTRIES = 3;
+/**
+ * @deprecated Kept for tests/import compatibility. Cross-fill means we no longer
+ * require labeled coverage across multiple MPAs to attempt generation.
+ */
+export const MIN_ELIGIBLE_MPAS = 1;
 
 export interface MpaReadiness {
   mpaKey: AcaPortfolioMpaKey;
@@ -120,23 +123,19 @@ export function evaluateEpbGenerationReadiness(
     );
   }
 
-  if (eligibleMpaKeys.length < MIN_ELIGIBLE_MPAS) {
-    reasons.push(
-      `Cover at least ${MIN_ELIGIBLE_MPAS} performance areas before generating (currently ${eligibleMpaKeys.length}).`
-    );
-  }
-
   const warnings: string[] = [];
   const emptyMpas = ACA_PORTFOLIO_MPA_KEYS.filter(
     (key) => perMpa[key].entryCount === 0
   );
   if (emptyMpas.length > 0) {
     warnings.push(
-      `No entries for ${emptyMpas
+      `No entries tagged for ${emptyMpas
         .map((key) => perMpa[key].label)
-        .join(", ")} — ${
-        emptyMpas.length === 1 ? "that section" : "those sections"
-      } will be left blank.`
+        .join(", ")} — Generate EPB will try to fill ${
+        emptyMpas.length === 1 ? "it" : "them"
+      } from accomplishments that scored well on ${
+        emptyMpas.length === 1 ? "that area" : "those areas"
+      }.`
     );
   }
 

--- a/src/lib/generate-epb-run.ts
+++ b/src/lib/generate-epb-run.ts
@@ -1,4 +1,5 @@
 import { ENTRY_MGAS } from "@/lib/constants";
+import { assignEpbSentenceGroups } from "@/lib/assign-epb-sentences";
 import {
   ACA_PORTFOLIO_MPA_KEYS,
   type AcaPortfolioMpaKey,
@@ -29,6 +30,11 @@ export interface MpaSelection {
   mpaKey: AcaPortfolioMpaKey;
   /** Unique accomplishment ids across all groups for this MPA. */
   accomplishmentIds: string[];
+  /**
+   * Per-sentence accomplishment groups (preserves combine boundaries for
+   * customContext / customContext2).
+   */
+  groups: string[][];
   /** 1 or 2 — drives statementCount for /api/generate. */
   sentenceCount: 1 | 2;
 }
@@ -57,32 +63,19 @@ export function planToEditable(plan: EpbPlan): EditablePlan {
 }
 
 /**
- * Build an editable plan directly from pre-selected accomplishment records,
- * grouping by each entry's tagged MPA (one sentence group per MPA). Used when
- * the user already picked accomplishments on /entries and skips AI selection.
+ * Build an editable plan from accomplishment records using score-based
+ * home claims + stash/pop cross-fill (up to two sentences per MPA).
  */
 export function editableFromRecords(
   records: PlanAccomplishmentRecord[]
 ): EditablePlan {
-  const byMpa: Record<string, string[]> = {};
-  for (const record of records) {
-    if (!isAcaMpaKey(record.taggedMpa)) continue;
-    (byMpa[record.taggedMpa] ??= []).push(record.id);
-  }
-  const editable: EditablePlan = {};
-  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
-    const ids = byMpa[mpaKey];
-    if (ids && ids.length > 0) {
-      editable[mpaKey] = { enabled: true, groups: [ids] };
-    }
-  }
-  return editable;
+  return planToEditable(assignEpbSentenceGroups(records));
 }
 
 /**
  * Reduce the editable plan to per-MPA generation selections: enabled MPAs with
- * at least one non-empty group, unioned ids, and sentence count = number of
- * non-empty groups (capped at two).
+ * at least one non-empty group, preserved group boundaries, and sentence count
+ * = number of non-empty groups (capped at two).
  */
 export function editableToMpaSelections(editable: EditablePlan): MpaSelection[] {
   const selections: MpaSelection[] = [];
@@ -107,10 +100,31 @@ export function editableToMpaSelections(editable: EditablePlan): MpaSelection[] 
     selections.push({
       mpaKey,
       accomplishmentIds: ids,
+      groups: nonEmptyGroups.map((g) => [...g]),
       sentenceCount: nonEmptyGroups.length >= 2 ? 2 : 1,
     });
   }
   return selections;
+}
+
+/** Build customContext (+ optional customContext2) from per-sentence groups. */
+export function buildGroupedMpaContexts(
+  groups: string[][],
+  recordsById: Map<string, PlanAccomplishmentRecord>
+): { customContext: string; customContext2?: string } {
+  const resolve = (ids: string[]) =>
+    ids
+      .map((id) => recordsById.get(id))
+      .filter((r): r is PlanAccomplishmentRecord => !!r);
+
+  const first = buildMpaCustomContext(resolve(groups[0] ?? []));
+  if (groups.length < 2) {
+    return { customContext: first };
+  }
+  const second = buildMpaCustomContext(resolve(groups[1] ?? []));
+  return second
+    ? { customContext: first, customContext2: second }
+    : { customContext: first };
 }
 
 /**

--- a/src/lib/generate-epb-run.ts
+++ b/src/lib/generate-epb-run.ts
@@ -130,17 +130,21 @@ export function buildGroupedMpaContexts(
 /**
  * Fused free-text for one MPA's selected accomplishments — matches the format
  * the single-statement fuse flow sends as `customContext` to /api/generate.
+ * When multiple records are present, instruct the model to treat them as one
+ * cumulative effort and accumulate metrics (hours, dollars, counts).
  */
 export function buildMpaCustomContext(
   records: PlanAccomplishmentRecord[]
 ): string {
-  return records
+  const body = records
     .map((r) => {
       const impact = r.impact ? `. Impact: ${r.impact}` : "";
       const metrics = r.metrics ? `. Metrics: ${r.metrics}` : "";
       return `${r.action_verb}: ${r.details}${impact}${metrics}`;
     })
     .join("\n\n");
+  if (records.length <= 1) return body;
+  return `SAME CUMULATIVE EFFORT — rewrite as ONE statement and ACCUMULATE metrics (hours, dollars, counts) across the entries below:\n\n${body}`;
 }
 
 /**

--- a/src/lib/plan-epb-prompt.ts
+++ b/src/lib/plan-epb-prompt.ts
@@ -1,9 +1,13 @@
 import { ENTRY_MGAS, getRubricTierForRank } from "@/lib/constants";
-import { ACA_PORTFOLIO_MPA_KEYS } from "@/lib/cycle-portfolio";
+import {
+  ACA_PORTFOLIO_MPA_KEYS,
+  type AcaPortfolioMpaKey,
+} from "@/lib/cycle-portfolio";
 import {
   PLAN_MAX_SENTENCES_PER_MPA,
   type PlanAccomplishmentRecord,
 } from "@/lib/plan-epb";
+import type { EpbCandidatePools } from "@/lib/assign-epb-sentences";
 import type { Rank } from "@/types/database";
 
 function mpaReference(): string {
@@ -33,79 +37,123 @@ function formatRecord(record: PlanAccomplishmentRecord): string {
   return lines.map((l) => `  ${l}`).join("\n");
 }
 
-export interface BuildPlanEpbPromptArgs {
-  records: PlanAccomplishmentRecord[];
+export interface BuildGroupEpbPromptArgs {
+  pools: EpbCandidatePools;
+  recordsById: Map<string, PlanAccomplishmentRecord>;
   rateeRank: Rank | string | null;
   rateeAfsc?: string | null;
-  /** Ratee duty description — context for how accomplishments map to the role. */
   dutyDescription?: string | null;
-  /** True when the input is one of several chunks (selection still per-MPA). */
-  isChunked?: boolean;
 }
 
 /**
- * Prompt for the EPB planning step. The model selects the strongest
- * accomplishments per core MPA and groups the ones that should be COMBINED into
- * a single statement sentence. Returns strict JSON only.
+ * Prompt for the EPB *grouping* step. Candidate ids per MPA are already chosen
+ * by score-based allocation. The model only decides which entries describe the
+ * SAME action→result→impact effort (combine + accumulate metrics) vs distinct
+ * efforts (separate sentences). Never use action_verb equality as the rule.
  */
-export function buildPlanEpbPrompt(args: BuildPlanEpbPromptArgs): string {
-  const { records, rateeRank, rateeAfsc, dutyDescription, isChunked } = args;
+export function buildGroupEpbPrompt(args: BuildGroupEpbPromptArgs): string {
+  const { pools, recordsById, rateeRank, rateeAfsc, dutyDescription } = args;
   const tier = getRubricTierForRank(rateeRank);
   const tierNote =
     tier === "senior"
       ? "This ratee is a senior NCO (AF Form 932) — weight scope, leadership, and unit-level impact."
       : "This ratee is junior enlisted (AF Form 931) — weight job proficiency, initiative, and quantified results.";
 
-  const recordBlock = records
-    .map((record, index) => `[#${index + 1}]\n${formatRecord(record)}`)
+  const poolBlocks = ACA_PORTFOLIO_MPA_KEYS.filter(
+    (key) => pools[key].length > 0
+  )
+    .map((mpaKey) => {
+      const label = ENTRY_MGAS.find((m) => m.key === mpaKey)?.label ?? mpaKey;
+      const entries = pools[mpaKey]
+        .map((id, index) => {
+          const record = recordsById.get(id);
+          if (!record) return null;
+          return `[${mpaKey} #${index + 1}]\n${formatRecord(record)}`;
+        })
+        .filter(Boolean)
+        .join("\n\n");
+      return `=== POOL: ${mpaKey} (${label}) ===\n${entries}`;
+    })
     .join("\n\n");
 
   const dutyBlock = dutyDescription?.trim()
-    ? `\nDUTY DESCRIPTION (use to judge relevance and MPA fit):\n${dutyDescription.trim()}\n`
+    ? `\nDUTY DESCRIPTION (context only):\n${dutyDescription.trim()}\n`
     : "";
 
-  return `You are an expert U.S. Air Force EPB writer planning which accomplishments to turn into performance statements.
+  return `You are an expert U.S. Air Force EPB writer. Candidate accomplishments are ALREADY assigned to each Major Performance Area (MPA). Your only job is to group them into at most ${PLAN_MAX_SENTENCES_PER_MPA} performance STATEMENT sentences per MPA.
 
 RATEE
 - Rank: ${rateeRank ?? "unknown"}
 - AFSC: ${rateeAfsc ?? "unknown"}
 - ${tierNote}
 ${dutyBlock}
-CORE MPAS (only these):
+CORE MPAS:
 ${mpaReference()}
 
-YOUR TASK
-For each core MPA, choose the accomplishments that will produce the strongest 1-2 performance statements, and GROUP the accomplishments that should be combined into a single sentence.
+HOW TO JUDGE "SAME EFFORT" (CRITICAL — DO NOT USE VERB MATCHING)
+Compare action → result → impact (and metrics). Ignore whether action_verb strings match.
+
+COMBINE into ONE sentence group when entries describe the SAME recurring / cumulative effort, even if wording or verbs differ. Example:
+- "Volunteered at the USO for 4 hours on this day"
+- "Spent 4 hours serving veterans at the USO" (different day)
+→ SAME effort → one group; downstream writing should accumulate to ~8 hours and tell one story.
+
+KEEP SEPARATE (different sentence groups) when efforts are substantively different even if they share a verb. Example:
+- "Led squadron PT sessions…" vs "Led a network migration…" → different efforts → two groups.
+
+METRIC RULE
+When combining, note in rationale that metrics should accumulate (hours, dollars, counts). Do not invent metrics that are not present.
 
 SELECTION RULES
-1. Prioritize higher overall_score and higher mpa_relevancy for the target MPA, but DO NOT simply filter by score.
-2. Combine "like" accomplishments (same effort/initiative recurring across the cycle) into ONE sentence group so their metrics accumulate (man-hours, dollars saved, counts). A low-scoring entry on its own can be valuable when combined.
-3. A sentence group may contain a single accomplishment when it stands strongly on its own.
-4. Prefer the accomplishment's tagged_mpa, but you may place an entry under its primary_mpa when relevancy clearly favors it.
-5. Output at most ${PLAN_MAX_SENTENCES_PER_MPA} sentence groups per MPA. Omit an MPA entirely if nothing fits.
-6. Only use accomplishment ids from the list below. Never invent ids.
-${
-  isChunked
-    ? "7. This is a partial batch of the ratee's accomplishments; select from what is provided. Results are merged later."
-    : ""
-}
+1. Output at most ${PLAN_MAX_SENTENCES_PER_MPA} sentence groups per MPA.
+2. Prefer the strongest overall_score / mpa_relevancy entries for that MPA when choosing which efforts become the two sentences.
+3. A sentence group may be a single id when it stands alone.
+4. You may omit weaker pool ids entirely (leave them unused) — do not force every candidate into a sentence.
+5. Only use ids listed in that MPA's pool. Never invent ids. Never move an id to another MPA.
+6. Omit an MPA from the output if its pool cannot produce a useful statement.
 
-ACCOMPLISHMENTS
-${recordBlock}
+CANDIDATE POOLS
+${poolBlocks}
 
 OUTPUT
 Return STRICT JSON only, no prose, matching exactly:
 {
   "mpas": [
     {
-      "mpaKey": "<one of the core MPA keys>",
+      "mpaKey": "<one of the core MPA keys that has a pool>",
       "sentences": [
         {
           "accomplishmentIds": ["<id>", "..."],
-          "rationale": "<one short line on why these, and why combined>"
+          "rationale": "<why same/different effort; mention metric accumulation if combining>"
         }
       ]
     }
   ]
 }`;
 }
+
+/** @deprecated Prefer buildGroupEpbPrompt after score-based allocation. */
+export function buildPlanEpbPrompt(args: {
+  records: PlanAccomplishmentRecord[];
+  rateeRank: Rank | string | null;
+  rateeAfsc?: string | null;
+  dutyDescription?: string | null;
+  isChunked?: boolean;
+}): string {
+  const pools = Object.fromEntries(
+    ACA_PORTFOLIO_MPA_KEYS.map((key) => [
+      key,
+      args.records.filter((r) => r.taggedMpa === key).map((r) => r.id),
+    ])
+  ) as EpbCandidatePools;
+  const recordsById = new Map(args.records.map((r) => [r.id, r] as const));
+  return buildGroupEpbPrompt({
+    pools,
+    recordsById,
+    rateeRank: args.rateeRank,
+    rateeAfsc: args.rateeAfsc,
+    dutyDescription: args.dutyDescription,
+  });
+}
+
+export type { AcaPortfolioMpaKey };

--- a/src/lib/plan-epb.ts
+++ b/src/lib/plan-epb.ts
@@ -11,11 +11,10 @@ import type {
 /**
  * Data contract for the "Generate EPB" planning step.
  *
- * Score-based assignment (`assignEpbSentenceGroups`) inspects every cycle
- * accomplishment (with its ACA relevancy scores) and returns, per core MPA, up
- * to two "sentence groups". Each group is the set of accomplishments to combine
- * into ONE statement sentence. Related action verbs are combined so metrics can
- * accumulate; leftovers are stashed for cross-MPA fill.
+ * Score-based allocation picks candidate ids per MPA (home + stash/pop). An LLM
+ * then groups those candidates into up to two sentence groups by judging
+ * action → result → impact similarity (NOT action_verb string equality), so
+ * cumulative efforts can merge and accumulate metrics.
  */
 
 /** Max accomplishments per LLM planning chunk (keeps payloads well under limits). */

--- a/src/lib/plan-epb.ts
+++ b/src/lib/plan-epb.ts
@@ -11,11 +11,11 @@ import type {
 /**
  * Data contract for the "Generate EPB" planning step.
  *
- * The LLM inspects every cycle accomplishment (with its ACA scores) and returns,
- * per core MPA, up to two "sentence groups". Each group is the set of
- * accomplishments to combine into ONE statement sentence. This is where the
- * "combine like accomplishments even if individually low-scoring" intelligence
- * lives — we do not pattern-match on the server.
+ * Score-based assignment (`assignEpbSentenceGroups`) inspects every cycle
+ * accomplishment (with its ACA relevancy scores) and returns, per core MPA, up
+ * to two "sentence groups". Each group is the set of accomplishments to combine
+ * into ONE statement sentence. Related action verbs are combined so metrics can
+ * accumulate; leftovers are stashed for cross-MPA fill.
  */
 
 /** Max accomplishments per LLM planning chunk (keeps payloads well under limits). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Generate EPB was collapsing to **one sentence per tagged MPA**. This PR makes planning **hybrid**:

1. **Scores** allocate candidate pools per MPA (home claims + stash/pop cross-fill)
2. **LLM** groups those candidates by **action → result → impact** similarity — **not** action_verb string matching — so cumulative efforts can merge and accumulate metrics (e.g. two USO volunteer entries → one statement with ~8 hours)
3. Generation sends `customContext` + `customContext2`, and multi-entry groups get an explicit “accumulate metrics” prefix

### Why not verb matching
Users are inconsistent: same effort often uses different verbs; same verb often means different efforts. Combine/split has to be semantic.

### Also
- Readiness no longer blocks when all entries are tagged to one MPA
- Preselect still runs through **Plan my EPB** (LLM grouping) with `accomplishmentIds`
- Fallback singleton plan if the grouping LLM call fails

### Follow-ups (plans 020–023)
Best-fit stash allocation, soft-home misfiles, unassessed policy, retire unused chunk/merge helpers (keep ARI grouping).

### Verification
- Unit tests: pass
- React Doctor (`--scope changed`): **100 / 100**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff214-c56b-7bd4-b20f-05889f9d21bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff214-c56b-7bd4-b20f-05889f9d21bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

