### PR TITLE
feat(epb): review notes/moves + entries education/awards

### DIFF
--- a/plans/024-entries-education-award-followups.md
+++ b/plans/024-entries-education-award-followups.md
@@ -1,0 +1,20 @@
+# 024 — Entries education/award follow-ups
+
+## Context
+
+Feature landed: expanded verbs, `education_context`, `accomplishment_awards`, recognition UI in add-accomplishment modal. Local **and remote** migrations **210** + **211** applied. Award-link replace now diffs add/remove (no delete-all wipe on insert failure).
+
+## Still open (executor handoff)
+
+1. **Refactor `AddAwardDialog`** to consume shared `AwardFields` (`src/components/awards/award-fields.tsx`) so Team awards and entry recognition stay in sync.
+2. **Dashboard edit dialog** custom-verb parity (`accomplishment-detail-dialog` still Select-only).
+3. **EPB generate path** — inject `formatEducationContextForPrompt` + linked awards into `generate-epb-run` / `/api/generate` the same way assessment already does.
+4. **Award create from entries** — prefer a server action (RLS + validation) over client Supabase insert for self/supervisor award creation; tighten `award_team_members` WITH CHECK for self-award path.
+5. **Pre-plan auto-assess** — surface soft-fail toast when some entries skip assessment so users know scoring may be incomplete.
+
+## Verification
+
+- `npx vitest run src/lib/__tests__/award-recognition-education.test.ts src/lib/__tests__/generate-epb-run.test.ts`
+- `npm run motion:check`
+- `npx react-doctor@latest --verbose --scope changed` (ignore pre-existing `mpa-section-card` sacred-surface finding)
+- Confirm MyEPBuddy local stack (`project_id=myepbuddy`) before any `supabase db push --local`

--- a/src/app/(app)/entries/page.tsx
+++ b/src/app/(app)/entries/page.tsx
@@ -185,10 +185,40 @@ function EntriesContent() {
 
         if (!error && data) {
           const typedData = data as unknown as Accomplishment[];
-          setAccomplishments(typedData);
+          const ids = typedData.map((a) => a.id);
+          let withLinks = typedData;
+          if (ids.length > 0) {
+            const { data: links } = await (supabase as any)
+              .from("accomplishment_awards")
+              .select("accomplishment_id, award_id, sort_order")
+              .in("accomplishment_id", ids)
+              .abortSignal(controller.signal);
+            if (links && !controller.signal.aborted) {
+              const byAcc = new Map<string, { award_id: string; sort_order: number }[]>();
+              for (const row of links as Array<{
+                accomplishment_id: string;
+                award_id: string;
+                sort_order: number;
+              }>) {
+                const list = byAcc.get(row.accomplishment_id) || [];
+                list.push(row);
+                byAcc.set(row.accomplishment_id, list);
+              }
+              withLinks = typedData.map((a) => {
+                const rows = (byAcc.get(a.id) || []).sort(
+                  (x, y) => x.sort_order - y.sort_order
+                );
+                return {
+                  ...a,
+                  linked_award_ids: rows.map((r) => r.award_id),
+                };
+              });
+            }
+          }
+          setAccomplishments(withLinks);
 
           const creatorIds = [...new Set(
-            typedData
+            withLinks
               .filter((a) => a.created_by && a.created_by !== a.user_id)
               .map((a) => a.created_by)
           )];

--- a/src/app/actions/accomplishments.ts
+++ b/src/app/actions/accomplishments.ts
@@ -2,7 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
-import type { Accomplishment } from "@/types/database";
+import type { Accomplishment, EducationContext } from "@/types/database";
+import { sanitizeEducationContext } from "@/lib/education-context";
+import { awardsMatchRatee } from "@/lib/accomplishment-award-link";
 import {
   scanForSensitiveData,
   getScanSummary,
@@ -64,8 +66,114 @@ function validateSensitiveData(
   return { blocked: false, matches: [] };
 }
 
+type AccomplishmentWriteExtras = {
+  award_ids?: string[];
+  education_context?: EducationContext | null;
+};
+
+async function assertAwardsMatchRatee(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  awardIds: string[],
+  rateeUserId: string | null,
+  rateeTeamMemberId: string | null
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (awardIds.length === 0) return { ok: true };
+
+  const unique = [...new Set(awardIds)];
+  const { data, error } = await supabase
+    .from("awards")
+    .select("id, recipient_profile_id, recipient_team_member_id")
+    .in("id", unique);
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return awardsMatchRatee(
+    (data || []) as Array<{
+      id: string;
+      recipient_profile_id: string | null;
+      recipient_team_member_id: string | null;
+    }>,
+    unique,
+    rateeUserId,
+    rateeTeamMemberId
+  );
+}
+
+async function replaceAccomplishmentAwards(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  accomplishmentId: string,
+  awardIds: string[]
+): Promise<{ error?: string }> {
+  const { data: existingRows, error: existingError } = await supabase
+    .from("accomplishment_awards")
+    .select("award_id")
+    .eq("accomplishment_id", accomplishmentId);
+
+  if (existingError) {
+    return { error: existingError.message };
+  }
+
+  const existingIds = new Set<string>(
+    ((existingRows || []) as Array<{ award_id: string }>).map((r) => r.award_id)
+  );
+  const nextIds = [...new Set(awardIds)];
+  const nextSet = new Set(nextIds);
+
+  const toRemove = [...existingIds].filter((id) => !nextSet.has(id));
+  const toAdd = nextIds.filter((id) => !existingIds.has(id));
+
+  if (toRemove.length > 0) {
+    const { error: delError } = await supabase
+      .from("accomplishment_awards")
+      .delete()
+      .eq("accomplishment_id", accomplishmentId)
+      .in("award_id", toRemove);
+
+    if (delError) {
+      return { error: delError.message };
+    }
+  }
+
+  if (toAdd.length > 0) {
+    const rows = toAdd.map((award_id) => ({
+      accomplishment_id: accomplishmentId,
+      award_id,
+      sort_order: nextIds.indexOf(award_id),
+    }));
+
+    const { error: insError } = await supabase
+      .from("accomplishment_awards")
+      .insert(rows);
+
+    if (insError) {
+      return { error: insError.message };
+    }
+  }
+
+  // Keep sort_order aligned with the requested order for surviving links.
+  for (let index = 0; index < nextIds.length; index++) {
+    const award_id = nextIds[index]!;
+    if (toAdd.includes(award_id)) continue;
+    const { error: sortError } = await supabase
+      .from("accomplishment_awards")
+      .update({ sort_order: index })
+      .eq("accomplishment_id", accomplishmentId)
+      .eq("award_id", award_id);
+    if (sortError) {
+      return { error: sortError.message };
+    }
+  }
+
+  return {};
+}
+
 export async function createAccomplishment(
-  data: Omit<Accomplishment, "id" | "created_at" | "updated_at">
+  data: Omit<Accomplishment, "id" | "created_at" | "updated_at" | "linked_award_ids"> &
+    AccomplishmentWriteExtras
 ) {
   const supabase = await createClient();
 
@@ -77,17 +185,21 @@ export async function createAccomplishment(
     return { error: "Not authenticated" };
   }
 
+  const { award_ids, education_context, ...rest } = data;
+  const education = sanitizeEducationContext(education_context ?? null);
+
   // Server-side sensitive data scan — defense-in-depth
-  const stewardship = data.stewardship_impact ?? {};
+  const stewardship = rest.stewardship_impact ?? {};
   const validation = validateSensitiveData(
     {
-      details: data.details,
-      impact: data.impact,
-      metrics: data.metrics,
+      details: rest.details,
+      impact: rest.impact,
+      metrics: rest.metrics,
       stewardship_time: stewardship.time,
       stewardship_money: stewardship.money,
       stewardship_resources: stewardship.resources,
       stewardship_outcome: stewardship.outcome,
+      education_program: education?.program,
     },
     user.id
   );
@@ -95,13 +207,27 @@ export async function createAccomplishment(
     return { error: validation.error };
   }
 
+  const awardIds = award_ids ?? [];
+  if (awardIds.length > 0) {
+    const check = await assertAwardsMatchRatee(
+      supabase,
+      awardIds,
+      rest.team_member_id ? null : rest.user_id,
+      rest.team_member_id
+    );
+    if (!check.ok) {
+      return { error: check.error };
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: accomplishment, error } = await (supabase as any)
     .from("accomplishments")
     .insert({
-      ...data,
+      ...rest,
       stewardship_impact: stewardship,
-      created_by: data.created_by || user.id,
+      education_context: education,
+      created_by: rest.created_by || user.id,
     })
     .select()
     .single();
@@ -111,14 +237,41 @@ export async function createAccomplishment(
     return { error: error.message };
   }
 
+  if (awardIds.length > 0) {
+    const linkResult = await replaceAccomplishmentAwards(
+      supabase,
+      accomplishment.id,
+      awardIds
+    );
+    if (linkResult.error) {
+      console.error("Link awards error:", linkResult.error);
+      // Roll back the new accomplishment so we don't leave an orphan entry
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (supabase as any)
+        .from("accomplishments")
+        .delete()
+        .eq("id", accomplishment.id);
+      return { error: linkResult.error };
+    }
+  }
+
   revalidatePath("/entries");
   revalidatePath("/dashboard");
-  return { data: accomplishment as Accomplishment };
+  return {
+    data: {
+      ...(accomplishment as Accomplishment),
+      education_context: education,
+      linked_award_ids: awardIds,
+    } as Accomplishment,
+  };
 }
 
 export async function updateAccomplishment(
   id: string,
-  data: Partial<Omit<Accomplishment, "id" | "created_at" | "updated_at">>
+  data: Partial<
+    Omit<Accomplishment, "id" | "created_at" | "updated_at" | "linked_award_ids">
+  > &
+    AccomplishmentWriteExtras
 ) {
   const supabase = await createClient();
 
@@ -130,19 +283,29 @@ export async function updateAccomplishment(
     return { error: "Not authenticated" };
   }
 
+  const { award_ids, education_context, ...rest } = data;
+  const hasEducationKey = Object.prototype.hasOwnProperty.call(
+    data,
+    "education_context"
+  );
+  const education = hasEducationKey
+    ? sanitizeEducationContext(education_context ?? null)
+    : undefined;
+
   // Server-side sensitive data scan — defense-in-depth
   // Only scan fields that are being updated
-  const stewardship = data.stewardship_impact;
-  if (data.details || data.impact || data.metrics || stewardship) {
+  const stewardship = rest.stewardship_impact;
+  if (rest.details || rest.impact || rest.metrics || stewardship || education) {
     const validation = validateSensitiveData(
       {
-        details: data.details,
-        impact: data.impact,
-        metrics: data.metrics,
+        details: rest.details,
+        impact: rest.impact,
+        metrics: rest.metrics,
         stewardship_time: stewardship?.time,
         stewardship_money: stewardship?.money,
         stewardship_resources: stewardship?.resources,
         stewardship_outcome: stewardship?.outcome,
+        education_program: education?.program,
       },
       user.id
     );
@@ -151,10 +314,45 @@ export async function updateAccomplishment(
     }
   }
 
+  if (award_ids && award_ids.length > 0) {
+    // Load ratee from existing row when not in payload
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: existing, error: existingError } = await (supabase as any)
+      .from("accomplishments")
+      .select("user_id, team_member_id")
+      .eq("id", id)
+      .single();
+
+    if (existingError || !existing) {
+      return { error: existingError?.message || "Accomplishment not found" };
+    }
+
+    const rateeUserId = rest.user_id ?? existing.user_id;
+    const rateeTeamMemberId =
+      rest.team_member_id !== undefined
+        ? rest.team_member_id
+        : existing.team_member_id;
+
+    const check = await assertAwardsMatchRatee(
+      supabase,
+      award_ids,
+      rateeTeamMemberId ? null : rateeUserId,
+      rateeTeamMemberId
+    );
+    if (!check.ok) {
+      return { error: check.error };
+    }
+  }
+
+  const updatePayload = {
+    ...rest,
+    ...(education !== undefined ? { education_context: education } : {}),
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: accomplishment, error } = await (supabase as any)
     .from("accomplishments")
-    .update(data)
+    .update(updatePayload)
     .eq("id", id)
     .select()
     .single();
@@ -164,9 +362,27 @@ export async function updateAccomplishment(
     return { error: error.message };
   }
 
+  if (award_ids !== undefined) {
+    const linkResult = await replaceAccomplishmentAwards(
+      supabase,
+      id,
+      award_ids
+    );
+    if (linkResult.error) {
+      console.error("Link awards error:", linkResult.error);
+      return { error: linkResult.error };
+    }
+  }
+
   revalidatePath("/entries");
   revalidatePath("/dashboard");
-  return { data: accomplishment as Accomplishment };
+  return {
+    data: {
+      ...(accomplishment as Accomplishment),
+      ...(education !== undefined ? { education_context: education } : {}),
+      ...(award_ids !== undefined ? { linked_award_ids: award_ids } : {}),
+    } as Accomplishment,
+  };
 }
 
 export async function deleteAccomplishment(id: string) {
@@ -194,6 +410,35 @@ export async function deleteAccomplishment(id: string) {
   revalidatePath("/entries");
   revalidatePath("/dashboard");
   return { success: true };
+}
+
+export async function getAccomplishmentAwardIds(
+  accomplishmentId: string
+): Promise<{ data?: string[]; error?: string }> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "Not authenticated" };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from("accomplishment_awards")
+    .select("award_id, sort_order")
+    .eq("accomplishment_id", accomplishmentId)
+    .order("sort_order", { ascending: true });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return {
+    data: ((data || []) as Array<{ award_id: string }>).map((r) => r.award_id),
+  };
 }
 
 async function getAccomplishments(

--- a/src/app/api/assess-accomplishment-preview/route.ts
+++ b/src/app/api/assess-accomplishment-preview/route.ts
@@ -19,9 +19,10 @@ import {
   getRubricTierForRank,
   DEFAULT_APP_MODEL_ID,
 } from "@/lib/constants";
-import type { AccomplishmentAssessmentScores, Rank, StewardshipImpact } from "@/types/database";
+import type { AccomplishmentAssessmentScores, EducationContext, Rank, StewardshipImpact } from "@/types/database";
 import { buildAccomplishmentAssessmentPrompt } from "@/lib/assess-accomplishment-prompt";
 import { normalizeStewardshipImpact } from "@/lib/stewardship-impact";
+import { normalizeEducationContext } from "@/lib/education-context";
 import { scanAccomplishmentsForLLM } from "@/lib/sensitive-data-scanner";
 import { resolveRequestedModel } from "@/app/actions/ai-models";
 import { checkAndTrackUsage } from "@/lib/usage-tracker";
@@ -36,6 +37,7 @@ interface AssessPreviewRequest {
   impact: string | null;
   metrics: string | null;
   stewardship_impact?: StewardshipImpact | null;
+  education_context?: EducationContext | null;
   mpa: string;
   model?: string;
   rateeRank?: string | null;
@@ -149,12 +151,14 @@ export async function POST(request: Request) {
       impact,
       metrics,
       stewardship_impact,
+      education_context,
       mpa,
       model = DEFAULT_APP_MODEL_ID,
       targetUserId,
       targetManagedMemberId,
     } = body;
     const stewardship = normalizeStewardshipImpact(stewardship_impact ?? {});
+    const education = normalizeEducationContext(education_context ?? null);
     modelId = await resolveRequestedModel(model, "generate");
 
     if (!action_verb || !details) {
@@ -265,6 +269,7 @@ export async function POST(request: Request) {
           metrics,
           mpa,
           stewardship_impact: stewardship,
+          education_context: education,
         },
         resolvedRateeRank
       ),

--- a/src/app/api/assess-accomplishment/route.ts
+++ b/src/app/api/assess-accomplishment/route.ts
@@ -180,6 +180,7 @@ export async function POST(request: Request) {
           stewardship_impact: normalizeStewardshipImpact(
             accomplishment.stewardship_impact
           ),
+          education_context: accomplishment.education_context ?? null,
         },
         rateeRank
       ),

--- a/src/components/awards/award-fields.tsx
+++ b/src/components/awards/award-fields.tsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { Award as AwardIcon, Medal, Star, Trophy, Users } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SearchableSelect } from "@/components/ui/searchable-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AWARD_CATEGORIES,
+  AWARD_LEVELS,
+  AWARD_QUARTERS,
+  AWARD_TYPES,
+  SPECIAL_AWARDS_CATALOG,
+} from "@/lib/constants";
+import { cn } from "@/lib/utils";
+import { motionChip } from "@/lib/motion/classes";
+import type {
+  AwardCategory,
+  AwardLevel,
+  AwardQuarter,
+  AwardType,
+} from "@/types/database";
+
+export type AwardFieldsTeamMemberOption = {
+  id: string;
+  name: string;
+  rank: string | null;
+  type: "profile" | "team_member";
+};
+
+export type AwardFieldsValue = {
+  awardType: AwardType;
+  coinPresenter: string;
+  coinDescription: string;
+  coinDate: string;
+  quarter: AwardQuarter;
+  awardYear: number;
+  awardLevel: AwardLevel;
+  awardCategory: AwardCategory;
+  awardName: string;
+  selectedCatalogAward: string;
+  selectedAwardCategory: string;
+  isCustomAward: boolean;
+  selectedTeamMemberIds: string[];
+};
+
+export function emptyAwardFieldsValue(
+  year = new Date().getFullYear()
+): AwardFieldsValue {
+  return {
+    awardType: "coin",
+    coinPresenter: "",
+    coinDescription: "",
+    coinDate: new Date().toISOString().split("T")[0],
+    quarter: "Q1",
+    awardYear: year,
+    awardLevel: "squadron",
+    awardCategory: "nco",
+    awardName: "",
+    selectedCatalogAward: "",
+    selectedAwardCategory: "",
+    isCustomAward: false,
+    selectedTeamMemberIds: [],
+  };
+}
+
+export function validateAwardFields(value: AwardFieldsValue): string | null {
+  if (value.awardType === "coin") {
+    if (!value.coinPresenter.trim()) return "Please enter who presented the coin";
+    if (!value.coinDate) return "Please select when the coin was received";
+  }
+  if (value.awardType === "special") {
+    if (value.isCustomAward && !value.awardName.trim()) {
+      return "Please enter an award name";
+    }
+    if (!value.isCustomAward && !value.selectedCatalogAward) {
+      return "Please select an award";
+    }
+  }
+  return null;
+}
+
+function getAwardIcon(type: AwardType) {
+  switch (type) {
+    case "coin":
+      return <Medal className="size-4" />;
+    case "quarterly":
+      return <AwardIcon className="size-4" />;
+    case "annual":
+      return <Trophy className="size-4" />;
+    case "special":
+      return <Star className="size-4" />;
+    default:
+      return <AwardIcon className="size-4" />;
+  }
+}
+
+type AwardFieldsProps = {
+  value: AwardFieldsValue;
+  onChange: (next: AwardFieldsValue) => void;
+  teamMemberOptions?: AwardFieldsTeamMemberOption[];
+  disabled?: boolean;
+  idPrefix?: string;
+};
+
+export function AwardFields({
+  value,
+  onChange,
+  teamMemberOptions = [],
+  disabled = false,
+  idPrefix = "award",
+}: AwardFieldsProps) {
+  const currentYear = new Date().getFullYear();
+  const isTeamAward = value.awardCategory === "team";
+
+  const patch = (partial: Partial<AwardFieldsValue>) => {
+    onChange({ ...value, ...partial });
+  };
+
+  const toggleTeamMember = (id: string) => {
+    const set = new Set(value.selectedTeamMemberIds);
+    if (set.has(id)) set.delete(id);
+    else set.add(id);
+    patch({ selectedTeamMemberIds: Array.from(set) });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Award Type</Label>
+        <div
+          className="grid grid-cols-2 sm:grid-cols-4 gap-2"
+          role="radiogroup"
+          aria-label="Award type"
+        >
+          {AWARD_TYPES.map((type) => (
+            <button
+              key={type.value}
+              type="button"
+              role="radio"
+              aria-checked={value.awardType === type.value}
+              disabled={disabled}
+              onClick={() => patch({ awardType: type.value })}
+              className={cn(
+                motionChip,
+                "flex flex-col items-center gap-1 p-3 rounded-lg border-2",
+                value.awardType === type.value
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:border-primary/50"
+              )}
+            >
+              {getAwardIcon(type.value)}
+              <span className="text-xs font-medium">{type.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {value.awardType === "coin" && (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-coinPresenter`}>Presented By *</Label>
+            <Input
+              id={`${idPrefix}-coinPresenter`}
+              placeholder="e.g., Col Smith, 388 FW/CC"
+              value={value.coinPresenter}
+              onChange={(e) => patch({ coinPresenter: e.target.value })}
+              disabled={disabled}
+              aria-required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-coinDate`}>Date Received *</Label>
+            <Input
+              id={`${idPrefix}-coinDate`}
+              type="date"
+              value={value.coinDate}
+              onChange={(e) => patch({ coinDate: e.target.value })}
+              disabled={disabled}
+              aria-required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-coinDescription`}>What was it for?</Label>
+            <Textarea
+              id={`${idPrefix}-coinDescription`}
+              placeholder="Brief description of the exceptional performance..."
+              value={value.coinDescription}
+              onChange={(e) => patch({ coinDescription: e.target.value })}
+              rows={3}
+              disabled={disabled}
+            />
+          </div>
+        </>
+      )}
+
+      {["quarterly", "annual", "special"].includes(value.awardType) && (
+        <>
+          {value.awardType === "special" && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id={`${idPrefix}-isCustomAward`}
+                  checked={value.isCustomAward}
+                  disabled={disabled}
+                  onCheckedChange={(checked) => {
+                    const isCustom = checked === true;
+                    patch({
+                      isCustomAward: isCustom,
+                      selectedCatalogAward: isCustom ? "" : value.selectedCatalogAward,
+                      selectedAwardCategory: isCustom ? "" : value.selectedAwardCategory,
+                      awardName: isCustom ? value.awardName : "",
+                    });
+                  }}
+                />
+                <Label
+                  htmlFor={`${idPrefix}-isCustomAward`}
+                  className="cursor-pointer text-sm"
+                >
+                  Enter custom award name
+                </Label>
+              </div>
+
+              {value.isCustomAward ? (
+                <div className="space-y-2">
+                  <Label htmlFor={`${idPrefix}-customName`}>Custom Award Name *</Label>
+                  <Input
+                    id={`${idPrefix}-customName`}
+                    placeholder="Enter award name..."
+                    value={value.awardName}
+                    onChange={(e) => patch({ awardName: e.target.value })}
+                    disabled={disabled}
+                    aria-required
+                  />
+                </div>
+              ) : (
+                <>
+                  <div className="space-y-2">
+                    <Label>Award Category *</Label>
+                    <Select
+                      value={value.selectedAwardCategory}
+                      disabled={disabled}
+                      onValueChange={(val) =>
+                        patch({
+                          selectedAwardCategory: val,
+                          selectedCatalogAward: "",
+                        })
+                      }
+                    >
+                      <SelectTrigger aria-label="Special award category">
+                        <SelectValue placeholder="Select a category" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SPECIAL_AWARDS_CATALOG.map((category) => (
+                          <SelectItem key={category.key} value={category.key}>
+                            {category.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {value.selectedAwardCategory && (
+                    <div className="space-y-2">
+                      <Label>Award Name *</Label>
+                      <SearchableSelect
+                        value={value.selectedCatalogAward}
+                        onValueChange={(val) =>
+                          patch({
+                            selectedCatalogAward: val,
+                            awardName: "",
+                          })
+                        }
+                        options={
+                          SPECIAL_AWARDS_CATALOG.find(
+                            (c) => c.key === value.selectedAwardCategory
+                          )?.awards.map((award) => ({
+                            value: award,
+                            label: award,
+                          })) ?? []
+                        }
+                        placeholder="Select an award"
+                        searchPlaceholder="Search awards..."
+                        emptyMessage="No awards found."
+                        aria-label="Award name"
+                        disabled={disabled}
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {value.awardType === "quarterly" && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label>Quarter *</Label>
+                <Select
+                  value={value.quarter}
+                  disabled={disabled}
+                  onValueChange={(v) => patch({ quarter: v as AwardQuarter })}
+                >
+                  <SelectTrigger aria-label="Award quarter">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AWARD_QUARTERS.map((q) => (
+                      <SelectItem key={q.value} value={q.value}>
+                        {q.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Year *</Label>
+                <Select
+                  value={String(value.awardYear)}
+                  disabled={disabled}
+                  onValueChange={(v) => patch({ awardYear: parseInt(v, 10) })}
+                >
+                  <SelectTrigger aria-label="Award year">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[currentYear, currentYear - 1, currentYear - 2].map((y) => (
+                      <SelectItem key={y} value={String(y)}>
+                        {y}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+
+          {["annual", "special"].includes(value.awardType) && (
+            <div className="space-y-2">
+              <Label>Award Year *</Label>
+              <Select
+                value={String(value.awardYear)}
+                disabled={disabled}
+                onValueChange={(v) => patch({ awardYear: parseInt(v, 10) })}
+              >
+                <SelectTrigger className="w-[180px]" aria-label="Award year">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[currentYear, currentYear - 1, currentYear - 2, currentYear - 3].map(
+                    (y) => (
+                      <SelectItem key={y} value={String(y)}>
+                        {y}
+                      </SelectItem>
+                    )
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {["quarterly", "annual"].includes(value.awardType) && (
+            <>
+              <div className="space-y-2">
+                <Label>Highest Level Won At</Label>
+                <Select
+                  value={value.awardLevel}
+                  disabled={disabled}
+                  onValueChange={(v) => patch({ awardLevel: v as AwardLevel })}
+                >
+                  <SelectTrigger aria-label="Award level">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AWARD_LEVELS.map((level) => (
+                      <SelectItem key={level.value} value={level.value}>
+                        {level.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Category</Label>
+                <Select
+                  value={value.awardCategory}
+                  disabled={disabled}
+                  onValueChange={(v) => {
+                    const cat = v as AwardCategory;
+                    patch({
+                      awardCategory: cat,
+                      selectedTeamMemberIds:
+                        cat !== "team" ? [] : value.selectedTeamMemberIds,
+                    });
+                  }}
+                >
+                  <SelectTrigger aria-label="Award category">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AWARD_CATEGORIES.map((cat) => (
+                      <SelectItem key={cat.value} value={cat.value}>
+                        {cat.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {["quarterly", "annual"].includes(value.awardType) &&
+        isTeamAward &&
+        teamMemberOptions.length > 0 && (
+          <div className="space-y-2 p-3 rounded-lg bg-muted/20 shadow-[0_1px_2px_rgba(0,0,0,0.05),0_2px_4px_rgba(0,0,0,0.02),0_0_0_0.5px_rgba(0,0,0,0.08)]">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm flex items-center gap-1">
+                <Users className="size-3" />
+                Team Members
+              </Label>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-xs"
+                  disabled={disabled}
+                  onClick={() =>
+                    patch({
+                      selectedTeamMemberIds: teamMemberOptions.map((m) => m.id),
+                    })
+                  }
+                >
+                  Select All
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-xs"
+                  disabled={disabled}
+                  onClick={() => patch({ selectedTeamMemberIds: [] })}
+                >
+                  Clear
+                </Button>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto">
+              {teamMemberOptions.map((member) => {
+                const selected = value.selectedTeamMemberIds.includes(member.id);
+                return (
+                  <Badge
+                    key={member.id}
+                    variant={selected ? "default" : "outline"}
+                    className={cn(
+                      motionChip,
+                      "cursor-pointer",
+                      selected ? "bg-primary" : "hover:bg-primary/10"
+                    )}
+                    onClick={() => !disabled && toggleTeamMember(member.id)}
+                    role="checkbox"
+                    aria-checked={selected}
+                    tabIndex={disabled ? -1 : 0}
+                    onKeyDown={(e) => {
+                      if (disabled) return;
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        toggleTeamMember(member.id);
+                      }
+                    }}
+                  >
+                    {member.rank} {member.name}
+                  </Badge>
+                );
+              })}
+            </div>
+            {value.selectedTeamMemberIds.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {value.selectedTeamMemberIds.length} team member(s) selected
+              </p>
+            )}
+          </div>
+        )}
+    </div>
+  );
+}

--- a/src/components/entries/education-context-fields.tsx
+++ b/src/components/entries/education-context-fields.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { GraduationCap } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { motionChip, motionCollapseGrid } from "@/lib/motion/classes";
+import {
+  EDUCATION_CREDIT_UNITS,
+  type EducationContext,
+  type EducationCreditUnit,
+  hasEducationContext,
+} from "@/lib/education-context";
+
+export type EducationContextFormValue = {
+  enabled: boolean;
+  program: string;
+  credits: string;
+  unit: EducationCreditUnit;
+  completed_date: string;
+};
+
+export function emptyEducationFormValue(): EducationContextFormValue {
+  return {
+    enabled: false,
+    program: "",
+    credits: "",
+    unit: "credit_hours",
+    completed_date: "",
+  };
+}
+
+export function educationFormFromContext(
+  ctx: EducationContext | null | undefined
+): EducationContextFormValue {
+  if (!hasEducationContext(ctx)) return emptyEducationFormValue();
+  return {
+    enabled: true,
+    program: ctx!.program,
+    credits: ctx!.credits != null ? String(ctx!.credits) : "",
+    unit: ctx!.unit ?? "credit_hours",
+    completed_date: ctx!.completed_date ?? "",
+  };
+}
+
+export function educationContextFromForm(
+  form: EducationContextFormValue
+): EducationContext | null {
+  if (!form.enabled || !form.program.trim()) return null;
+  const creditsRaw = form.credits.trim();
+  const credits = creditsRaw ? Number(creditsRaw) : undefined;
+  return {
+    program: form.program.trim(),
+    ...(credits != null && Number.isFinite(credits) && credits > 0
+      ? { credits, unit: form.unit }
+      : {}),
+    ...(form.completed_date ? { completed_date: form.completed_date } : {}),
+  };
+}
+
+type EducationContextFieldsProps = {
+  value: EducationContextFormValue;
+  onChange: (next: EducationContextFormValue) => void;
+  disabled?: boolean;
+  onEnabledFirstTime?: () => void;
+};
+
+export function EducationContextFields({
+  value,
+  onChange,
+  disabled = false,
+  onEnabledFirstTime,
+}: EducationContextFieldsProps) {
+  const patch = (partial: Partial<EducationContextFormValue>) => {
+    onChange({ ...value, ...partial });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-sm flex items-center gap-1.5">
+          <GraduationCap className="size-3.5 text-muted-foreground" />
+          Education
+          <span className="text-muted-foreground font-normal text-xs">
+            (optional)
+          </span>
+        </Label>
+        <Button
+          type="button"
+          variant={value.enabled ? "secondary" : "outline"}
+          size="sm"
+          className={cn(motionChip, "h-7 text-xs")}
+          disabled={disabled}
+          aria-pressed={value.enabled}
+          aria-label={
+            value.enabled ? "Hide education fields" : "Add education context"
+          }
+          onClick={() => {
+            const next = !value.enabled;
+            patch({ enabled: next });
+            if (next) onEnabledFirstTime?.();
+          }}
+        >
+          {value.enabled ? "Remove" : "Add"}
+        </Button>
+      </div>
+
+      <div
+        className={motionCollapseGrid}
+        data-open={value.enabled ? "true" : "false"}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="space-y-3 pt-1 pb-1">
+            <p className="text-xs text-muted-foreground">
+              Capture the program/credits as context. Your action and impact
+              should describe how that education supported the mission.
+            </p>
+            <div className="space-y-1.5">
+              <Label htmlFor="education_program" className="text-sm">
+                Program / course *
+              </Label>
+              <Input
+                id="education_program"
+                placeholder="e.g. CCAF AAS, ALS, CompTIA Security+"
+                value={value.program}
+                onChange={(e) => patch({ program: e.target.value })}
+                disabled={disabled}
+                className="h-9 sm:h-10 text-sm"
+                aria-label="Education program or course"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="education_credits" className="text-sm">
+                  Credits / hours
+                </Label>
+                <Input
+                  id="education_credits"
+                  type="number"
+                  min={0}
+                  step="0.5"
+                  inputMode="decimal"
+                  placeholder="e.g. 12"
+                  value={value.credits}
+                  onChange={(e) => patch({ credits: e.target.value })}
+                  disabled={disabled}
+                  className="h-9 sm:h-10 text-sm"
+                  aria-label="Education credits or hours"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-sm">Unit</Label>
+                <Select
+                  value={value.unit}
+                  disabled={disabled}
+                  onValueChange={(v) =>
+                    patch({ unit: v as EducationCreditUnit })
+                  }
+                >
+                  <SelectTrigger
+                    className="h-9 sm:h-10 text-sm"
+                    aria-label="Credit unit"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {EDUCATION_CREDIT_UNITS.map((u) => (
+                      <SelectItem key={u.value} value={u.value}>
+                        {u.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="education_completed" className="text-sm">
+                Completed
+                <span className="text-muted-foreground font-normal ml-1 text-xs">
+                  (optional)
+                </span>
+              </Label>
+              <Input
+                id="education_completed"
+                type="date"
+                value={value.completed_date}
+                onChange={(e) => patch({ completed_date: e.target.value })}
+                disabled={disabled}
+                className="h-9 sm:h-10 text-sm"
+                aria-label="Education completion date"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/entries/entry-card.tsx
+++ b/src/components/entries/entry-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { MoreHorizontal, Pencil, Trash2, UserCheck } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash2, UserCheck, GraduationCap, Award } from "lucide-react";
 import { AssessmentDetailDialog } from "@/components/entries/assessment-detail-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -24,6 +24,7 @@ import {
   hasStewardshipImpactContent,
   normalizeStewardshipImpact,
 } from "@/lib/stewardship-impact";
+import { educationContextSummary } from "@/lib/education-context";
 import { formatShortDate, formatShortDateWithYear } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Accomplishment } from "@/types/database";
@@ -118,6 +119,27 @@ export function EntryCard({
                     ? formatShortDate(entry.date)
                     : formatShortDateWithYear(entry.date)}
                 </span>
+                {educationContextSummary(entry.education_context) && (
+                  <Badge
+                    variant="outline"
+                    className="gap-1 text-[10px] font-normal h-5 px-1.5"
+                  >
+                    <GraduationCap className="size-2.5" aria-hidden />
+                    <span className="max-w-[10rem] truncate">
+                      {educationContextSummary(entry.education_context)}
+                    </span>
+                  </Badge>
+                )}
+                {(entry.linked_award_ids?.length ?? 0) > 0 && (
+                  <Badge
+                    variant="outline"
+                    className="gap-1 text-[10px] font-normal h-5 px-1.5"
+                  >
+                    <Award className="size-2.5" aria-hidden />
+                    {entry.linked_award_ids!.length} award
+                    {entry.linked_award_ids!.length === 1 ? "" : "s"}
+                  </Badge>
+                )}
                 {showCreator && (
                   <TooltipProvider delayDuration={200}>
                     <Tooltip>

--- a/src/components/entries/entry-form-dialog.tsx
+++ b/src/components/entries/entry-form-dialog.tsx
@@ -28,9 +28,10 @@ import { toast } from "@/components/ui/sonner";
 import {
   createAccomplishment,
   updateAccomplishment,
+  getAccomplishmentAwardIds,
 } from "@/app/actions/accomplishments";
 import { DEFAULT_ACTION_VERBS, ENTRY_MGAS, getActiveCycleYear, isEnlisted } from "@/lib/constants";
-import type { Rank } from "@/types/database";
+import type { Award, Rank } from "@/types/database";
 import { Loader2, Sparkles, Target, BarChart3, ClipboardCopy } from "lucide-react";
 import { celebrateEntry } from "@/lib/confetti";
 import { cn } from "@/lib/utils";
@@ -48,6 +49,13 @@ import {
   stewardshipFormFromImpact,
   stewardshipImpactFromForm,
 } from "@/components/entries/stewardship-impact-fields";
+import {
+  EducationContextFields,
+  emptyEducationFormValue,
+  educationContextFromForm,
+  educationFormFromContext,
+} from "@/components/entries/education-context-fields";
+import { RecognitionImpactFields } from "@/components/entries/recognition-impact-fields";
 import { createClient } from "@/lib/supabase/client";
 import { scanForSensitiveData, getScanSummary } from "@/lib/sensitive-data-scanner";
 import { handleStaleDeploymentError } from "@/lib/stale-deployment";
@@ -55,6 +63,12 @@ import {
   composeImpactString,
   hydrateStewardshipImpact,
 } from "@/lib/stewardship-impact";
+import {
+  composeRecognitionPhrase,
+  mergeRecognitionIntoOutcome,
+} from "@/lib/award-recognition";
+import { useAwardsStore } from "@/stores/awards-store";
+import { normalizeEducationContext } from "@/lib/education-context";
 
 interface EntryFormDialogProps {
   open: boolean;
@@ -122,6 +136,7 @@ export function EntryFormDialog({
   const { profile, subordinates, managedMembers } = useUserStore();
   const { addAccomplishment, updateAccomplishment: updateStore } =
     useAccomplishmentsStore();
+  const { awards } = useAwardsStore();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isAssessing, setIsAssessing] = useState(false);
@@ -134,6 +149,12 @@ export function EntryFormDialog({
   const assessmentFormUsed = assessmentPreview.formUsed;
   const assessmentRateeRank = assessmentPreview.rateeRank;
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [linkedAwards, setLinkedAwards] = useState<Award[]>([]);
+  const [lastRecognitionPhrase, setLastRecognitionPhrase] = useState<string | null>(
+    null
+  );
+  const [education, setEducation] = useState(emptyEducationFormValue());
+  const [mpaTouched, setMpaTouched] = useState(false);
   const supabase = createClient();
   const [form, setForm] = useState({
     date: new Date().toISOString().split("T")[0],
@@ -146,6 +167,13 @@ export function EntryFormDialog({
   });
 
   const mgas = ENTRY_MGAS;
+
+  const rateeProfileId = targetManagedMemberId
+    ? null
+    : targetUserId || profile?.id || null;
+  const rateeTeamMemberId = targetManagedMemberId || null;
+
+  const educationEnabled = education.enabled && !!education.program.trim();
 
   const targetRateeRank = (() => {
     if (targetManagedMemberId) {
@@ -228,6 +256,7 @@ export function EntryFormDialog({
           impact: composeImpactString(stewardshipImpactFromForm(form.stewardship)),
           metrics: form.metrics || null,
           stewardship_impact: stewardshipImpactFromForm(form.stewardship),
+          education_context: educationContextFromForm(education),
           mpa: form.mpa,
           rateeRank: targetRateeRank,
           targetUserId: targetUserId ?? null,
@@ -307,6 +336,14 @@ export function EntryFormDialog({
         mpa: editEntry.mpa || "miscellaneous", // Default to Miscellaneous if null
         tags: Array.isArray(editEntry.tags) ? editEntry.tags.join(", ") : "",
       });
+      setEducation(
+        educationFormFromContext(
+          normalizeEducationContext(editEntry.education_context)
+        )
+      );
+      setMpaTouched(true);
+      setLinkedAwards([]);
+      setLastRecognitionPhrase(null);
       // Load existing assessment if available
       dispatchAssessmentPreview({
         type: "reset",
@@ -319,7 +356,38 @@ export function EntryFormDialog({
         if (cancelled) return;
         setSelectedProjectId(projectId);
       });
-    } else {
+      void getAccomplishmentAwardIds(accomplishmentId).then((result) => {
+        if (cancelled || result.error || !result.data) return;
+        const ids = result.data;
+        const fromStore = awards.filter((a) => ids.includes(a.id));
+        if (fromStore.length === ids.length) {
+          setLinkedAwards(
+            ids
+              .map((id) => fromStore.find((a) => a.id === id))
+              .filter(Boolean) as Award[]
+          );
+          setLastRecognitionPhrase(
+            composeRecognitionPhrase(fromStore)
+          );
+          return;
+        }
+        // Fetch missing awards
+        void (async () => {
+          const supabaseClient = createClient();
+          const { data } = await supabaseClient
+            .from("awards")
+            .select("*")
+            .in("id", ids);
+          if (cancelled) return;
+          const fetched = (data || []) as Award[];
+          const ordered = ids
+            .map((id) => fetched.find((a) => a.id === id))
+            .filter(Boolean) as Award[];
+          setLinkedAwards(ordered);
+          setLastRecognitionPhrase(composeRecognitionPhrase(ordered));
+        })();
+      });
+    } else if (open) {
       setForm({
         date: new Date().toISOString().split("T")[0],
         action_verb: "",
@@ -329,6 +397,10 @@ export function EntryFormDialog({
         mpa: "executing_mission", // Default to Executing the Mission
         tags: "",
       });
+      setEducation(emptyEducationFormValue());
+      setMpaTouched(false);
+      setLinkedAwards([]);
+      setLastRecognitionPhrase(null);
       // Clear assessment preview
       dispatchAssessmentPreview({ type: "reset" });
       setSelectedProjectId(null);
@@ -337,7 +409,37 @@ export function EntryFormDialog({
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset on open/edit only; awards store used for hydrate snapshot
   }, [editEntry, open]);
+
+  function handleLinkedAwardsChange(next: Award[]) {
+    const phrase = composeRecognitionPhrase(next);
+    setLinkedAwards(next);
+    setForm((prev) => ({
+      ...prev,
+      stewardship: {
+        ...prev.stewardship,
+        outcome: mergeRecognitionIntoOutcome(
+          prev.stewardship.outcome,
+          phrase,
+          lastRecognitionPhrase
+        ),
+      },
+    }));
+    setLastRecognitionPhrase(phrase);
+  }
+
+  function handleEducationChange(
+    next: ReturnType<typeof emptyEducationFormValue>
+  ) {
+    setEducation(next);
+  }
+
+  function handleEducationEnabledFirstTime() {
+    if (!mpaTouched) {
+      setForm((prev) => ({ ...prev, mpa: "improving_unit" }));
+    }
+  }
 
   // Load existing project link for an accomplishment
   // Type assertions needed due to Supabase type generation issue with new tables
@@ -394,6 +496,8 @@ export function EntryFormDialog({
 
     const stewardshipImpact = stewardshipImpactFromForm(form.stewardship);
     const composedImpact = composeImpactString(stewardshipImpact);
+    const educationContext = educationContextFromForm(education);
+    const awardIds = linkedAwards.map((a) => a.id);
 
     // Scan for PII, CUI, and classification markings — hard block if found
     const sensitiveMatches = scanForSensitiveData({
@@ -404,6 +508,7 @@ export function EntryFormDialog({
       stewardship_money: form.stewardship.money,
       stewardship_resources: form.stewardship.resources,
       stewardship_outcome: form.stewardship.outcome,
+      education_program: educationContext?.program,
     });
     if (sensitiveMatches.length > 0) {
       toast.error(getScanSummary(sensitiveMatches), { duration: 10000 });
@@ -436,6 +541,8 @@ export function EntryFormDialog({
           details: form.details,
           impact: composedImpact,
           stewardship_impact: stewardshipImpact,
+          education_context: educationContext,
+          award_ids: awardIds,
           metrics: form.metrics || null,
           mpa: form.mpa,
           tags,
@@ -490,6 +597,8 @@ export function EntryFormDialog({
           details: form.details,
           impact: composedImpact,
           stewardship_impact: stewardshipImpact,
+          education_context: educationContext,
+          award_ids: awardIds,
           metrics: form.metrics || null,
           mpa: form.mpa,
           tags,
@@ -592,7 +701,10 @@ export function EntryFormDialog({
               <Label htmlFor="mpa" className="text-sm">Major Performance Area</Label>
               <Select
                 value={form.mpa}
-                onValueChange={(value) => setForm({ ...form, mpa: value })}
+                onValueChange={(value) => {
+                  setMpaTouched(true);
+                  setForm({ ...form, mpa: value });
+                }}
               >
                 <SelectTrigger id="mpa" aria-label="Select MPA" className="h-9 sm:h-10">
                   <SelectValue placeholder="Select MPA" />
@@ -626,26 +738,44 @@ export function EntryFormDialog({
           </div>
 
           <div className="space-y-1.5 sm:space-y-2">
-            <Label htmlFor="action_verb" className="text-sm">Action Verb *</Label>
+            <Label htmlFor="action_verb" className="text-sm">
+              Action Verb *
+              <span className="text-muted-foreground font-normal ml-1 sm:ml-2 text-xs sm:text-sm">
+                Select or type your own
+              </span>
+            </Label>
             <ComboboxInput
               value={form.action_verb}
               onChange={(value) => setForm((prev) => ({ ...prev, action_verb: value }))}
               options={DEFAULT_ACTION_VERBS}
-              placeholder="Select or type a verb..."
-              aria-label="Action verb"
+              placeholder="Select or type your own verb..."
+              aria-label="Action verb — select or type your own"
             />
           </div>
+
+          <EducationContextFields
+            value={education}
+            onChange={handleEducationChange}
+            disabled={isSubmitting || isAssessing}
+            onEnabledFirstTime={handleEducationEnabledFirstTime}
+          />
 
           <div className="space-y-1.5 sm:space-y-2">
             <Label htmlFor="details" className="text-sm">
               Details *
               <span className="text-muted-foreground font-normal ml-1 sm:ml-2 text-xs sm:text-sm">
-                What did you do?
+                {educationEnabled
+                  ? "What did you do with this education that supported the mission?"
+                  : "What did you do?"}
               </span>
             </Label>
             <Textarea
               id="details"
-              placeholder="Describe what you accomplished in detail..."
+              placeholder={
+                educationEnabled
+                  ? "Describe how you applied this education to the mission..."
+                  : "Describe what you accomplished in detail..."
+              }
               value={form.details}
               onChange={(e) => setForm({ ...form, details: e.target.value })}
               required
@@ -657,6 +787,15 @@ export function EntryFormDialog({
           <StewardshipImpactFields
             value={form.stewardship}
             onChange={(stewardship) => setForm({ ...form, stewardship })}
+            disabled={isSubmitting || isAssessing}
+            educationAware={educationEnabled}
+          />
+
+          <RecognitionImpactFields
+            linkedAwards={linkedAwards}
+            onLinkedAwardsChange={handleLinkedAwardsChange}
+            recipientProfileId={rateeProfileId}
+            recipientTeamMemberId={rateeTeamMemberId}
             disabled={isSubmitting || isAssessing}
           />
 

--- a/src/components/entries/generate-epb-dialog.tsx
+++ b/src/components/entries/generate-epb-dialog.tsx
@@ -4,12 +4,11 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { useUserStore } from "@/stores/user-store";
+import { useAccomplishmentsStore } from "@/stores/accomplishments-store";
 import { useEPBShellStore, type SelectedRatee } from "@/stores/epb-shell-store";
 import { handleUsageLimitResponse } from "@/stores/usage-limit-store";
 import { billableFetch } from "@/lib/fetch-with-retry";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -18,12 +17,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/sonner";
 import { TokenCostBadge } from "@/components/billing/token-cost-badge";
@@ -33,10 +26,10 @@ import {
   motionEnter,
   motionEnterDurList,
   motionEnterDurNormal,
+  motionEnterFade,
   motionInputFocus,
   motionListEnterStagger,
   motionPressOnly,
-  motionSurfaceCard,
 } from "@/lib/motion/classes";
 import {
   getActiveCycleYear,
@@ -48,6 +41,7 @@ import {
 } from "@/lib/model-preferences";
 import { isSubstantialEpbStatement } from "@/lib/fuse-to-epb";
 import { createEpbShell } from "@/lib/epb-shell-create";
+import { GenerateEpbReviewPanel } from "@/components/entries/generate-epb-review-panel";
 import {
   buildGroupedMpaContexts,
   combineVersions,
@@ -64,10 +58,14 @@ import {
   type EpbPlan,
   type PlanAccomplishmentRecord,
 } from "@/lib/plan-epb";
-import type { EpbGenerationReadiness } from "@/lib/epb-generation-readiness";
+import {
+  entriesNeedingAssessment,
+  type EpbGenerationReadiness,
+} from "@/lib/epb-generation-readiness";
 import { Analytics } from "@/lib/analytics";
 import type {
   Accomplishment,
+  AccomplishmentAssessmentScores,
   EPBShell,
   EPBShellSection,
   Rank,
@@ -79,11 +77,8 @@ import {
   CheckCircle2,
   ChevronDown,
   ClipboardList,
-  FileWarning,
   Loader2,
-  Plus,
   Sparkles,
-  X,
 } from "lucide-react";
 
 type DialogStep =
@@ -128,6 +123,12 @@ export function GenerateEpbDialog({
   const router = useRouter();
   const supabase = createClient();
   const { profile } = useUserStore();
+  const storeAccomplishments = useAccomplishmentsStore(
+    (s) => s.accomplishments
+  );
+  const updateAccomplishment = useAccomplishmentsStore(
+    (s) => s.updateAccomplishment
+  );
   const { setSelectedRatee, setSectionCollapsed, collapseAll } =
     useEPBShellStore();
 
@@ -136,6 +137,10 @@ export function GenerateEpbDialog({
     : [];
   const isPreselected = preselectedRecords.length > 0;
   const dutyProvided = initialDutyDescription !== undefined;
+  const assessmentPool = isPreselected
+    ? (preselected ?? [])
+    : storeAccomplishments;
+  const pendingAssessmentIds = entriesNeedingAssessment(assessmentPool);
 
   const [step, setStep] = useState<DialogStep>("preflight");
   const [records, setRecords] = useState<PlanAccomplishmentRecord[]>(
@@ -145,6 +150,10 @@ export function GenerateEpbDialog({
   const [rationaleByMpa, setRationaleByMpa] = useState<Record<string, string>>(
     {}
   );
+  const [assessProgress, setAssessProgress] = useState<{
+    done: number;
+    total: number;
+  } | null>(null);
   const [activeShell, setActiveShell] = useState<ShellWithSections | null>(
     initialShell ?? null
   );
@@ -180,6 +189,7 @@ export function GenerateEpbDialog({
     setRecords([]);
     setEditable({});
     setRationaleByMpa({});
+    setAssessProgress(null);
     setActiveShell(null);
     setConflictPolicy("overwrite");
     setRunStatus({});
@@ -189,6 +199,52 @@ export function GenerateEpbDialog({
     setDutyLoaded(false);
     setDutyLoading(false);
     setDutyGenerating(false);
+  };
+
+  /** Score missing/stale ACA entries so plan-epb can use MPA fit. Soft-fails per entry. */
+  const ensureFreshAssessments = async (pool: Accomplishment[]) => {
+    const ids = entriesNeedingAssessment(pool);
+    if (ids.length === 0) return true;
+
+    setAssessProgress({ done: 0, total: ids.length });
+    for (let i = 0; i < ids.length; i++) {
+      const accomplishmentId = ids[i]!;
+      try {
+        const response = await billableFetch("/api/assess-accomplishment", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ accomplishmentId }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          if (handleUsageLimitResponse(errorData)) {
+            setAssessProgress(null);
+            return false;
+          }
+        } else {
+          const { assessment, assessed_at, model } = await response.json();
+          const assessedAtNext =
+            typeof assessed_at === "string"
+              ? assessed_at
+              : new Date().toISOString();
+          updateAccomplishment(accomplishmentId, {
+            assessment_scores: assessment as AccomplishmentAssessmentScores,
+            assessed_at: assessedAtNext,
+            assessment_model: model,
+            updated_at: assessedAtNext,
+          });
+        }
+      } catch (error) {
+        console.error("Pre-plan assessment failed:", error);
+      }
+
+      setAssessProgress({ done: i + 1, total: ids.length });
+      if (i < ids.length - 1) await sleep(PACING_MS);
+    }
+
+    setAssessProgress(null);
+    return true;
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -298,6 +354,12 @@ export function GenerateEpbDialog({
     setStep("planning");
     setErrorMessage("");
     try {
+      const assessedOk = await ensureFreshAssessments(assessmentPool);
+      if (!assessedOk) {
+        setStep("preflight");
+        return;
+      }
+
       const cycleYear = getActiveCycleYear(ratee.rank as Rank | null);
       const shell = await findActiveShell().catch(() => null);
       setActiveShell(shell);
@@ -351,46 +413,6 @@ export function GenerateEpbDialog({
       setStep("error");
     }
   };
-
-  const updateMpa = (
-    mpaKey: string,
-    updater: (prev: { enabled: boolean; groups: string[][] }) => {
-      enabled: boolean;
-      groups: string[][];
-    }
-  ) => {
-    setEditable((prev) => ({ ...prev, [mpaKey]: updater(prev[mpaKey]) }));
-  };
-
-  const removeId = (mpaKey: string, groupIdx: number, id: string) =>
-    updateMpa(mpaKey, (prev) => ({
-      ...prev,
-      groups: prev.groups.map((g, i) =>
-        i === groupIdx ? g.filter((x) => x !== id) : g
-      ),
-    }));
-
-  const addId = (mpaKey: string, groupIdx: number, id: string) =>
-    updateMpa(mpaKey, (prev) => ({
-      ...prev,
-      groups: prev.groups.map((g, i) =>
-        i === groupIdx && !g.includes(id) ? [...g, id] : g
-      ),
-    }));
-
-  const removeGroup = (mpaKey: string, groupIdx: number) =>
-    updateMpa(mpaKey, (prev) => ({
-      ...prev,
-      groups: prev.groups.filter((_, i) => i !== groupIdx),
-    }));
-
-  const addGroup = (mpaKey: string) =>
-    updateMpa(mpaKey, (prev) =>
-      prev.groups.length >= 2 ? prev : { ...prev, groups: [...prev.groups, []] }
-    );
-
-  const toggleMpa = (mpaKey: string) =>
-    updateMpa(mpaKey, (prev) => ({ ...prev, enabled: !prev.enabled }));
 
   const chipLabel = (id: string): string => {
     const r = recordsById.get(id);
@@ -479,7 +501,8 @@ export function GenerateEpbDialog({
 
         const { customContext, customContext2 } = buildGroupedMpaContexts(
           selection.groups,
-          recordsById
+          recordsById,
+          selection.notes
         );
 
         const response = await billableFetch("/api/generate", {
@@ -591,6 +614,8 @@ export function GenerateEpbDialog({
   };
 
   const generateCost = selections.length;
+  /** Plan step (1) plus any auto-assessments still needed. */
+  const planActionCost = 1 + pendingAssessmentIds.length;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -745,11 +770,18 @@ export function GenerateEpbDialog({
               <Button
                 onClick={handleAnalyze}
                 className={cn("h-10 px-5", motionPressOnly)}
+                aria-label={
+                  pendingAssessmentIds.length > 0
+                    ? `Plan my EPB (includes assessing ${pendingAssessmentIds.length} ${
+                        pendingAssessmentIds.length === 1 ? "entry" : "entries"
+                      })`
+                    : "Plan my EPB"
+                }
               >
                 <Sparkles className="mr-2 size-4" />
                 Plan my EPB
                 <TokenCostBadge
-                  cost={1}
+                  cost={planActionCost}
                   compact
                   className="ml-2 border-primary-foreground/30 bg-primary-foreground/15 text-primary-foreground"
                 />
@@ -761,14 +793,31 @@ export function GenerateEpbDialog({
         {step === "planning" && (
           <>
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
-              <DialogTitle className="text-xl">Selecting your best work</DialogTitle>
+              <DialogTitle className="text-xl">
+                {assessProgress
+                  ? "Scoring your entries"
+                  : "Selecting your best work"}
+              </DialogTitle>
               <DialogDescription>
-                Ranking by MPA fit, then grouping the same efforts together so
-                related metrics can accumulate…
+                {assessProgress
+                  ? `Assessing ${assessProgress.done} of ${assessProgress.total} so MPA fit can guide selection…`
+                  : "Ranking by MPA fit, then grouping the same efforts together so related metrics can accumulate…"}
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16">
               <Loader2 className="size-10 animate-spin text-muted-foreground" />
+              {assessProgress && (
+                <p
+                  className={cn(
+                    "text-sm text-muted-foreground tabular-nums",
+                    motionEnter,
+                    motionEnterFade
+                  )}
+                  aria-live="polite"
+                >
+                  {assessProgress.done}/{assessProgress.total}
+                </p>
+              )}
             </div>
           </>
         )}
@@ -778,195 +827,23 @@ export function GenerateEpbDialog({
             <DialogHeader className="shrink-0 space-y-2 border-b px-6 py-5 pr-12 sm:px-8 sm:py-6">
               <DialogTitle className="text-xl">Review the selection</DialogTitle>
               <DialogDescription className="text-sm leading-relaxed">
-                Each sentence group becomes one statement. Entries in the same
-                group are treated as one effort (metrics accumulate). Different
-                groups stay separate — up to two sentences per area.
+                Each sentence group becomes one statement. Add optional context
+                per sentence, reorder with the arrows, or move entries between
+                sentences and performance areas — up to two sentences per area.
               </DialogDescription>
             </DialogHeader>
 
             <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8 sm:py-7">
-              <div className="flex flex-col gap-4">
-                {conflictingMpas.length > 0 && (
-                  <div className="rounded-xl border border-amber-400/40 bg-amber-50 p-4 dark:bg-amber-950/30">
-                    <div className="flex items-start gap-2">
-                      <FileWarning className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-300" />
-                      <div className="flex-1">
-                        <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
-                          {conflictingMpas.length} area
-                          {conflictingMpas.length === 1 ? "" : "s"} already{" "}
-                          {conflictingMpas.length === 1 ? "has" : "have"} a statement
-                        </p>
-                        <p className="mt-0.5 text-xs text-amber-700/90 dark:text-amber-300/90">
-                          {conflictingMpas.map(mpaLabel).join(", ")}
-                        </p>
-                        <div
-                          className="mt-3 grid grid-cols-2 gap-2"
-                          role="group"
-                          aria-label="What to do with existing statements"
-                        >
-                          {(["overwrite", "stage"] as const).map((policy) => (
-                            <button
-                              key={policy}
-                              type="button"
-                              onClick={() => setConflictPolicy(policy)}
-                              aria-pressed={conflictPolicy === policy}
-                              className={cn(
-                                "h-10 rounded-lg border text-sm font-medium",
-                                motionPressOnly,
-                                conflictPolicy === policy
-                                  ? "border-primary bg-primary text-primary-foreground"
-                                  : "bg-background hover:bg-muted"
-                              )}
-                            >
-                              {policy === "overwrite"
-                                ? "Overwrite them"
-                                : "Keep & stage new"}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {selections.length === 0 && (
-                  <p className="rounded-lg border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
-                    No performance areas selected. Enable at least one below.
-                  </p>
-                )}
-
-                {Object.keys(editable).map((mpaKey, index) => {
-                  const entry = editable[mpaKey];
-                  const usedIds = new Set(entry.groups.flat());
-                  const available = records.filter(
-                    (r) => !usedIds.has(r.id)
-                  );
-                  return (
-                    <section
-                      key={mpaKey}
-                      className={cn(
-                        "rounded-xl border bg-background p-4 sm:p-5",
-                        motionSurfaceCard,
-                        motionEnter,
-                        motionEnterDurList,
-                        !entry.enabled && "opacity-60"
-                      )}
-                      style={motionListEnterStagger(index)}
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <label className="flex items-center gap-2.5">
-                          <Checkbox
-                            checked={entry.enabled}
-                            onCheckedChange={() => toggleMpa(mpaKey)}
-                            aria-label={`Include ${mpaLabel(mpaKey)}`}
-                          />
-                          <span className="text-sm font-semibold">
-                            {mpaLabel(mpaKey)}
-                          </span>
-                        </label>
-                        <Badge variant="outline" className="text-[10px]">
-                          {entry.groups.filter((g) => g.length > 0).length || 0} sentence
-                          {entry.groups.filter((g) => g.length > 0).length === 1
-                            ? ""
-                            : "s"}
-                        </Badge>
-                      </div>
-
-                      {rationaleByMpa[mpaKey] && (
-                        <p className="mt-2 text-xs italic text-muted-foreground leading-snug">
-                          {rationaleByMpa[mpaKey]}
-                        </p>
-                      )}
-
-                      {entry.enabled && (
-                        <div className="mt-3 space-y-3">
-                          {entry.groups.map((group, groupIdx) => (
-                            <div
-                              key={`${mpaKey}-g${groupIdx}`}
-                              className="rounded-lg border bg-muted/20 p-3"
-                            >
-                              <div className="mb-2 flex items-center justify-between">
-                                <span className="text-xs font-medium text-muted-foreground">
-                                  Sentence {groupIdx + 1}
-                                </span>
-                                <button
-                                  type="button"
-                                  onClick={() => removeGroup(mpaKey, groupIdx)}
-                                  className="text-xs text-muted-foreground hover:text-destructive"
-                                  aria-label={`Remove sentence ${groupIdx + 1}`}
-                                >
-                                  Remove
-                                </button>
-                              </div>
-                              <div className="flex flex-wrap gap-2">
-                                {group.map((id) => (
-                                  <span
-                                    key={id}
-                                    className="flex w-full items-start gap-1.5 rounded-md border bg-background px-2 py-1 text-xs"
-                                  >
-                                    <span className="min-w-0 flex-1 whitespace-normal break-words leading-snug">
-                                      {chipLabel(id)}
-                                    </span>
-                                    <button
-                                      type="button"
-                                      onClick={() => removeId(mpaKey, groupIdx, id)}
-                                      aria-label={`Remove ${chipLabel(id)}`}
-                                      className="mt-0.5 shrink-0 text-muted-foreground hover:text-destructive"
-                                    >
-                                      <X className="size-3" />
-                                    </button>
-                                  </span>
-                                ))}
-                                {group.length === 0 && (
-                                  <span className="text-xs text-muted-foreground">
-                                    Add an accomplishment to this sentence.
-                                  </span>
-                                )}
-                              </div>
-                              {available.length > 0 && (
-                                <div className="mt-2">
-                                  <Select
-                                    value=""
-                                    onValueChange={(id) => addId(mpaKey, groupIdx, id)}
-                                  >
-                                    <SelectTrigger
-                                      className="h-8 text-xs"
-                                      aria-label={`Add accomplishment to sentence ${groupIdx + 1}`}
-                                    >
-                                      <span className="flex items-center gap-1.5 text-muted-foreground">
-                                        <Plus className="size-3.5" />
-                                        Add accomplishment
-                                      </span>
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                      {available.map((r) => (
-                                        <SelectItem key={r.id} value={r.id}>
-                                          {chipLabel(r.id)}
-                                        </SelectItem>
-                                      ))}
-                                    </SelectContent>
-                                  </Select>
-                                </div>
-                              )}
-                            </div>
-                          ))}
-                          {entry.groups.length < 2 && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 text-xs"
-                              onClick={() => addGroup(mpaKey)}
-                            >
-                              <Plus className="mr-1.5 size-3.5" />
-                              Add second sentence
-                            </Button>
-                          )}
-                        </div>
-                      )}
-                    </section>
-                  );
-                })}
-              </div>
+              <GenerateEpbReviewPanel
+                editable={editable}
+                onEditableChange={setEditable}
+                records={records}
+                rationaleByMpa={rationaleByMpa}
+                conflictingMpas={conflictingMpas}
+                conflictPolicy={conflictPolicy}
+                onConflictPolicyChange={setConflictPolicy}
+                chipLabel={chipLabel}
+              />
             </div>
 
             <DialogFooter className="shrink-0 gap-3 border-t bg-muted/20 px-6 py-4 sm:px-8 sm:justify-between">

--- a/src/components/entries/generate-epb-review-panel.tsx
+++ b/src/components/entries/generate-epb-review-panel.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  listMoveDestinations,
+  mpaLabel,
+  moveAccomplishmentToSlot,
+  reorderSentenceGroups,
+  SENTENCE_NOTE_MAX_CHARS,
+  type ConflictPolicy,
+  type EditablePlan,
+} from "@/lib/generate-epb-run";
+import { ACA_PORTFOLIO_MPA_KEYS } from "@/lib/cycle-portfolio";
+import {
+  motionEnter,
+  motionEnterDurList,
+  motionInputFocus,
+  motionListEnterStagger,
+  motionPressOnly,
+  motionSurfaceCard,
+} from "@/lib/motion/classes";
+import { cn } from "@/lib/utils";
+import type { PlanAccomplishmentRecord } from "@/lib/plan-epb";
+import {
+  ArrowDown,
+  ArrowUp,
+  FileWarning,
+  Plus,
+  X,
+} from "lucide-react";
+
+export interface GenerateEpbReviewPanelProps {
+  editable: EditablePlan;
+  onEditableChange: (next: EditablePlan) => void;
+  records: PlanAccomplishmentRecord[];
+  rationaleByMpa: Record<string, string>;
+  conflictingMpas: string[];
+  conflictPolicy: ConflictPolicy;
+  onConflictPolicyChange: (policy: ConflictPolicy) => void;
+  chipLabel: (id: string) => string;
+}
+
+export function GenerateEpbReviewPanel({
+  editable,
+  onEditableChange,
+  records,
+  rationaleByMpa,
+  conflictingMpas,
+  conflictPolicy,
+  onConflictPolicyChange,
+  chipLabel,
+}: GenerateEpbReviewPanelProps) {
+  const updateMpa = (
+    mpaKey: string,
+    updater: (prev: EditablePlan[string]) => EditablePlan[string]
+  ) => {
+    onEditableChange({
+      ...editable,
+      [mpaKey]: updater(editable[mpaKey]),
+    });
+  };
+
+  const removeId = (mpaKey: string, groupIdx: number, id: string) =>
+    updateMpa(mpaKey, (prev) => ({
+      ...prev,
+      groups: prev.groups.map((g, i) =>
+        i === groupIdx ? g.filter((x) => x !== id) : g
+      ),
+    }));
+
+  const addId = (mpaKey: string, groupIdx: number, id: string) =>
+    updateMpa(mpaKey, (prev) => ({
+      ...prev,
+      groups: prev.groups.map((g, i) =>
+        i === groupIdx && !g.includes(id) ? [...g, id] : g
+      ),
+    }));
+
+  const removeGroup = (mpaKey: string, groupIdx: number) =>
+    updateMpa(mpaKey, (prev) => ({
+      ...prev,
+      groups: prev.groups.filter((_, i) => i !== groupIdx),
+      notes: prev.notes.filter((_, i) => i !== groupIdx),
+    }));
+
+  const addGroup = (mpaKey: string) =>
+    updateMpa(mpaKey, (prev) =>
+      prev.groups.length >= 2
+        ? prev
+        : {
+            ...prev,
+            groups: [...prev.groups, []],
+            notes: [...prev.notes.slice(0, prev.groups.length), ""],
+          }
+    );
+
+  const setNote = (mpaKey: string, groupIdx: number, value: string) =>
+    updateMpa(mpaKey, (prev) => {
+      const notes = prev.groups.map((_, i) => prev.notes[i] ?? "");
+      notes[groupIdx] = value.slice(0, SENTENCE_NOTE_MAX_CHARS);
+      return { ...prev, notes };
+    });
+
+  const toggleMpa = (mpaKey: string) =>
+    updateMpa(mpaKey, (prev) => ({ ...prev, enabled: !prev.enabled }));
+
+  const moveId = (
+    mpaKey: string,
+    groupIdx: number,
+    id: string,
+    destValue: string
+  ) => {
+    const [destMpa, destGroupRaw] = destValue.split("::");
+    const destGroupIdx = Number(destGroupRaw);
+    if (!destMpa || Number.isNaN(destGroupIdx)) return;
+    onEditableChange(
+      moveAccomplishmentToSlot(
+        editable,
+        { mpaKey, groupIdx, id },
+        { mpaKey: destMpa, groupIdx: destGroupIdx }
+      )
+    );
+  };
+
+  const selectionsEmpty = Object.values(editable).every(
+    (entry) =>
+      !entry.enabled || entry.groups.every((g) => g.length === 0)
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {conflictingMpas.length > 0 && (
+        <div className="rounded-xl border border-amber-400/40 bg-amber-50 p-4 dark:bg-amber-950/30">
+          <div className="flex items-start gap-2">
+            <FileWarning className="mt-0.5 size-4 shrink-0 text-amber-700 dark:text-amber-300" />
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+                {conflictingMpas.length} area
+                {conflictingMpas.length === 1 ? "" : "s"} already{" "}
+                {conflictingMpas.length === 1 ? "has" : "have"} a statement
+              </p>
+              <p className="mt-0.5 text-xs text-amber-700/90 dark:text-amber-300/90">
+                {conflictingMpas.map(mpaLabel).join(", ")}
+              </p>
+              <div
+                className="mt-3 grid grid-cols-2 gap-2"
+                role="group"
+                aria-label="What to do with existing statements"
+              >
+                {(["overwrite", "stage"] as const).map((policy) => (
+                  <button
+                    key={policy}
+                    type="button"
+                    onClick={() => onConflictPolicyChange(policy)}
+                    aria-pressed={conflictPolicy === policy}
+                    className={cn(
+                      "h-10 rounded-lg border text-sm font-medium",
+                      motionPressOnly,
+                      conflictPolicy === policy
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "bg-background hover:bg-muted"
+                    )}
+                  >
+                    {policy === "overwrite"
+                      ? "Overwrite them"
+                      : "Keep & stage new"}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {selectionsEmpty && (
+        <p className="rounded-lg border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+          No performance areas selected. Enable at least one below.
+        </p>
+      )}
+
+      {ACA_PORTFOLIO_MPA_KEYS.map((mpaKey, index) => {
+        const entry = editable[mpaKey];
+        if (!entry) return null;
+        const usedIds = new Set(entry.groups.flat());
+        const available = records.filter((r) => !usedIds.has(r.id));
+        const sentenceCount = entry.groups.filter((g) => g.length > 0).length;
+
+        return (
+          <section
+            key={mpaKey}
+            className={cn(
+              "rounded-xl border bg-background p-4 sm:p-5",
+              motionSurfaceCard,
+              motionEnter,
+              motionEnterDurList,
+              !entry.enabled && "opacity-60"
+            )}
+            style={motionListEnterStagger(index)}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <label className="flex items-center gap-2.5">
+                <Checkbox
+                  checked={entry.enabled}
+                  onCheckedChange={() => toggleMpa(mpaKey)}
+                  aria-label={`Include ${mpaLabel(mpaKey)}`}
+                />
+                <span className="text-sm font-semibold">
+                  {mpaLabel(mpaKey)}
+                </span>
+              </label>
+              <Badge variant="outline" className="text-[10px]">
+                {sentenceCount || 0} sentence
+                {sentenceCount === 1 ? "" : "s"}
+              </Badge>
+            </div>
+
+            {rationaleByMpa[mpaKey] && (
+              <p className="mt-2 text-xs italic text-muted-foreground leading-snug">
+                {rationaleByMpa[mpaKey]}
+              </p>
+            )}
+
+            {entry.enabled && (
+              <div className="mt-3 space-y-3">
+                {entry.groups.map((group, groupIdx) => {
+                  const note = entry.notes[groupIdx] ?? "";
+                  const destinations = listMoveDestinations(editable, {
+                    mpaKey,
+                    groupIdx,
+                  });
+
+                  return (
+                    <div
+                      key={`${mpaKey}-g${groupIdx}`}
+                      className="rounded-lg border bg-muted/20 p-3"
+                    >
+                      <div className="mb-2 flex items-center justify-between gap-2">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          Sentence {groupIdx + 1}
+                        </span>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className={cn("size-7", motionPressOnly)}
+                            disabled={groupIdx === 0}
+                            onClick={() =>
+                              onEditableChange(
+                                reorderSentenceGroups(
+                                  editable,
+                                  mpaKey,
+                                  groupIdx,
+                                  groupIdx - 1
+                                )
+                              )
+                            }
+                            aria-label={`Move sentence ${groupIdx + 1} up`}
+                          >
+                            <ArrowUp className="size-3.5" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className={cn("size-7", motionPressOnly)}
+                            disabled={groupIdx >= entry.groups.length - 1}
+                            onClick={() =>
+                              onEditableChange(
+                                reorderSentenceGroups(
+                                  editable,
+                                  mpaKey,
+                                  groupIdx,
+                                  groupIdx + 1
+                                )
+                              )
+                            }
+                            aria-label={`Move sentence ${groupIdx + 1} down`}
+                          >
+                            <ArrowDown className="size-3.5" />
+                          </Button>
+                          <button
+                            type="button"
+                            onClick={() => removeGroup(mpaKey, groupIdx)}
+                            className="ml-1 text-xs text-muted-foreground hover:text-destructive"
+                            aria-label={`Remove sentence ${groupIdx + 1}`}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-col gap-2">
+                        {group.map((id) => (
+                          <div
+                            key={id}
+                            className="flex w-full flex-col gap-1.5 rounded-md border bg-background px-2 py-1.5 sm:flex-row sm:items-start"
+                          >
+                            <span className="min-w-0 flex-1 whitespace-normal break-words text-xs leading-snug">
+                              {chipLabel(id)}
+                            </span>
+                            <div className="flex shrink-0 items-center gap-1">
+                              {destinations.length > 0 && (
+                                <Select
+                                  value=""
+                                  onValueChange={(dest) =>
+                                    moveId(mpaKey, groupIdx, id, dest)
+                                  }
+                                >
+                                  <SelectTrigger
+                                    className="h-7 w-[7.5rem] text-[10px]"
+                                    aria-label={`Move ${chipLabel(id)} to another sentence`}
+                                  >
+                                    <span className="text-muted-foreground">
+                                      Move to…
+                                    </span>
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {destinations.map((dest) => (
+                                      <SelectItem
+                                        key={`${dest.mpaKey}-${dest.groupIdx}`}
+                                        value={`${dest.mpaKey}::${dest.groupIdx}`}
+                                      >
+                                        {dest.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              )}
+                              <button
+                                type="button"
+                                onClick={() => removeId(mpaKey, groupIdx, id)}
+                                aria-label={`Remove ${chipLabel(id)}`}
+                                className="shrink-0 p-1 text-muted-foreground hover:text-destructive"
+                              >
+                                <X className="size-3" />
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                        {group.length === 0 && (
+                          <span className="text-xs text-muted-foreground">
+                            Add an accomplishment to this sentence.
+                          </span>
+                        )}
+                      </div>
+
+                      <div className="mt-3 space-y-1.5">
+                        <label
+                          htmlFor={`sentence-note-${mpaKey}-${groupIdx}`}
+                          className="text-xs font-medium text-muted-foreground"
+                        >
+                          Extra context for this sentence{" "}
+                          <span className="font-normal">(optional)</span>
+                        </label>
+                        <Textarea
+                          id={`sentence-note-${mpaKey}-${groupIdx}`}
+                          value={note}
+                          onChange={(e) =>
+                            setNote(mpaKey, groupIdx, e.target.value)
+                          }
+                          rows={2}
+                          placeholder="e.g., Emphasize the 3-week early finish; leave out the temporary manning detail."
+                          aria-label={`Extra context for ${mpaLabel(mpaKey)} sentence ${groupIdx + 1}`}
+                          className={cn(
+                            "min-h-[4rem] resize-y text-sm",
+                            motionInputFocus
+                          )}
+                        />
+                        <div className="flex justify-end">
+                          <span className="text-[10px] tabular-nums text-muted-foreground">
+                            {note.length}/{SENTENCE_NOTE_MAX_CHARS}
+                          </span>
+                        </div>
+                      </div>
+
+                      {available.length > 0 && (
+                        <div className="mt-2">
+                          <Select
+                            value=""
+                            onValueChange={(id) =>
+                              addId(mpaKey, groupIdx, id)
+                            }
+                          >
+                            <SelectTrigger
+                              className="h-8 text-xs"
+                              aria-label={`Add accomplishment to sentence ${groupIdx + 1}`}
+                            >
+                              <span className="flex items-center gap-1.5 text-muted-foreground">
+                                <Plus className="size-3.5" />
+                                Add accomplishment
+                              </span>
+                            </SelectTrigger>
+                            <SelectContent>
+                              {available.map((r) => (
+                                <SelectItem key={r.id} value={r.id}>
+                                  {chipLabel(r.id)}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+                {entry.groups.length === 0 ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 text-xs"
+                    onClick={() => addGroup(mpaKey)}
+                  >
+                    <Plus className="mr-1.5 size-3.5" />
+                    Add sentence
+                  </Button>
+                ) : entry.groups.length < 2 ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 text-xs"
+                    onClick={() => addGroup(mpaKey)}
+                  >
+                    <Plus className="mr-1.5 size-3.5" />
+                    Add second sentence
+                  </Button>
+                ) : null}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/entries/recognition-impact-fields.tsx
+++ b/src/components/entries/recognition-impact-fields.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useState } from "react";
+import { Award as AwardIcon, Link2, Plus, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  AwardFields,
+  emptyAwardFieldsValue,
+  validateAwardFields,
+  type AwardFieldsTeamMemberOption,
+  type AwardFieldsValue,
+} from "@/components/awards/award-fields";
+import { toast } from "@/components/ui/sonner";
+import { createClient } from "@/lib/supabase/client";
+import { getQuarterDateRange } from "@/lib/constants";
+import {
+  composeRecognitionPhrase,
+  formatAwardShortLabel,
+} from "@/lib/award-recognition";
+import { cn } from "@/lib/utils";
+import { motionChip, motionCollapseGrid } from "@/lib/motion/classes";
+import { useAwardsStore } from "@/stores/awards-store";
+import { useUserStore } from "@/stores/user-store";
+import type { Award } from "@/types/database";
+
+type RecognitionImpactFieldsProps = {
+  linkedAwards: Award[];
+  onLinkedAwardsChange: (awards: Award[]) => void;
+  /** Ratee profile id (self or subordinate); mutually exclusive with managed id */
+  recipientProfileId?: string | null;
+  recipientTeamMemberId?: string | null;
+  disabled?: boolean;
+};
+
+export function RecognitionImpactFields({
+  linkedAwards,
+  onLinkedAwardsChange,
+  recipientProfileId,
+  recipientTeamMemberId,
+  disabled = false,
+}: RecognitionImpactFieldsProps) {
+  const { profile, subordinates, managedMembers } = useUserStore();
+  const { addAward, setAwards, getAwardsForMember } = useAwardsStore();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [loadingAwards, setLoadingAwards] = useState(false);
+  const [draft, setDraft] = useState<AwardFieldsValue>(() =>
+    emptyAwardFieldsValue()
+  );
+
+  async function ensureRateeAwardsLoaded() {
+    if (loadingAwards) return;
+
+    setLoadingAwards(true);
+    const supabase = createClient();
+    try {
+      let query = supabase.from("awards").select("*");
+      if (recipientTeamMemberId) {
+        query = query.eq("recipient_team_member_id", recipientTeamMemberId);
+      } else if (recipientProfileId) {
+        query = query.eq("recipient_profile_id", recipientProfileId);
+      } else {
+        return;
+      }
+      const { data, error } = await query.order("created_at", {
+        ascending: false,
+      });
+      if (error) throw error;
+      const fetched = (data || []) as Award[];
+      const current = useAwardsStore.getState().awards;
+      const others = current.filter(
+        (a) =>
+          !(
+            (recipientProfileId &&
+              a.recipient_profile_id === recipientProfileId) ||
+            (recipientTeamMemberId &&
+              a.recipient_team_member_id === recipientTeamMemberId)
+          )
+      );
+      setAwards([...fetched, ...others]);
+    } catch (err) {
+      console.error("Failed to load ratee awards:", err);
+    } finally {
+      setLoadingAwards(false);
+    }
+  }
+
+  const rateeAwards = getAwardsForMember(
+    recipientProfileId || undefined,
+    recipientTeamMemberId || undefined
+  );
+  // Include already-linked awards even if store hasn't loaded the full ratee set yet
+  const availableById = new Map<string, Award>();
+  for (const a of rateeAwards) availableById.set(a.id, a);
+  for (const a of linkedAwards) availableById.set(a.id, a);
+  const available = Array.from(availableById.values());
+
+  const linkedIds = new Set(linkedAwards.map((a) => a.id));
+  const unlinked = available.filter((a) => !linkedIds.has(a.id));
+
+  const teamMemberOptions: AwardFieldsTeamMemberOption[] = [
+    ...subordinates.map((s) => ({
+      id: s.id,
+      name: s.full_name || "Unknown",
+      rank: s.rank,
+      type: "profile" as const,
+    })),
+    ...managedMembers
+      .filter((m) => m.member_status === "active")
+      .map((m) => ({
+        id: m.id,
+        name: m.full_name || "Unknown",
+        rank: m.rank,
+        type: "team_member" as const,
+      })),
+  ].filter(
+    (r) =>
+      !(
+        (recipientProfileId &&
+          r.type === "profile" &&
+          r.id === recipientProfileId) ||
+        (recipientTeamMemberId &&
+          r.type === "team_member" &&
+          r.id === recipientTeamMemberId)
+      )
+  );
+
+  const recognitionPreview = composeRecognitionPhrase(linkedAwards);
+
+  function linkAward(award: Award) {
+    if (linkedIds.has(award.id)) return;
+    onLinkedAwardsChange([...linkedAwards, award]);
+  }
+
+  function unlinkAward(id: string) {
+    onLinkedAwardsChange(linkedAwards.filter((a) => a.id !== id));
+  }
+
+  async function handleCreateAward() {
+    if (!profile) return;
+    const error = validateAwardFields(draft);
+    if (error) {
+      toast.error(error);
+      return;
+    }
+    if (!recipientProfileId && !recipientTeamMemberId) {
+      toast.error("No recipient for this award");
+      return;
+    }
+
+    setCreating(true);
+    const supabase = createClient();
+    try {
+      const currentYear = new Date().getFullYear();
+      const cycleYear =
+        draft.awardType === "coin" ? currentYear : draft.awardYear;
+      const finalAwardName =
+        draft.selectedCatalogAward || draft.awardName || null;
+      const isTeamAward = draft.awardCategory === "team";
+
+      let periodStart: string | null = null;
+      let periodEnd: string | null = null;
+      if (draft.awardType === "quarterly") {
+        const dates = getQuarterDateRange(draft.quarter, draft.awardYear);
+        periodStart = dates.start;
+        periodEnd = dates.end;
+      } else if (draft.awardType === "annual") {
+        periodStart = `${draft.awardYear}-01-01`;
+        periodEnd = `${draft.awardYear}-12-31`;
+      }
+
+      // Self-entry: supervisor_id = self (RLS allows own received awards).
+      // Supervisor entry for ratee: supervisor_id = profile.id.
+      const { data: award, error: awardError } = await supabase
+        .from("awards")
+        .insert({
+          recipient_profile_id: recipientProfileId || null,
+          recipient_team_member_id: recipientTeamMemberId || null,
+          created_by: profile.id,
+          supervisor_id: profile.id,
+          award_type: draft.awardType,
+          award_name: finalAwardName,
+          coin_presenter:
+            draft.awardType === "coin" ? draft.coinPresenter : null,
+          coin_description:
+            draft.awardType === "coin"
+              ? draft.coinDescription || null
+              : null,
+          coin_date: draft.awardType === "coin" ? draft.coinDate : null,
+          quarter: draft.awardType === "quarterly" ? draft.quarter : null,
+          award_year: ["quarterly", "annual", "special"].includes(
+            draft.awardType
+          )
+            ? draft.awardYear
+            : null,
+          period_start: periodStart,
+          period_end: periodEnd,
+          award_level: ["quarterly", "annual"].includes(draft.awardType)
+            ? draft.awardLevel
+            : null,
+          award_category: ["quarterly", "annual"].includes(draft.awardType)
+            ? draft.awardCategory
+            : null,
+          is_team_award: isTeamAward,
+          cycle_year: cycleYear,
+        } as never)
+        .select()
+        .single();
+
+      if (awardError) throw awardError;
+      const typedAward = award as Award;
+
+      if (isTeamAward && draft.selectedTeamMemberIds.length > 0) {
+        const teamMemberInserts = draft.selectedTeamMemberIds.map(
+          (memberId) => {
+            const member = teamMemberOptions.find((r) => r.id === memberId);
+            return {
+              award_id: typedAward.id,
+              profile_id: member?.type === "profile" ? memberId : null,
+              team_member_id:
+                member?.type === "team_member" ? memberId : null,
+            };
+          }
+        );
+        const { error: teamError } = await supabase
+          .from("award_team_members")
+          .insert(teamMemberInserts as never);
+        if (teamError) throw teamError;
+      }
+
+      addAward(typedAward);
+      onLinkedAwardsChange([...linkedAwards, typedAward]);
+      setDraft(emptyAwardFieldsValue());
+      setCreateOpen(false);
+      toast.success("Award added and linked");
+    } catch (err) {
+      console.error("Error creating award from entry:", err);
+      toast.error("Failed to add award");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <Label className="text-sm flex items-center gap-1.5">
+          <AwardIcon className="size-3.5 text-muted-foreground" />
+          Recognition
+          <span className="text-muted-foreground font-normal text-xs">
+            (optional impact)
+          </span>
+        </Label>
+        <div className="flex gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(motionChip, "h-7 text-xs")}
+            disabled={disabled}
+            aria-expanded={pickerOpen}
+            aria-label="Link existing award"
+            onClick={() => {
+              setPickerOpen((o) => {
+                const next = !o;
+                if (next) void ensureRateeAwardsLoaded();
+                return next;
+              });
+              setCreateOpen(false);
+            }}
+          >
+            <Link2 className="size-3 mr-1" />
+            {loadingAwards ? "Loading…" : "Link"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(motionChip, "h-7 text-xs")}
+            disabled={disabled}
+            aria-expanded={createOpen}
+            aria-label="Create and link award"
+            onClick={() => {
+              setCreateOpen((o) => {
+                const next = !o;
+                if (next) setDraft(emptyAwardFieldsValue());
+                return next;
+              });
+              setPickerOpen(false);
+            }}
+          >
+            <Plus className="size-3 mr-1" />
+            New
+          </Button>
+        </div>
+      </div>
+
+      {linkedAwards.length > 0 && (
+        <div className="flex flex-wrap gap-1.5" role="list" aria-label="Linked awards">
+          {linkedAwards.map((award) => (
+            <Badge
+              key={award.id}
+              variant="secondary"
+              className="gap-1 pr-1 max-w-full"
+              role="listitem"
+            >
+              <span className="truncate">{formatAwardShortLabel(award)}</span>
+              <button
+                type="button"
+                className={cn(motionChip, "rounded-sm p-0.5 hover:bg-muted")}
+                aria-label={`Remove ${formatAwardShortLabel(award)}`}
+                disabled={disabled}
+                onClick={() => unlinkAward(award.id)}
+              >
+                <X className="size-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {recognitionPreview && (
+        <p className="text-xs text-muted-foreground">
+          Impact phrase:{" "}
+          <span className="text-foreground/80 italic">{recognitionPreview}</span>
+        </p>
+      )}
+
+      <div
+        className={motionCollapseGrid}
+        data-open={pickerOpen ? "true" : "false"}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="pt-1 space-y-2">
+            {unlinked.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No other awards on file for this ratee. Create one with New.
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5 max-h-28 overflow-y-auto">
+                {unlinked.map((award) => (
+                  <Badge
+                    key={award.id}
+                    variant="outline"
+                    className={cn(motionChip, "cursor-pointer")}
+                    onClick={() => !disabled && linkAward(award)}
+                    role="button"
+                    tabIndex={disabled ? -1 : 0}
+                    onKeyDown={(e) => {
+                      if (disabled) return;
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        linkAward(award);
+                      }
+                    }}
+                  >
+                    {formatAwardShortLabel(award)}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div
+        className={motionCollapseGrid}
+        data-open={createOpen ? "true" : "false"}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="pt-2 space-y-3 rounded-lg p-3 bg-muted/30 shadow-[0_1px_2px_rgba(0,0,0,0.05),0_2px_4px_rgba(0,0,0,0.02),0_0_0_0.5px_rgba(0,0,0,0.08)]">
+            <AwardFields
+              value={draft}
+              onChange={setDraft}
+              teamMemberOptions={teamMemberOptions}
+              disabled={disabled || creating}
+              idPrefix="entry-award"
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={creating}
+                onClick={() => setCreateOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={disabled || creating}
+                onClick={() => void handleCreateAward()}
+              >
+                {creating ? "Adding…" : "Add & link"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/entries/stewardship-impact-fields.tsx
+++ b/src/components/entries/stewardship-impact-fields.tsx
@@ -86,6 +86,8 @@ export interface StewardshipImpactFieldsProps {
   onChange: (next: StewardshipImpactFormValue) => void;
   disabled?: boolean;
   idPrefix?: string;
+  /** When education context is present — mission-tie copy for impact */
+  educationAware?: boolean;
 }
 
 export function StewardshipImpactFields({
@@ -93,19 +95,26 @@ export function StewardshipImpactFields({
   onChange,
   disabled = false,
   idPrefix = "stewardship",
+  educationAware = false,
 }: StewardshipImpactFieldsProps) {
   return (
     <div className="space-y-2.5">
       <div className="space-y-0.5">
         <Label className="text-sm">Impact</Label>
         <p className="text-xs text-muted-foreground">
-          What did this buy back for the mission? (optional)
+          {educationAware
+            ? "How did this education enable mission results? (optional)"
+            : "What did this buy back for the mission? (optional)"}
         </p>
       </div>
       <div className="grid grid-cols-[auto_1rem_minmax(0,1fr)] items-center gap-x-1.5 gap-y-2.5">
         {FIELDS.map((field) => {
           const fieldId = `${idPrefix}-${field.key}`;
           const hintId = `${fieldId}-hint`;
+          const placeholder =
+            educationAware && field.key === "outcome"
+              ? "e.g. applied PME to cut qual timeline / mentored shop"
+              : field.placeholder;
           return (
             <div key={field.key} className="contents">
               <Label
@@ -134,7 +143,9 @@ export function StewardshipImpactFields({
                   sideOffset={6}
                   className="max-w-[260px] text-xs leading-snug"
                 >
-                  {field.hint}
+                  {educationAware && field.key === "outcome"
+                    ? "Tie the education to mission results — readiness, capacity, or unit improvement enabled by what was learned."
+                    : field.hint}
                 </TooltipContent>
               </Tooltip>
               <Input
@@ -146,10 +157,14 @@ export function StewardshipImpactFields({
                     [field.key]: e.target.value.slice(0, STEWARDSHIP_FIELD_MAX),
                   })
                 }
-                placeholder={field.placeholder}
+                placeholder={placeholder}
                 disabled={disabled}
                 aria-label={field.label}
-                title={field.hint}
+                title={
+                  educationAware && field.key === "outcome"
+                    ? "Tie education to mission results"
+                    : field.hint
+                }
                 className="h-9 text-sm"
                 maxLength={STEWARDSHIP_FIELD_MAX}
               />

--- a/src/components/epb/duty-description-card.tsx
+++ b/src/components/epb/duty-description-card.tsx
@@ -24,6 +24,11 @@ import {
 } from "@/lib/motion/classes";
 import { MAX_DUTY_DESCRIPTION_CHARACTERS } from "@/lib/constants";
 import {
+  MAX_GENERATED_STATEMENT_SETS,
+  type GeneratedStatementSource,
+} from "@/lib/epb-generated-set-history";
+import { EpbSnapshotHistoryPanel } from "./epb-snapshot-history-panel";
+import {
   Copy,
   Check,
   Loader2,
@@ -67,7 +72,7 @@ interface RevisionBatch {
 }
 
 /** Cap on remembered revision sets per card (short-term, in-session). */
-const MAX_REVISION_HISTORY = 8;
+const MAX_REVISION_HISTORY = MAX_GENERATED_STATEMENT_SETS;
 
 interface DutyDescriptionCardProps {
   currentDutyDescription: string;
@@ -81,6 +86,11 @@ interface DutyDescriptionCardProps {
   // Snapshots (history)
   snapshots?: DutyDescriptionSnapshot[];
   onCreateSnapshot?: (text: string) => Promise<void>;
+  /** Persist last generated revise set into Snapshot History (rolling 3 sets). */
+  onSaveGeneratedSet?: (
+    statements: string[],
+    source?: GeneratedStatementSource,
+  ) => Promise<void>;
   // Saved examples (shell-specific)
   savedExamples?: DutyDescriptionExample[];
   onSaveExample?: (text: string, note?: string) => Promise<void>;
@@ -117,6 +127,7 @@ export function DutyDescriptionCard({
   onToggleComplete,
   snapshots = [],
   onCreateSnapshot,
+  onSaveGeneratedSet,
   savedExamples = [],
   onSaveExample,
   onDeleteExample,
@@ -164,6 +175,7 @@ export function DutyDescriptionCard({
   const [showTemplatesPanel, setShowTemplatesPanel] = useState(false);
   const [showSaveTemplateDialog, setShowSaveTemplateDialog] = useState(false);
   const [isCreatingSnapshot, setIsCreatingSnapshot] = useState(false);
+  const [applyingRevisionText, setApplyingRevisionText] = useState<string | null>(null);
   const [isRevisePanelClosing, setIsRevisePanelClosing] = useState(false);
   const [isRevisionsResultsClosing, setIsRevisionsResultsClosing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -475,6 +487,11 @@ export function DutyDescriptionCard({
         setRevisionHistory(nextHistory);
         setActiveRevisionIndex(nextHistory.length - 1);
         resizeCardBody(() => setGeneratedRevisions(results), scrollGeneratedRevisionsIntoView);
+        if (onSaveGeneratedSet) {
+          void onSaveGeneratedSet(results, "revise").catch((err) => {
+            console.error("Failed to save revised set to History:", err);
+          });
+        }
       } else {
         toast.error("No revisions generated");
       }
@@ -517,23 +534,50 @@ export function DutyDescriptionCard({
     }
   };
 
-  // Use a generated revision
-  const handleUseRevision = (version: string, versionIndex: number) => {
-    setLocalText(version);
-    setDutyDescriptionDraft(version);
-    setIsDutyDescriptionDirty(version !== currentDutyDescription);
-    toast.success("Revision applied");
-    
-    // Track for style learning (fire-and-forget)
-    styleFeedback.trackRevisionSelected({
-      version: versionIndex + 1,
-      totalVersions: generatedRevisions.length,
-      charCount: version.length,
-      category: "duty_description",
-      aggressiveness: reviseAggressiveness,
-    });
+  // Use a generated revision — snapshot the current workspace first so the
+  // previous version remains recoverable from History.
+  const handleUseRevision = async (version: string, versionIndex: number) => {
+    if (applyingRevisionText !== null) return;
+    setApplyingRevisionText(version);
+    try {
+      const previousText = localText.trim();
+      const shouldSnapshot =
+        !!onCreateSnapshot &&
+        previousText.length > 0 &&
+        previousText !== version.trim();
 
-    closeRevisePanelWithScroll();
+      if (shouldSnapshot && onCreateSnapshot) {
+        try {
+          await onCreateSnapshot(localText);
+        } catch (error) {
+          console.error(error);
+          toast.error("Failed to save snapshot of current description");
+          return;
+        }
+      }
+
+      setLocalText(version);
+      setDutyDescriptionDraft(version);
+      setIsDutyDescriptionDirty(version !== currentDutyDescription);
+      toast.success(
+        shouldSnapshot
+          ? "Revision applied · previous version saved"
+          : "Revision applied",
+      );
+
+      // Track for style learning (fire-and-forget)
+      styleFeedback.trackRevisionSelected({
+        version: versionIndex + 1,
+        totalVersions: generatedRevisions.length,
+        charCount: version.length,
+        category: "duty_description",
+        aggressiveness: reviseAggressiveness,
+      });
+
+      closeRevisePanelWithScroll();
+    } finally {
+      setApplyingRevisionText(null);
+    }
   };
 
   const handleToggleCollapse = () => {
@@ -860,55 +904,17 @@ export function DutyDescriptionCard({
 
           {/* History Panel */}
           {showHistoryPanel && (
-            <div className="rounded-lg border bg-muted/30 animate-in fade-in-0 duration-200">
-              <div className="p-4 border-b">
-                <h4 className="font-medium text-sm">Snapshot History</h4>
-                <p className="text-xs text-muted-foreground">
-                  {snapshots.length} snapshot{snapshots.length !== 1 && "s"}
-                </p>
-              </div>
-              <div className="max-h-64 overflow-y-auto">
-                {snapshots.length === 0 ? (
-                  <p className="p-3 text-sm text-muted-foreground text-center">
-                    No snapshots yet. Click the camera icon to save your current text.
-                  </p>
-                ) : (
-                  snapshots.map((snap) => (
-                    <div
-                      key={snap.id}
-                      className="p-4 border-b last:border-0"
-                    >
-                      <div className="flex items-start justify-between gap-2 mb-1">
-                        <span className="text-[10px] text-muted-foreground">
-                          {formatDateTime(snap.created_at)}
-                        </span>
-                        <div className="flex items-center gap-1">
-                          <button type="button"
-                            onClick={() => {
-                              navigator.clipboard.writeText(snap.description_text);
-                              toast.success("Copied");
-                            }}
-                            className="h-5 px-1.5 rounded text-[10px] hover:bg-muted transition-colors"
-                            aria-label="Copy snapshot to clipboard"
-                          >
-                            <Copy className="size-3" />
-                          </button>
-                          <button type="button"
-                            onClick={() => handleApplySnapshot(snap.description_text)}
-                            className="h-5 px-1.5 rounded text-[10px] bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
-                          >
-                            Apply
-                          </button>
-                        </div>
-                      </div>
-                      <p className="text-xs text-muted-foreground line-clamp-2">
-                        {snap.description_text}
-                      </p>
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
+            <EpbSnapshotHistoryPanel
+              snapshots={snapshots.map((snap) => ({
+                id: snap.id,
+                text: snap.description_text,
+                note: snap.note,
+                created_at: snap.created_at,
+              }))}
+              onApply={(item) => handleApplySnapshot(item.text)}
+              applyLabel="Apply"
+              variant="muted"
+            />
           )}
 
           {/* Examples Panel */}
@@ -1201,11 +1207,15 @@ export function DutyDescriptionCard({
                           <Tooltip>
                             <TooltipTrigger asChild>
                               <button type="button"
-                                onClick={() => handleUseRevision(version, index)}
-                                disabled={isUseThisClosing}
+                                onClick={() => void handleUseRevision(version, index)}
+                                disabled={isUseThisClosing || applyingRevisionText !== null}
                                 className="h-6 px-2 rounded text-[10px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors inline-flex items-center disabled:opacity-50"
                               >
-                                <Check className="size-3 mr-1" />
+                                {applyingRevisionText === version ? (
+                                  <Loader2 className="size-3 mr-1 animate-spin" />
+                                ) : (
+                                  <Check className="size-3 mr-1" />
+                                )}
                                 Use This
                               </button>
                             </TooltipTrigger>

--- a/src/components/epb/epb-shell-form.tsx
+++ b/src/components/epb/epb-shell-form.tsx
@@ -90,6 +90,14 @@ import type {
   StatementGenerationResult,
 } from "@/lib/formatting-violation-note";
 import { scanTextForLLM } from "@/lib/sensitive-data-scanner";
+import {
+  MAX_GENERATED_STATEMENT_SETS,
+  MAX_STATEMENTS_PER_GENERATED_SET,
+  buildGeneratedSetSnapshotNote,
+  idsOfGeneratedSetsBeyondLimit,
+  idsOfManualSnapshotsBeyondLimit,
+  type GeneratedStatementSource,
+} from "@/lib/epb-generated-set-history";
 
 // Map raw award records to simplified selection format for statement integration
 interface RawAwardRecord {
@@ -1274,17 +1282,23 @@ export function EPBShellForm({
     setCurrentShell({ ...currentShell, duty_description: text });
   };
 
-  // Create a duty description snapshot (max 10, oldest gets deleted when 11th is added)
+  // Create a duty description snapshot (max 10 manual; AI sets use a separate rolling budget)
   const handleCreateDutyDescriptionSnapshot = async (text: string) => {
     if (!currentShell || !profile || !text.trim()) return;
 
-    // If we already have 10 snapshots, delete the oldest
-    if (dutyDescriptionSnapshots.length >= 10) {
-      const oldestSnapshot = dutyDescriptionSnapshots[dutyDescriptionSnapshots.length - 1];
+    const overflowIds = idsOfManualSnapshotsBeyondLimit(
+      dutyDescriptionSnapshots.map((s) => ({
+        id: s.id,
+        note: s.note,
+        created_at: s.created_at,
+      })),
+      9, // leave room for the new manual row
+    );
+    if (overflowIds.length > 0) {
       await supabase
         .from("epb_duty_description_snapshots")
         .delete()
-        .eq("id", oldestSnapshot.id);
+        .in("id", overflowIds);
     }
 
     const { data, error } = await supabase
@@ -1299,8 +1313,50 @@ export function EPBShellForm({
 
     if (error) throw error;
 
-    // Add to local state
-    setDutyDescriptionSnapshots([data as DutyDescriptionSnapshot, ...dutyDescriptionSnapshots.slice(0, 9)]);
+    const kept = dutyDescriptionSnapshots.filter((s) => !overflowIds.includes(s.id));
+    setDutyDescriptionSnapshots([data as DutyDescriptionSnapshot, ...kept]);
+  };
+
+  // Persist a generated revise/generate set into History (last 3 sets / 9 statements).
+  const handleSaveDutyDescriptionGeneratedSet = async (
+    statements: string[],
+    source: GeneratedStatementSource = "revise",
+  ) => {
+    if (!currentShell || !profile) return;
+    const texts = statements
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .slice(0, MAX_STATEMENTS_PER_GENERATED_SET);
+    if (texts.length === 0) return;
+
+    const batchId = `${Date.now()}`;
+    const rows = texts.map((description_text, index) => ({
+      shell_id: currentShell.id,
+      description_text,
+      created_by: profile.id,
+      note: buildGeneratedSetSnapshotNote(source, batchId, index + 1),
+    }));
+
+    const { data, error } = await supabase
+      .from("epb_duty_description_snapshots")
+      .insert(rows as never)
+      .select();
+
+    if (error) throw error;
+
+    const inserted = (data as DutyDescriptionSnapshot[]) ?? [];
+    const merged = [...inserted, ...dutyDescriptionSnapshots];
+    const pruneIds = idsOfGeneratedSetsBeyondLimit(
+      merged.map((s) => ({ id: s.id, note: s.note, created_at: s.created_at })),
+      MAX_GENERATED_STATEMENT_SETS,
+    );
+    if (pruneIds.length > 0) {
+      await supabase
+        .from("epb_duty_description_snapshots")
+        .delete()
+        .in("id", pruneIds);
+    }
+    setDutyDescriptionSnapshots(merged.filter((s) => !pruneIds.includes(s.id)));
   };
 
   // Save a duty description example
@@ -1395,32 +1451,28 @@ export function EPBShellForm({
     setDutyDescriptionTemplates(dutyDescriptionTemplates.filter((t) => t.id !== templateId));
   };
 
-  // Create a snapshot (max 10 per section, oldest gets deleted when 11th is added)
+  // Create a workspace snapshot (max 10 manual; AI sets use a separate rolling budget)
   const handleCreateSnapshot = async (mpa: string, text: string) => {
     const section = sections[mpa];
     if (!section || !profile) return;
 
     const existingSnapshots = snapshots[section.id] || [];
-    
-    // If we already have 10 snapshots, delete the oldest one
-    if (existingSnapshots.length >= 10) {
-      // Sort by created_at ascending to find oldest
-      const sortedSnapshots = [...existingSnapshots].sort(
-        (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    const overflowIds = idsOfManualSnapshotsBeyondLimit(
+      existingSnapshots.map((s) => ({
+        id: s.id,
+        note: s.note,
+        created_at: s.created_at,
+      })),
+      9, // leave room for the new manual row
+    );
+    if (overflowIds.length > 0) {
+      await supabase.from("epb_shell_snapshots").delete().in("id", overflowIds);
+      setSnapshots(
+        section.id,
+        existingSnapshots.filter((s) => !overflowIds.includes(s.id)),
       );
-      const oldestSnapshot = sortedSnapshots[0];
-      
-      // Delete oldest from database
-      await supabase
-        .from("epb_shell_snapshots")
-        .delete()
-        .eq("id", oldestSnapshot.id);
-      
-      // Remove from local state
-      setSnapshots(section.id, existingSnapshots.filter(s => s.id !== oldestSnapshot.id));
     }
 
-    // Create new snapshot
     const { data, error } = await supabase
       .from("epb_shell_snapshots")
       .insert({
@@ -1434,6 +1486,52 @@ export function EPBShellForm({
     if (error) throw error;
 
     addSnapshot(section.id, data as EPBShellSnapshot);
+  };
+
+  // Persist a generated revise/generate set into History (last 3 sets / 9 statements).
+  const handleSaveGeneratedStatementSet = async (
+    mpa: string,
+    statements: string[],
+    source: GeneratedStatementSource,
+  ) => {
+    const section = sections[mpa];
+    if (!section || !profile) return;
+
+    const texts = statements
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .slice(0, MAX_STATEMENTS_PER_GENERATED_SET);
+    if (texts.length === 0) return;
+
+    const batchId = `${Date.now()}`;
+    const rows = texts.map((statement_text, index) => ({
+      section_id: section.id,
+      statement_text,
+      created_by: profile.id,
+      note: buildGeneratedSetSnapshotNote(source, batchId, index + 1),
+    }));
+
+    const { data, error } = await supabase
+      .from("epb_shell_snapshots")
+      .insert(rows as never)
+      .select();
+
+    if (error) throw error;
+
+    const inserted = (data as EPBShellSnapshot[]) ?? [];
+    const existing = snapshots[section.id] || [];
+    const merged = [...inserted, ...existing];
+    const pruneIds = idsOfGeneratedSetsBeyondLimit(
+      merged.map((s) => ({ id: s.id, note: s.note, created_at: s.created_at })),
+      MAX_GENERATED_STATEMENT_SETS,
+    );
+    if (pruneIds.length > 0) {
+      await supabase.from("epb_shell_snapshots").delete().in("id", pruneIds);
+    }
+    setSnapshots(
+      section.id,
+      merged.filter((s) => !pruneIds.includes(s.id)),
+    );
   };
 
   // Save an example statement to the scratchpad
@@ -2196,6 +2294,7 @@ export function EPBShellForm({
           onToggleComplete={handleToggleDutyDescriptionComplete}
           snapshots={dutyDescriptionSnapshots}
           onCreateSnapshot={handleCreateDutyDescriptionSnapshot}
+          onSaveGeneratedSet={handleSaveDutyDescriptionGeneratedSet}
           savedExamples={dutyDescriptionExamples}
           onSaveExample={handleSaveDutyDescriptionExample}
           onDeleteExample={handleDeleteDutyDescriptionExample}
@@ -2230,6 +2329,9 @@ export function EPBShellForm({
                 onSaveImpactBooster={(booster) => handleSaveImpactBooster(mpa.key, booster)}
                 onClearImpactBooster={() => handleClearImpactBooster(mpa.key)}
                 onCreateSnapshot={(text) => handleCreateSnapshot(mpa.key, text)}
+                onSaveGeneratedSet={(statements, source) =>
+                  handleSaveGeneratedStatementSet(mpa.key, statements, source)
+                }
                 onGenerateStatement={(opts) => handleGenerateStatement(mpa.key, opts)}
                 onReviseStatement={(text, ctx, count, aggr) => handleReviseStatement(mpa.key, text, ctx, count, aggr)}
                 snapshots={snapshots[section.id] || []}

--- a/src/components/epb/epb-snapshot-history-panel.tsx
+++ b/src/components/epb/epb-snapshot-history-panel.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "@/components/ui/sonner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { formatDateTime } from "@/lib/format";
+import {
+  groupSnapshotsForHistory,
+  type SnapshotHistoryGroup,
+  type SnapshotHistoryItem,
+} from "@/lib/epb-generated-set-history";
+import {
+  motionChevronOpen,
+  motionCollapseGrid,
+  motionEnter,
+  motionEnterDurNormal,
+  motionListRow,
+  motionPressable,
+  motionTransitionColors,
+} from "@/lib/motion/classes";
+import { ChevronDown, Copy, RotateCcw, Sparkles, Camera } from "lucide-react";
+
+export type EpbSnapshotHistoryPanelProps = {
+  snapshots: SnapshotHistoryItem[];
+  onApply: (item: SnapshotHistoryItem) => void;
+  /** Button label for applying a snapshot to the workspace. */
+  applyLabel?: "Apply" | "Restore";
+  /** Visual shell — muted matches DD; elevated matches MPA cards. */
+  variant?: "muted" | "elevated";
+  className?: string;
+};
+
+function groupSummary(group: SnapshotHistoryGroup): string {
+  if (group.kind === "ai-set") {
+    const n = group.items.length;
+    return `${group.title} · ${n} option${n !== 1 ? "s" : ""}`;
+  }
+  return "Workspace snapshot";
+}
+
+export function EpbSnapshotHistoryPanel({
+  snapshots,
+  onApply,
+  applyLabel = "Apply",
+  variant = "muted",
+  className,
+}: EpbSnapshotHistoryPanelProps) {
+  const groups = groupSnapshotsForHistory(snapshots);
+  const newestAiKey =
+    groups.find((g): g is Extract<SnapshotHistoryGroup, { kind: "ai-set" }> => g.kind === "ai-set")
+      ?.key ?? null;
+
+  // User toggles only — newest AI set stays open by default when unset.
+  const [expandedOverrides, setExpandedOverrides] = useState<Record<string, boolean>>({});
+
+  const isGroupOpen = (key: string) =>
+    key in expandedOverrides ? expandedOverrides[key]! : key === newestAiKey;
+
+  const toggleGroup = (key: string) => {
+    setExpandedOverrides((prev) => {
+      const currentlyOpen = key in prev ? prev[key]! : key === newestAiKey;
+      return { ...prev, [key]: !currentlyOpen };
+    });
+  };
+
+  const handleCopy = (text: string) => {
+    void navigator.clipboard.writeText(text);
+    toast.success("Copied");
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border overflow-hidden",
+        motionEnter,
+        motionEnterDurNormal,
+        variant === "elevated" ? "bg-card shadow-lg" : "bg-muted/30",
+        className,
+      )}
+    >
+      <div className="p-4 border-b">
+        <h4 className="font-medium text-sm">Snapshot History</h4>
+        <p className="text-xs text-muted-foreground">
+          {groups.length === 0
+            ? "No snapshots yet"
+            : `${groups.length} entr${groups.length === 1 ? "y" : "ies"}`}
+          <span className="text-muted-foreground/70">
+            {" "}
+            · AI sets grouped · last 3 kept
+          </span>
+        </p>
+      </div>
+
+      <div className="max-h-72 overflow-y-auto">
+        {groups.length === 0 ? (
+          <p className="p-3 text-sm text-muted-foreground text-center">
+            No snapshots yet. Generated alternatives are saved here automatically,
+            or click the camera icon to save your current text.
+          </p>
+        ) : (
+          groups.map((group) => {
+            if (group.kind === "manual") {
+              return (
+                <ManualHistoryRow
+                  key={group.key}
+                  text={group.item.text}
+                  createdAt={group.created_at}
+                  applyLabel={applyLabel}
+                  onCopy={() => handleCopy(group.item.text)}
+                  onApply={() => onApply(group.item)}
+                />
+              );
+            }
+
+            const open = isGroupOpen(group.key);
+            return (
+              <div key={group.key} className="border-b last:border-b-0">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group.key)}
+                  aria-expanded={open}
+                  aria-controls={`history-set-${group.batchId}`}
+                  className={cn(
+                    "w-full flex items-center gap-2 px-4 py-3 text-left",
+                    motionListRow,
+                    "hover:bg-muted/50",
+                  )}
+                >
+                  <Sparkles className="size-3.5 text-primary shrink-0" aria-hidden="true" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs font-medium truncate">{groupSummary(group)}</p>
+                    <p className="text-[10px] text-muted-foreground">
+                      {formatDateTime(group.created_at)}
+                    </p>
+                  </div>
+                  <ChevronDown
+                    className={cn(
+                      "size-4 text-muted-foreground shrink-0",
+                      motionChevronOpen,
+                      open && "rotate-180",
+                    )}
+                    aria-hidden="true"
+                  />
+                </button>
+
+                <div
+                  id={`history-set-${group.batchId}`}
+                  className={motionCollapseGrid}
+                  data-open={open ? "true" : "false"}
+                >
+                  <div className="overflow-hidden">
+                    <div className="px-3 pb-3 space-y-2">
+                      {group.items.map((item) => (
+                        <div
+                          key={item.id}
+                          className="rounded-md border bg-background/80 p-3 space-y-2"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <span className="text-[10px] font-medium text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                              Option {item.optionIndex}
+                            </span>
+                            <div className="flex items-center gap-1 shrink-0">
+                              <button
+                                type="button"
+                                onClick={() => handleCopy(item.text)}
+                                className={cn(
+                                  "h-6 px-1.5 rounded text-[10px] hover:bg-muted inline-flex items-center",
+                                  motionPressable,
+                                  motionTransitionColors,
+                                )}
+                                aria-label={`Copy option ${item.optionIndex}`}
+                              >
+                                <Copy className="size-3" />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => onApply(item)}
+                                className={cn(
+                                  "h-6 px-2 rounded text-[10px] bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-1",
+                                  motionPressable,
+                                )}
+                                aria-label={`${applyLabel} option ${item.optionIndex}`}
+                              >
+                                <RotateCcw className="size-3" />
+                                {applyLabel}
+                              </button>
+                            </div>
+                          </div>
+                          <p className="text-sm select-text cursor-text whitespace-pre-wrap leading-relaxed">
+                            {item.text}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ManualHistoryRow({
+  text,
+  createdAt,
+  applyLabel,
+  onCopy,
+  onApply,
+}: {
+  text: string;
+  createdAt: string;
+  applyLabel: "Apply" | "Restore";
+  onCopy: () => void;
+  onApply: () => void;
+}) {
+  return (
+    <div className="p-4 border-b last:border-b-0 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex items-start gap-2">
+          <Camera className="size-3.5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="text-xs font-medium">Workspace snapshot</p>
+            <p className="text-[10px] text-muted-foreground">{formatDateTime(createdAt)}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            onClick={onCopy}
+            className={cn(
+              "h-6 px-1.5 rounded text-[10px] hover:bg-muted inline-flex items-center",
+              motionPressable,
+              motionTransitionColors,
+            )}
+            aria-label="Copy snapshot to clipboard"
+          >
+            <Copy className="size-3" />
+          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onApply}
+                className={cn(
+                  "h-6 px-2 rounded text-[10px] bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-1",
+                  motionPressable,
+                )}
+              >
+                <RotateCcw className="size-3" />
+                {applyLabel}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Replace current workspace with this version</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+      <p className="text-sm select-text cursor-text whitespace-pre-wrap leading-relaxed">
+        {text}
+      </p>
+    </div>
+  );
+}

--- a/src/components/epb/mpa-section-card.tsx
+++ b/src/components/epb/mpa-section-card.tsx
@@ -20,7 +20,16 @@ import {
 import { toast } from "@/components/ui/sonner";
 import { Analytics } from "@/lib/analytics";
 import { cn, getCharacterCountColor } from "@/lib/utils";
-import { STANDARD_MGAS, MAX_STATEMENT_CHARACTERS, MAX_HLR_CHARACTERS } from "@/lib/constants";
+import {
+  STANDARD_MGAS,
+  MAX_STATEMENT_CHARACTERS,
+  MAX_HLR_CHARACTERS,
+} from "@/lib/constants";
+import {
+  MAX_GENERATED_STATEMENT_SETS,
+  type GeneratedStatementSource,
+} from "@/lib/epb-generated-set-history";
+import { EpbSnapshotHistoryPanel } from "./epb-snapshot-history-panel";
 import {
   Sparkles,
   Copy,
@@ -101,6 +110,11 @@ interface MPASectionCardProps {
   /** Clear Impact Booster for this MPA */
   onClearImpactBooster?: () => Promise<void>;
   onCreateSnapshot: (text: string) => Promise<void>;
+  /** Persist last generated revise/generate set into Snapshot History (rolling 3 sets). */
+  onSaveGeneratedSet?: (
+    statements: string[],
+    source: GeneratedStatementSource,
+  ) => Promise<void>;
   onGenerateStatement: (options: GenerateOptions) => Promise<StatementGenerationResult>;
   onReviseStatement: (text: string, context?: string, versionCount?: number, aggressiveness?: number) => Promise<StatementGenerationResult>;
   snapshots: EPBShellSnapshot[];
@@ -316,8 +330,8 @@ interface RevisionBatch {
   createdAt: number;
 }
 
-/** Cap on remembered revision sets per section (short-term, in-session). */
-const MAX_REVISION_HISTORY = 8;
+/** Cap on remembered revision/generate sets per section (short-term, in-session). */
+const MAX_REVISION_HISTORY = MAX_GENERATED_STATEMENT_SETS;
 
 export function MPASectionCard({
   section,
@@ -328,6 +342,7 @@ export function MPASectionCard({
   onSaveImpactBooster,
   onClearImpactBooster,
   onCreateSnapshot,
+  onSaveGeneratedSet,
   onGenerateStatement,
   onReviseStatement,
   snapshots,
@@ -385,6 +400,7 @@ export function MPASectionCard({
   const [showHistory, setShowHistory] = useState(false);
   const [showPromptSettings, setShowPromptSettings] = useState(false);
   const [isCreatingSnapshot, setIsCreatingSnapshot] = useState(false);
+  const [applyingRevisionText, setApplyingRevisionText] = useState<string | null>(null);
   const [isAutosaving, setIsAutosaving] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isSplitViewClosing, setIsSplitViewClosing] = useState(false);
@@ -415,6 +431,9 @@ export function MPASectionCard({
   const [statementFormattingViolations, setStatementFormattingViolations] = useState<
     FormattingViolationFlag[] | undefined
   >(undefined);
+  // Short-term history of AI Generate sets (same rolling window as revise).
+  const [statementHistory, setStatementHistory] = useState<RevisionBatch[]>([]);
+  const [activeStatementIndex, setActiveStatementIndex] = useState(0);
 
   // Impact Booster — shared draft fields keep pre/post panels in sync; flush on Generate / Revise
   const [includeImpactBooster, setIncludeImpactBooster] = useState(true);
@@ -1047,10 +1066,24 @@ export function MPASectionCard({
         clarifyingContext,
       });
       if (results.length > 0) {
+        const batch: RevisionBatch = {
+          revisions: results,
+          context: "",
+          aggressiveness: 50,
+          createdAt: Date.now(),
+        };
+        const nextHistory = [...statementHistory, batch].slice(-MAX_REVISION_HISTORY);
+        setStatementHistory(nextHistory);
+        setActiveStatementIndex(nextHistory.length - 1);
         // Solid appear: swap results in place (no clear→remount fade). Height
         // tween locks before paint so the card grows without a flash/jerk.
         setStatementFormattingViolations(formattingViolations);
         resizeCardBody(() => setGeneratedStatements(results), scrollGeneratedStatementsIntoView);
+        if (onSaveGeneratedSet) {
+          void onSaveGeneratedSet(results, "generate").catch((err) => {
+            console.error("Failed to save generated set to History:", err);
+          });
+        }
       } else {
         toast.error("No statements generated");
       }
@@ -1180,6 +1213,11 @@ export function MPASectionCard({
         // tween locks before paint so the list does not flash/jerk.
         setRevisionFormattingViolations(formattingViolations);
         resizeCardBody(() => setGeneratedRevisions(revisions), scrollGeneratedRevisionsIntoView);
+        if (onSaveGeneratedSet) {
+          void onSaveGeneratedSet(revisions, "revise").catch((err) => {
+            console.error("Failed to save revised set to History:", err);
+          });
+        }
       } else {
         toast.error("No revisions generated");
       }
@@ -1224,26 +1262,60 @@ export function MPASectionCard({
     resizeCardBody(() => setGeneratedRevisions(batch.revisions));
   };
 
-  // Use a generated revision (replace current statement)
-  const handleUseRevision = (revision: string, versionIndex: number) => {
-    Analytics.statementRevisionApplied(section.mpa);
-    setLocalText(revision);
-    updateSectionState(section.mpa, {
-      draftText: revision,
-      isDirty: true,
-    });
-    toast.success("Revision applied");
-    
-    // Track for style learning (fire-and-forget)
-    styleFeedback.trackRevisionSelected({
-      version: versionIndex + 1,
-      totalVersions: generatedRevisions.length,
-      charCount: revision.length,
-      category: mpaCategory,
-      aggressiveness: reviseAggressiveness,
-    });
+  // Switch the displayed AI Generate set (no token cost).
+  const viewStatementBatch = (index: number) => {
+    const batch = statementHistory[index];
+    if (!batch) return;
+    setActiveStatementIndex(index);
+    resizeCardBody(() => setGeneratedStatements(batch.revisions));
+  };
 
-    closeRevisePanelWithScroll();
+  // Use a generated revision — snapshot the current workspace first so the
+  // previous version remains recoverable from History (DD/MPA/HLR).
+  const handleUseRevision = async (revision: string, versionIndex: number) => {
+    if (applyingRevisionText !== null) return;
+    setApplyingRevisionText(revision);
+    try {
+      const previousText = localText.trim();
+      const shouldSnapshot =
+        previousText.length > 0 && previousText !== revision.trim();
+
+      if (shouldSnapshot) {
+        try {
+          await onCreateSnapshot(localText);
+          Analytics.statementSnapshotCreated(section.mpa);
+        } catch (error) {
+          console.error(error);
+          toast.error("Failed to save snapshot of current statement");
+          return;
+        }
+      }
+
+      Analytics.statementRevisionApplied(section.mpa);
+      setLocalText(revision);
+      updateSectionState(section.mpa, {
+        draftText: revision,
+        isDirty: true,
+      });
+      toast.success(
+        shouldSnapshot
+          ? "Revision applied · previous version saved"
+          : "Revision applied",
+      );
+
+      // Track for style learning (fire-and-forget)
+      styleFeedback.trackRevisionSelected({
+        version: versionIndex + 1,
+        totalVersions: generatedRevisions.length,
+        charCount: revision.length,
+        category: mpaCategory,
+        aggressiveness: reviseAggressiveness,
+      });
+
+      closeRevisePanelWithScroll();
+    } finally {
+      setApplyingRevisionText(null);
+    }
   };
 
   // Handle action selection for statement 1
@@ -1599,6 +1671,15 @@ export function MPASectionCard({
                       void resizeCardBodyAfter(async () => {
                         await handleModeChange("ai-assist");
                         setShowRevisePanel(false);
+                        // Restore last AI Generate set so prior results return free.
+                        setGeneratedStatements(
+                          statementHistory.length > 0
+                            ? (
+                                statementHistory[activeStatementIndex] ??
+                                statementHistory[statementHistory.length - 1]
+                              ).revisions
+                            : [],
+                        );
                       }, () => {
                         setTimeout(() => {
                           aiGeneratePanelRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
@@ -1778,51 +1859,31 @@ export function MPASectionCard({
 
             {/* History Panel - inline dropdown */}
             {showHistory && (
-              <div className="rounded-lg border bg-card shadow-lg overflow-hidden animate-in fade-in-0 duration-200">
-                <div className="p-4 border-b">
-                  <h4 className="font-medium text-sm">Snapshot History</h4>
-                  <p className="text-xs text-muted-foreground">
-                    {snapshots.length} snapshot{snapshots.length !== 1 && "s"}
-                  </p>
-                </div>
-                <div className="max-h-64 overflow-y-auto">
-                  {snapshots.length === 0 ? (
-                    <p className="p-3 text-sm text-muted-foreground text-center">
-                      No snapshots yet. Click the camera icon to save your current text.
-                    </p>
-                  ) : (
-                    snapshots.map((snap) => (
-                      <div
-                        key={snap.id}
-                        className="p-4 border-b last:border-b-0"
-                      >
-                        <div className="flex items-start justify-between gap-2 mb-1">
-                          <p className="text-xs text-muted-foreground">
-                            {formatDateTime(snap.created_at)}
-                          </p>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button type="button"
-                                onClick={() => handleRestoreSnapshot(snap)}
-                                className="text-[10px] px-1.5 py-0.5 rounded border bg-muted/50 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shrink-0"
-                              >
-                                <RotateCcw className="size-3.5 inline mr-1" />
-                                Restore
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Replace current statement with this version</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </div>
-                        <p className="text-sm select-text cursor-text whitespace-pre-wrap">
-                          {snap.statement_text}
-                        </p>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </div>
+              <EpbSnapshotHistoryPanel
+                snapshots={snapshots.map((snap) => ({
+                  id: snap.id,
+                  text: snap.statement_text,
+                  note: snap.note,
+                  created_at: snap.created_at,
+                }))}
+                onApply={(item) => {
+                  const snap = snapshots.find((s) => s.id === item.id);
+                  if (snap) {
+                    handleRestoreSnapshot(snap);
+                    return;
+                  }
+                  // Fallback if list drifted — still apply the text.
+                  Analytics.statementSnapshotRestored(section.mpa);
+                  updateSectionState(section.mpa, {
+                    draftText: item.text,
+                    isDirty: true,
+                  });
+                  setShowHistory(false);
+                  toast.success("Restored from snapshot");
+                }}
+                applyLabel="Restore"
+                variant="elevated"
+              />
             )}
 
             {/* Saved Examples Panel */}
@@ -2120,11 +2181,15 @@ export function MPASectionCard({
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <button type="button"
-                                    onClick={() => handleUseRevision(revision, index)}
-                                    disabled={isUseThisClosing}
+                                    onClick={() => void handleUseRevision(revision, index)}
+                                    disabled={isUseThisClosing || applyingRevisionText !== null}
                                     className="h-6 px-2 rounded text-[10px] bg-primary text-primary-foreground hover:bg-primary/90 transition-colors inline-flex items-center disabled:opacity-50"
                                   >
-                                    <Check className="size-4 mr-1.5" />
+                                    {applyingRevisionText === revision ? (
+                                      <Loader2 className="size-4 mr-1.5 animate-spin" />
+                                    ) : (
+                                      <Check className="size-4 mr-1.5" />
+                                    )}
                                     Use This
                                   </button>
                                 </TooltipTrigger>
@@ -2454,6 +2519,37 @@ export function MPASectionCard({
                       )}
                     </div>
                     <FormattingViolationNote flags={statementFormattingViolations} />
+                    {statementHistory.length > 1 && (
+                      <div className="flex items-center justify-between gap-2 rounded-md border border-dashed bg-background/60 px-2.5 py-1.5">
+                        <span className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                          <History className="size-3.5 shrink-0" aria-hidden="true" />
+                          Set {activeStatementIndex + 1} of {statementHistory.length}
+                          <span className="hidden sm:inline text-muted-foreground/70">
+                            · revisit past sets free
+                          </span>
+                        </span>
+                        <div className="flex items-center gap-1">
+                          <button
+                            type="button"
+                            onClick={() => viewStatementBatch(activeStatementIndex - 1)}
+                            disabled={activeStatementIndex === 0}
+                            aria-label="View previous generated set"
+                            className="h-6 w-6 inline-flex items-center justify-center rounded hover:bg-muted transition-colors disabled:opacity-40 disabled:pointer-events-none"
+                          >
+                            <ChevronLeft className="size-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => viewStatementBatch(activeStatementIndex + 1)}
+                            disabled={activeStatementIndex >= statementHistory.length - 1}
+                            aria-label="View next generated set"
+                            className="h-6 w-6 inline-flex items-center justify-center rounded hover:bg-muted transition-colors disabled:opacity-40 disabled:pointer-events-none"
+                          >
+                            <ChevronRight className="size-4" />
+                          </button>
+                        </div>
+                      </div>
+                    )}
                     {generatedStatements.map((statement, index) => (
                       <div
                         key={`stmt-${statement.slice(0, 48)}-${statement.length}`}

--- a/src/components/team/add-team-accomplishment-dialog.tsx
+++ b/src/components/team/add-team-accomplishment-dialog.tsx
@@ -32,6 +32,7 @@ import { handleStaleDeploymentError } from "@/lib/stale-deployment";
 import {
   DEFAULT_ACTION_VERBS,
   ENTRY_MGAS,
+  ENTRY_VERB_CATEGORIES,
   getActiveCycleYear,
 } from "@/lib/constants";
 import { composeImpactString } from "@/lib/stewardship-impact";
@@ -54,38 +55,7 @@ import {
 } from "@/components/entries/stewardship-impact-fields";
 
 // Role-based verb suggestions to help supervisors choose appropriate verbs
-const VERB_CATEGORIES = {
-  leadership: {
-    label: "Leadership",
-    verbs: ["Led", "Directed", "Managed", "Supervised", "Spearheaded", "Championed"],
-    description: "For members who took charge or led the effort",
-  },
-  collaboration: {
-    label: "Collaboration",
-    verbs: ["Co-led", "Partnered", "Collaborated", "Coordinated", "Teamed"],
-    description: "For members who shared leadership or worked closely together",
-  },
-  support: {
-    label: "Support",
-    verbs: ["Supported", "Assisted", "Aided", "Helped", "Contributed"],
-    description: "For members who provided key support",
-  },
-  execution: {
-    label: "Execution",
-    verbs: ["Executed", "Performed", "Completed", "Accomplished", "Delivered"],
-    description: "For members who carried out specific tasks",
-  },
-  expertise: {
-    label: "Expertise",
-    verbs: ["Analyzed", "Developed", "Designed", "Engineered", "Implemented"],
-    description: "For members who provided technical expertise",
-  },
-  mentorship: {
-    label: "Mentorship",
-    verbs: ["Mentored", "Trained", "Guided", "Coached", "Instructed"],
-    description: "For members who trained or mentored others",
-  },
-};
+const VERB_CATEGORIES = ENTRY_VERB_CATEGORIES;
 
 interface TeamMemberOption {
   id: string;

--- a/src/lib/__tests__/award-recognition-education.test.ts
+++ b/src/lib/__tests__/award-recognition-education.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeRecognitionPhrase,
+  formatAwardShortLabel,
+  mergeRecognitionIntoOutcome,
+  type AwardRecognitionInput,
+} from "@/lib/award-recognition";
+import {
+  normalizeEducationContext,
+  sanitizeEducationContext,
+  educationContextSummary,
+  formatEducationContextForPrompt,
+} from "@/lib/education-context";
+import { awardsMatchRatee } from "@/lib/accomplishment-award-link";
+
+function award(
+  partial: Partial<AwardRecognitionInput> & Pick<AwardRecognitionInput, "id" | "award_type">
+): AwardRecognitionInput {
+  return {
+    award_name: null,
+    coin_presenter: null,
+    coin_date: null,
+    quarter: null,
+    award_year: null,
+    award_level: null,
+    is_team_award: false,
+    ...partial,
+  };
+}
+
+describe("composeRecognitionPhrase", () => {
+  it("returns null for empty list", () => {
+    expect(composeRecognitionPhrase([])).toBeNull();
+  });
+
+  it("formats a single coin", () => {
+    expect(
+      composeRecognitionPhrase([
+        award({
+          id: "1",
+          award_type: "coin",
+          coin_presenter: "83 NOS/CC",
+        }),
+      ])
+    ).toBe("earning a 83 NOS/CC coin");
+  });
+
+  it("formats a team coin contribution", () => {
+    expect(
+      composeRecognitionPhrase([
+        award({
+          id: "1",
+          award_type: "coin",
+          coin_presenter: "Wg/CC",
+          is_team_award: true,
+        }),
+      ])
+    ).toBe("contributed to a Wg/CC team coin");
+  });
+
+  it("combines multiple competitive awards", () => {
+    const phrase = composeRecognitionPhrase([
+      award({
+        id: "1",
+        award_type: "quarterly",
+        award_level: "group",
+        quarter: "Q1",
+        award_year: 2026,
+      }),
+      award({
+        id: "2",
+        award_type: "annual",
+        award_level: "group",
+        award_year: 2026,
+      }),
+    ]);
+    expect(phrase).toContain("earning");
+    expect(phrase).toContain("Gp");
+    expect(phrase).toContain("awards");
+  });
+
+  it("formats short labels for chips", () => {
+    expect(
+      formatAwardShortLabel(
+        award({
+          id: "1",
+          award_type: "special",
+          award_name: "John Levitow Award",
+        })
+      )
+    ).toBe("John Levitow Award");
+  });
+});
+
+describe("mergeRecognitionIntoOutcome", () => {
+  it("sets outcome when empty", () => {
+    expect(mergeRecognitionIntoOutcome("", "earning a Gp qtr award", null)).toBe(
+      "earning a Gp qtr award"
+    );
+  });
+
+  it("does not clobber existing outcome that already includes phrase", () => {
+    expect(
+      mergeRecognitionIntoOutcome(
+        "cut cycle 40%; earning a Gp qtr award",
+        "earning a Gp qtr award",
+        "earning a Gp qtr award"
+      )
+    ).toBe("cut cycle 40%; earning a Gp qtr award");
+  });
+
+  it("appends new recognition without wiping user text", () => {
+    expect(
+      mergeRecognitionIntoOutcome("cut cycle 40%", "earning a Gp qtr award", null)
+    ).toBe("cut cycle 40%; earning a Gp qtr award");
+  });
+
+  it("replaces previous auto phrase", () => {
+    expect(
+      mergeRecognitionIntoOutcome(
+        "cut cycle 40%; earning a Sq qtr award",
+        "earning a Gp qtr award",
+        "earning a Sq qtr award"
+      )
+    ).toBe("cut cycle 40%; earning a Gp qtr award");
+  });
+
+  it("clears auto phrase when awards removed", () => {
+    expect(
+      mergeRecognitionIntoOutcome(
+        "earning a Gp qtr award",
+        null,
+        "earning a Gp qtr award"
+      )
+    ).toBe("");
+  });
+});
+
+describe("education context", () => {
+  it("normalizes and drops empty program", () => {
+    expect(normalizeEducationContext({ program: "  " })).toBeNull();
+    expect(sanitizeEducationContext({ program: "CCAF", credits: -1 })).toEqual({
+      program: "CCAF",
+    });
+  });
+
+  it("keeps positive credits with unit", () => {
+    expect(
+      normalizeEducationContext({
+        program: "CCAF AAS",
+        credits: 12,
+        unit: "semester_hours",
+        completed_date: "2026-05-01",
+      })
+    ).toEqual({
+      program: "CCAF AAS",
+      credits: 12,
+      unit: "semester_hours",
+      completed_date: "2026-05-01",
+    });
+  });
+
+  it("summarizes for badges", () => {
+    expect(
+      educationContextSummary({
+        program: "ALS",
+        credits: 5,
+        unit: "credit_hours",
+      })
+    ).toBe("ALS (5 cr)");
+  });
+
+  it("formats for assessment prompts", () => {
+    const text = formatEducationContextForPrompt({
+      program: "CCAF",
+      credits: 6,
+      unit: "credit_hours",
+    });
+    expect(text).toContain("CCAF");
+    expect(text).toContain("mission application");
+  });
+});
+
+describe("awardsMatchRatee", () => {
+  it("allows empty award list", () => {
+    expect(awardsMatchRatee([], [], "user-1", null)).toEqual({ ok: true });
+  });
+
+  it("rejects awards for a different ratee", () => {
+    const result = awardsMatchRatee(
+      [
+        {
+          id: "a1",
+          recipient_profile_id: "other",
+          recipient_team_member_id: null,
+        },
+      ],
+      ["a1"],
+      "user-1",
+      null
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts awards for the matching profile", () => {
+    expect(
+      awardsMatchRatee(
+        [
+          {
+            id: "a1",
+            recipient_profile_id: "user-1",
+            recipient_team_member_id: null,
+          },
+        ],
+        ["a1"],
+        "user-1",
+        null
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts awards for matching managed member", () => {
+    expect(
+      awardsMatchRatee(
+        [
+          {
+            id: "a1",
+            recipient_profile_id: null,
+            recipient_team_member_id: "tm-1",
+          },
+        ],
+        ["a1"],
+        null,
+        "tm-1"
+      )
+    ).toEqual({ ok: true });
+  });
+});

--- a/src/lib/__tests__/epb-generated-set-history.test.ts
+++ b/src/lib/__tests__/epb-generated-set-history.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_GENERATED_STATEMENT_SETS,
+  buildGeneratedSetSnapshotNote,
+  getGeneratedSetDisplayLabel,
+  groupSnapshotsForHistory,
+  idsOfGeneratedSetsBeyondLimit,
+  idsOfManualSnapshotsBeyondLimit,
+  isGeneratedSetSnapshotNote,
+  listGeneratedSetBatchIdsNewestFirst,
+  parseGeneratedSetBatchId,
+} from "@/lib/epb-generated-set-history";
+
+describe("epb-generated-set-history", () => {
+  it("builds and parses generated-set notes", () => {
+    const note = buildGeneratedSetSnapshotNote("revise", "batch-1", 2);
+    expect(isGeneratedSetSnapshotNote(note)).toBe(true);
+    expect(parseGeneratedSetBatchId(note)).toBe("batch-1");
+    expect(getGeneratedSetDisplayLabel(note)).toBe("Generated · Revise · Option 2");
+  });
+
+  it("keeps only the newest 3 AI sets when pruning", () => {
+    const snaps = [
+      { id: "a1", note: buildGeneratedSetSnapshotNote("generate", "b1", 1), created_at: "2026-01-01T00:00:00Z" },
+      { id: "a2", note: buildGeneratedSetSnapshotNote("generate", "b1", 2), created_at: "2026-01-01T00:00:01Z" },
+      { id: "b1", note: buildGeneratedSetSnapshotNote("revise", "b2", 1), created_at: "2026-01-02T00:00:00Z" },
+      { id: "c1", note: buildGeneratedSetSnapshotNote("revise", "b3", 1), created_at: "2026-01-03T00:00:00Z" },
+      { id: "d1", note: buildGeneratedSetSnapshotNote("revise", "b4", 1), created_at: "2026-01-04T00:00:00Z" },
+      { id: "manual", note: null, created_at: "2026-01-05T00:00:00Z" },
+    ];
+
+    expect(listGeneratedSetBatchIdsNewestFirst(snaps)).toEqual(["b4", "b3", "b2", "b1"]);
+    expect(idsOfGeneratedSetsBeyondLimit(snaps, MAX_GENERATED_STATEMENT_SETS).sort()).toEqual([
+      "a1",
+      "a2",
+    ]);
+  });
+
+  it("prunes only manual snapshots against the manual cap", () => {
+    const snaps = [
+      { id: "m1", note: null, created_at: "2026-01-01T00:00:00Z" },
+      { id: "m2", note: null, created_at: "2026-01-02T00:00:00Z" },
+      { id: "m3", note: null, created_at: "2026-01-03T00:00:00Z" },
+      {
+        id: "ai",
+        note: buildGeneratedSetSnapshotNote("revise", "b1", 1),
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+    expect(idsOfManualSnapshotsBeyondLimit(snaps, 2)).toEqual(["m1"]);
+  });
+
+  it("groups AI sets into expandable rows and keeps manuals flat", () => {
+    const groups = groupSnapshotsForHistory([
+      {
+        id: "a1",
+        text: "one",
+        note: buildGeneratedSetSnapshotNote("revise", "b1", 1),
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "a3",
+        text: "three",
+        note: buildGeneratedSetSnapshotNote("revise", "b1", 3),
+        created_at: "2026-01-01T00:00:02Z",
+      },
+      {
+        id: "a2",
+        text: "two",
+        note: buildGeneratedSetSnapshotNote("revise", "b1", 2),
+        created_at: "2026-01-01T00:00:01Z",
+      },
+      {
+        id: "m1",
+        text: "workspace",
+        note: null,
+        created_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: "g1",
+        text: "gen",
+        note: buildGeneratedSetSnapshotNote("generate", "b2", 1),
+        created_at: "2026-01-03T00:00:00Z",
+      },
+    ]);
+
+    expect(groups.map((g) => g.kind)).toEqual(["ai-set", "manual", "ai-set"]);
+    expect(groups[0]).toMatchObject({
+      kind: "ai-set",
+      title: "Generated · Generate",
+      batchId: "b2",
+    });
+    expect(groups[1]).toMatchObject({ kind: "manual" });
+    expect(groups[2]).toMatchObject({
+      kind: "ai-set",
+      title: "Generated · Revise",
+      batchId: "b1",
+    });
+    if (groups[2].kind === "ai-set") {
+      expect(groups[2].items.map((i) => i.optionIndex)).toEqual([1, 2, 3]);
+      expect(groups[2].items.map((i) => i.text)).toEqual(["one", "two", "three"]);
+    }
+  });
+});

--- a/src/lib/__tests__/epb-generation-readiness.test.ts
+++ b/src/lib/__tests__/epb-generation-readiness.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  entriesNeedingAssessment,
   evaluateEpbGenerationReadiness,
   getMpasWithExistingStatements,
   MIN_ELIGIBLE_MPAS,
@@ -124,7 +125,7 @@ describe("evaluateEpbGenerationReadiness", () => {
     ).toBe(true);
   });
 
-  it("warns about empty MPAs, unassessed, and stale entries without blocking", () => {
+  it("warns about empty MPAs without blocking; tracks unassessed/stale counts", () => {
     const result = evaluateEpbGenerationReadiness([
       assessed("executing_mission", 80),
       assessed("leading_people", 78),
@@ -142,8 +143,21 @@ describe("evaluateEpbGenerationReadiness", () => {
     expect(result.staleCount).toBe(1);
     const warningText = result.warnings.join(" ");
     expect(warningText).toContain("Improving the Unit"); // empty MPA
-    expect(warningText).toContain("no AI assessment");
-    expect(warningText).toContain("edited after assessment");
+    expect(warningText).not.toContain("no AI assessment");
+    expect(warningText).not.toContain("edited after assessment");
+  });
+
+  it("lists ACA entries that need a fresh assessment", () => {
+    const fresh = assessed("executing_mission", 80);
+    const missing = entry({ mpa: "managing_resources" });
+    const stale = assessed("leading_people", 65, {
+      assessed_at: "2026-03-02T00:00:00.000Z",
+      updated_at: "2026-03-05T00:00:00.000Z",
+    });
+    expect(entriesNeedingAssessment([fresh, missing, stale])).toEqual([
+      missing.id,
+      stale.id,
+    ]);
   });
 
   it("marks per-MPA strength using the portfolio quality floor", () => {

--- a/src/lib/__tests__/generate-epb-run.test.ts
+++ b/src/lib/__tests__/generate-epb-run.test.ts
@@ -5,8 +5,11 @@ import {
   editableFromRecords,
   buildMpaCustomContext,
   buildGroupedMpaContexts,
+  appendSentenceNote,
   combineVersions,
   extractVersionArrays,
+  moveAccomplishmentToSlot,
+  reorderSentenceGroups,
 } from "../generate-epb-run";
 import type { EpbPlan, PlanAccomplishmentRecord } from "../plan-epb";
 import type { AccomplishmentMPARelevancy } from "@/types/database";
@@ -59,11 +62,14 @@ describe("planToEditable + editableToMpaSelections", () => {
     ],
   };
 
-  it("maps a plan to enabled editable groups", () => {
+  it("maps a plan to enabled editable groups and seeds empty core MPAs", () => {
     const editable = planToEditable(plan);
     expect(editable.executing_mission.enabled).toBe(true);
     expect(editable.executing_mission.groups).toEqual([["a", "b"], ["c"]]);
+    expect(editable.executing_mission.notes).toEqual(["", ""]);
     expect(editable.leading_people.groups).toEqual([["d"]]);
+    expect(editable.managing_resources.enabled).toBe(false);
+    expect(editable.improving_unit.groups).toEqual([]);
   });
 
   it("preserves groups and derives sentence count from non-empty groups", () => {
@@ -71,6 +77,7 @@ describe("planToEditable + editableToMpaSelections", () => {
     const em = selections.find((s) => s.mpaKey === "executing_mission")!;
     expect(em.accomplishmentIds).toEqual(["a", "b", "c"]);
     expect(em.groups).toEqual([["a", "b"], ["c"]]);
+    expect(em.notes).toEqual(["", ""]);
     expect(em.sentenceCount).toBe(2);
     const lp = selections.find((s) => s.mpaKey === "leading_people")!;
     expect(lp.sentenceCount).toBe(1);
@@ -82,6 +89,15 @@ describe("planToEditable + editableToMpaSelections", () => {
     editable.executing_mission.enabled = false;
     editable.leading_people.groups = [[]];
     expect(editableToMpaSelections(editable)).toHaveLength(0);
+  });
+
+  it("carries trimmed per-sentence notes into selections", () => {
+    const editable = planToEditable(plan);
+    editable.executing_mission.notes = ["  emphasize tempo  ", "leave out manning"];
+    const em = editableToMpaSelections(editable).find(
+      (s) => s.mpaKey === "executing_mission"
+    )!;
+    expect(em.notes).toEqual(["emphasize tempo", "leave out manning"]);
   });
 });
 
@@ -150,8 +166,18 @@ describe("buildMpaCustomContext", () => {
   });
 });
 
-describe("buildGroupedMpaContexts", () => {
-  it("splits sentence groups into customContext and customContext2", () => {
+describe("appendSentenceNote + buildGroupedMpaContexts", () => {
+  it("appends rater guidance under the accomplishment body", () => {
+    expect(appendSentenceNote("Led: x", "stress early finish")).toContain(
+      "ADDITIONAL GUIDANCE FROM RATER"
+    );
+    expect(appendSentenceNote("Led: x", "stress early finish")).toContain(
+      "stress early finish"
+    );
+    expect(appendSentenceNote("Led: x", "  ")).toBe("Led: x");
+  });
+
+  it("splits sentence groups into customContext and customContext2 with notes", () => {
     const byId = new Map(
       [
         record("a", "executing_mission", {
@@ -168,9 +194,72 @@ describe("buildGroupedMpaContexts", () => {
       customContext: "Led: first",
       customContext2: "Built: second",
     });
+    expect(
+      buildGroupedMpaContexts([["a"], ["b"]], byId, ["note one", "note two"])
+    ).toEqual({
+      customContext:
+        "Led: first\n\nADDITIONAL GUIDANCE FROM RATER:\nnote one",
+      customContext2:
+        "Built: second\n\nADDITIONAL GUIDANCE FROM RATER:\nnote two",
+    });
     expect(buildGroupedMpaContexts([["a"]], byId)).toEqual({
       customContext: "Led: first",
     });
+  });
+});
+
+describe("reorderSentenceGroups + moveAccomplishmentToSlot", () => {
+  const base = planToEditable({
+    mpas: [
+      {
+        mpaKey: "executing_mission",
+        sentences: [
+          { accomplishmentIds: ["a"], rationale: "" },
+          { accomplishmentIds: ["b"], rationale: "" },
+        ],
+      },
+      {
+        mpaKey: "leading_people",
+        sentences: [{ accomplishmentIds: ["c"], rationale: "" }],
+      },
+    ],
+  });
+
+  it("reorders sentences and keeps notes aligned", () => {
+    const withNotes = {
+      ...base,
+      executing_mission: {
+        ...base.executing_mission,
+        notes: ["first note", "second note"],
+      },
+    };
+    const next = reorderSentenceGroups(withNotes, "executing_mission", 0, 1);
+    expect(next.executing_mission.groups).toEqual([["b"], ["a"]]);
+    expect(next.executing_mission.notes).toEqual([
+      "second note",
+      "first note",
+    ]);
+  });
+
+  it("moves an accomplishment across MPAs and enables the destination", () => {
+    const next = moveAccomplishmentToSlot(
+      base,
+      { mpaKey: "executing_mission", groupIdx: 0, id: "a" },
+      { mpaKey: "improving_unit", groupIdx: 0 }
+    );
+    expect(next.executing_mission.groups[0]).toEqual([]);
+    expect(next.improving_unit.enabled).toBe(true);
+    expect(next.improving_unit.groups).toEqual([["a"]]);
+  });
+
+  it("moves an accomplishment onto a new second sentence in another MPA", () => {
+    const next = moveAccomplishmentToSlot(
+      base,
+      { mpaKey: "executing_mission", groupIdx: 1, id: "b" },
+      { mpaKey: "leading_people", groupIdx: 1 }
+    );
+    expect(next.executing_mission.groups[1]).toEqual([]);
+    expect(next.leading_people.groups).toEqual([["c"], ["b"]]);
   });
 });
 

--- a/src/lib/accomplishment-award-link.ts
+++ b/src/lib/accomplishment-award-link.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers for linking awards to accomplishments (authz checks).
+ */
+
+export type AwardRecipientRow = {
+  id: string;
+  recipient_profile_id: string | null;
+  recipient_team_member_id: string | null;
+};
+
+/**
+ * Ensure every award belongs to the accomplishment ratee
+ * (profile XOR managed member).
+ */
+export function awardsMatchRatee(
+  awards: AwardRecipientRow[],
+  expectedIds: string[],
+  rateeUserId: string | null,
+  rateeTeamMemberId: string | null
+): { ok: true } | { ok: false; error: string } {
+  const unique = [...new Set(expectedIds)];
+  if (unique.length === 0) return { ok: true };
+
+  if (awards.length !== unique.length) {
+    return { ok: false, error: "One or more awards were not found" };
+  }
+
+  const byId = new Map(awards.map((a) => [a.id, a]));
+  for (const id of unique) {
+    const row = byId.get(id);
+    if (!row) {
+      return { ok: false, error: "One or more awards were not found" };
+    }
+    const matchesProfile =
+      !!rateeUserId &&
+      !!row.recipient_profile_id &&
+      row.recipient_profile_id === rateeUserId;
+    const matchesManaged =
+      !!rateeTeamMemberId &&
+      !!row.recipient_team_member_id &&
+      row.recipient_team_member_id === rateeTeamMemberId;
+    if (!matchesProfile && !matchesManaged) {
+      return {
+        ok: false,
+        error: "Cannot link an award that does not belong to this ratee",
+      };
+    }
+  }
+
+  return { ok: true };
+}

--- a/src/lib/assess-accomplishment-prompt.ts
+++ b/src/lib/assess-accomplishment-prompt.ts
@@ -16,7 +16,8 @@ import {
   formatStewardshipImpactForPrompt,
   normalizeStewardshipImpact,
 } from "@/lib/stewardship-impact";
-import type { Rank, StewardshipImpact } from "@/types/database";
+import { formatEducationContextForPrompt } from "@/lib/education-context";
+import type { EducationContext, Rank, StewardshipImpact } from "@/types/database";
 
 export interface AccomplishmentAssessmentInput {
   action_verb: string;
@@ -25,6 +26,7 @@ export interface AccomplishmentAssessmentInput {
   metrics: string | null;
   mpa: string;
   stewardship_impact?: StewardshipImpact | null;
+  education_context?: EducationContext | null;
 }
 
 /** Build the assessment prompt for an individual accomplishment using rank-appropriate ACA rubric */
@@ -103,11 +105,14 @@ export function buildAccomplishmentAssessmentPrompt(
     accomplishment.impact,
     accomplishment.metrics
   );
+  const educationBlock = formatEducationContextForPrompt(
+    accomplishment.education_context
+  );
 
   const accomplishmentText = `
 Action: ${accomplishment.action_verb}
 Details: ${accomplishment.details}
-${impactBlock}
+${educationBlock ? `${educationBlock}\n` : ""}${impactBlock}
 Currently categorized as: ${DEFAULT_MPA_DESCRIPTIONS[accomplishment.mpa]?.title || accomplishment.mpa}
 `.trim();
 

--- a/src/lib/award-recognition.ts
+++ b/src/lib/award-recognition.ts
@@ -1,0 +1,217 @@
+/**
+ * Compose concise recognition phrases from linked awards for accomplishment impact.
+ * Mirrors EPB generate guidance (combine multiple awards; include level; team framing).
+ */
+
+import type { Award, AwardLevel, AwardType } from "@/types/database";
+
+const LEVEL_ABBREV: Record<AwardLevel, string> = {
+  squadron: "Sq",
+  group: "Gp",
+  wing: "Wg",
+  majcom: "MAJCOM",
+  haf: "HAF",
+};
+
+export type AwardRecognitionInput = Pick<
+  Award,
+  | "id"
+  | "award_type"
+  | "award_name"
+  | "coin_presenter"
+  | "coin_date"
+  | "quarter"
+  | "award_year"
+  | "award_level"
+  | "is_team_award"
+>;
+
+function levelLabel(level: AwardLevel | null | undefined): string {
+  if (!level) return "";
+  return LEVEL_ABBREV[level] || level;
+}
+
+/** Short label for a single award (chips / pickers). */
+export function formatAwardShortLabel(award: AwardRecognitionInput): string {
+  const team = award.is_team_award ? " team" : "";
+  if (award.award_type === "coin") {
+    const who = award.coin_presenter?.trim() || "unit";
+    return `${who} coin${team}`;
+  }
+  const lvl = levelLabel(award.award_level);
+  const period =
+    award.award_type === "quarterly" && award.quarter
+      ? ` ${award.quarter}`
+      : "";
+  const year = award.award_year ? ` ${award.award_year}` : "";
+  const typeWord =
+    award.award_type === "quarterly"
+      ? "qtr"
+      : award.award_type === "annual"
+        ? "annual"
+        : "special";
+  const name = award.award_name?.trim();
+  if (name && award.award_type === "special") {
+    return `${name}${team}`;
+  }
+  return `${lvl ? `${lvl} ` : ""}${typeWord}${period}${year}${team}`.trim();
+}
+
+function formatCoinPhrase(award: AwardRecognitionInput): string {
+  const presenter = award.coin_presenter?.trim() || "unit leadership";
+  return award.is_team_award
+    ? `contributed to a ${presenter} team coin`
+    : `earning a ${presenter} coin`;
+}
+
+function formatCompetitivePhrase(awards: AwardRecognitionInput[]): string {
+  if (awards.length === 0) return "";
+
+  if (awards.length === 1) {
+    const a = awards[0];
+    const lvl = levelLabel(a.award_level);
+    const period =
+      a.award_type === "quarterly" && a.quarter ? ` ${a.quarter}` : "";
+    const typeWord =
+      a.award_type === "quarterly"
+        ? "qtr"
+        : a.award_type === "annual"
+          ? "annual"
+          : "special";
+    const name = a.award_name?.trim();
+    const core =
+      a.award_type === "special" && name
+        ? name
+        : `${lvl ? `${lvl} ` : ""}${typeWord}${period} award`;
+    return a.is_team_award
+      ? `contributed to ${core}`
+      : `earning ${core.startsWith("a") || core.startsWith("A") ? "" : "a "}${core}`.replace(
+          "earning  ",
+          "earning "
+        );
+  }
+
+  // Group competitive awards: count by level+type
+  const groups = new Map<string, { count: number; team: boolean }>();
+  for (const a of awards) {
+    const lvl = levelLabel(a.award_level) || "unit";
+    const typeWord =
+      a.award_type === "quarterly"
+        ? "qtr"
+        : a.award_type === "annual"
+          ? "annual"
+          : "special";
+    const key = `${lvl} ${typeWord}`;
+    const prev = groups.get(key) || { count: 0, team: false };
+    groups.set(key, {
+      count: prev.count + 1,
+      team: prev.team || a.is_team_award,
+    });
+  }
+
+  const parts = Array.from(groups.entries()).map(([key, { count, team }]) => {
+    const label = count > 1 ? `${count} ${key}` : key;
+    return team ? `${label} team` : label;
+  });
+
+  const hasTeam = awards.some((a) => a.is_team_award);
+  const joined =
+    parts.length === 1
+      ? parts[0]
+      : parts.length === 2
+        ? `${parts[0]} & ${parts[1]}`
+        : `${parts.slice(0, -1).join(", ")} & ${parts[parts.length - 1]}`;
+
+  return hasTeam && awards.every((a) => a.is_team_award)
+    ? `contributed to ${joined} awards`
+    : `earning ${joined} awards`;
+}
+
+/**
+ * Compose a single concise recognition clause from 0–N awards.
+ * Returns null when empty.
+ */
+export function composeRecognitionPhrase(
+  awards: AwardRecognitionInput[]
+): string | null {
+  if (!awards.length) return null;
+
+  const coins = awards.filter((a) => a.award_type === "coin");
+  const competitive = awards.filter((a) => a.award_type !== "coin");
+
+  const parts: string[] = [];
+  if (competitive.length > 0) {
+    parts.push(formatCompetitivePhrase(competitive));
+  }
+  if (coins.length === 1) {
+    parts.push(formatCoinPhrase(coins[0]));
+  } else if (coins.length > 1) {
+    const presenters = coins
+      .map((c) => c.coin_presenter?.trim() || "unit")
+      .filter(Boolean);
+    const unique = [...new Set(presenters)];
+    const coinPart =
+      unique.length === 1
+        ? `${coins.length} ${unique[0]} coins`
+        : `${coins.length} coins (${unique.join(", ")})`;
+    parts.push(
+      coins.every((c) => c.is_team_award)
+        ? `contributed to ${coinPart}`
+        : `earning ${coinPart}`
+    );
+  }
+
+  if (parts.length === 0) return null;
+  return parts.join("; ");
+}
+
+/**
+ * Merge recognition into stewardship outcome without clobbering user text.
+ * If outcome already contains the phrase, leave it. If outcome empty, set it.
+ * If outcome filled and recognition new, append with "; ".
+ */
+export function mergeRecognitionIntoOutcome(
+  outcome: string | undefined,
+  recognition: string | null,
+  previousRecognition: string | null
+): string {
+  const base = (outcome ?? "").trim();
+  const next = recognition?.trim() || "";
+  const prev = previousRecognition?.trim() || "";
+
+  if (!next) {
+    // Remove prior auto phrase if it was the whole outcome or a trailing segment
+    if (!prev || !base) return base;
+    if (base === prev) return "";
+    if (base.endsWith(`; ${prev}`)) return base.slice(0, -(prev.length + 2)).trim();
+    if (base.endsWith(prev) && base.length > prev.length) {
+      return base.slice(0, -prev.length).replace(/[;\s]+$/, "").trim();
+    }
+    return base;
+  }
+
+  if (!base) return next;
+  if (base.includes(next)) return base;
+
+  // Replace previous auto-injected phrase
+  if (prev && base.includes(prev)) {
+    return base.replace(prev, next).replace(/;\s*;/g, ";").trim();
+  }
+
+  return `${base}; ${next}`;
+}
+
+export function awardTypeLabel(type: AwardType): string {
+  switch (type) {
+    case "coin":
+      return "Coin";
+    case "quarterly":
+      return "Quarterly";
+    case "annual":
+      return "Annual";
+    case "special":
+      return "Special";
+    default:
+      return type;
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -201,33 +201,111 @@ export const AI_MODELS = [
 
 export type AIModel = (typeof AI_MODELS)[number];
 
-export const DEFAULT_ACTION_VERBS = [
+/** Shared verb pool for entry + team accomplishment intake (custom verbs still allowed). */
+export const ENTRY_ACTION_VERBS = [
+  // Leadership
   "Led",
   "Managed",
   "Directed",
-  "Coordinated",
-  "Executed",
+  "Supervised",
   "Spearheaded",
   "Championed",
   "Orchestrated",
+  "Commanded",
+  // Collaboration
+  "Coordinated",
+  "Co-led",
+  "Partnered",
+  "Collaborated",
+  "Teamed",
+  "Unified",
+  // Execution
+  "Executed",
+  "Performed",
+  "Completed",
+  "Accomplished",
+  "Delivered",
+  "Operationalized",
+  "Synchronized",
+  "Integrated",
+  // Expertise / build
   "Developed",
   "Implemented",
   "Established",
+  "Designed",
+  "Engineered",
+  "Analyzed",
+  "Resolved",
+  // Improvement
   "Transformed",
   "Pioneered",
   "Streamlined",
   "Optimized",
   "Enhanced",
   "Improved",
-  "Supervised",
+  "Modernized",
+  "Institutionalized",
+  // Mentorship / teaching
   "Trained",
   "Mentored",
   "Guided",
+  "Coached",
+  "Instructed",
   "Supported",
   "Facilitated",
-  "Analyzed",
-  "Resolved",
-];
+  "Assisted",
+  "Aided",
+  "Contributed",
+  "Helped",
+  // Mission application of education / skills
+  "Applied",
+  "Leveraged",
+  "Translated",
+  "Certified",
+  "Qualified",
+  "Standardized",
+  "Documented",
+  "Briefed",
+  "Presented",
+  "Deployed",
+] as const;
+
+/** @deprecated Prefer ENTRY_ACTION_VERBS — kept as mutable copy for ComboboxInput options. */
+export const DEFAULT_ACTION_VERBS: string[] = [...ENTRY_ACTION_VERBS];
+
+/** Suggested verb groups for team multi-add (options still come from ENTRY_ACTION_VERBS). */
+export const ENTRY_VERB_CATEGORIES = {
+  leadership: {
+    label: "Leadership",
+    verbs: ["Led", "Directed", "Managed", "Supervised", "Spearheaded", "Championed"],
+    description: "For members who took charge or led the effort",
+  },
+  collaboration: {
+    label: "Collaboration",
+    verbs: ["Co-led", "Partnered", "Collaborated", "Coordinated", "Teamed"],
+    description: "For members who shared leadership or worked closely together",
+  },
+  support: {
+    label: "Support",
+    verbs: ["Supported", "Assisted", "Aided", "Helped", "Contributed"],
+    description: "For members who provided key support",
+  },
+  execution: {
+    label: "Execution",
+    verbs: ["Executed", "Performed", "Completed", "Accomplished", "Delivered"],
+    description: "For members who carried out specific tasks",
+  },
+  expertise: {
+    label: "Expertise",
+    verbs: ["Analyzed", "Developed", "Designed", "Engineered", "Implemented"],
+    description: "For members who provided technical expertise",
+  },
+  mentorship: {
+    label: "Mentorship",
+    verbs: ["Mentored", "Trained", "Guided", "Coached", "Instructed"],
+    description: "For members who trained or mentored others",
+  },
+} as const;
 
 export const MAX_STATEMENT_CHARACTERS = 350;
 export const MAX_HLR_CHARACTERS = 250;

--- a/src/lib/education-context.ts
+++ b/src/lib/education-context.ts
@@ -1,0 +1,113 @@
+/**
+ * Optional education context on accomplishments.
+ * Action/details remain mission work; this metadata ties schooling to that work.
+ */
+
+import type { EducationContext } from "@/types/database";
+
+export type { EducationContext };
+export type EducationCreditUnit = NonNullable<EducationContext["unit"]>;
+
+export const EDUCATION_CREDIT_UNITS: {
+  value: EducationCreditUnit;
+  label: string;
+}[] = [
+  { value: "credit_hours", label: "Credit hours" },
+  { value: "semester_hours", label: "Semester hours" },
+  { value: "contact_hours", label: "Contact hours" },
+];
+
+export const EMPTY_EDUCATION_CONTEXT: EducationContext = {
+  program: "",
+};
+
+export function hasEducationContext(
+  value: EducationContext | null | undefined
+): boolean {
+  return !!value?.program?.trim();
+}
+
+/** Normalize DB/API JSON into a safe EducationContext or null when empty. */
+export function normalizeEducationContext(
+  raw: unknown
+): EducationContext | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const program =
+    typeof obj.program === "string" ? obj.program.trim().slice(0, 200) : "";
+  if (!program) return null;
+
+  let credits: number | undefined;
+  if (typeof obj.credits === "number" && Number.isFinite(obj.credits) && obj.credits > 0) {
+    credits = Math.min(obj.credits, 999);
+  } else if (typeof obj.credits === "string" && obj.credits.trim()) {
+    const parsed = Number(obj.credits);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      credits = Math.min(parsed, 999);
+    }
+  }
+
+  const unitRaw = obj.unit;
+  const unit: EducationCreditUnit | undefined =
+    credits != null &&
+    (unitRaw === "credit_hours" ||
+      unitRaw === "semester_hours" ||
+      unitRaw === "contact_hours")
+      ? unitRaw
+      : credits != null
+        ? "credit_hours"
+        : undefined;
+
+  const completed_date =
+    typeof obj.completed_date === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(obj.completed_date)
+      ? obj.completed_date
+      : undefined;
+
+  return {
+    program,
+    ...(credits != null ? { credits } : {}),
+    ...(unit ? { unit } : {}),
+    ...(completed_date ? { completed_date } : {}),
+  };
+}
+
+/** Sanitize form values before persist; returns null when program empty. */
+export function sanitizeEducationContext(
+  value: EducationContext | null | undefined
+): EducationContext | null {
+  return normalizeEducationContext(value ?? null);
+}
+
+export function formatEducationContextForPrompt(
+  value: EducationContext | null | undefined
+): string {
+  const n = normalizeEducationContext(value ?? null);
+  if (!n) return "";
+  const unitLabel =
+    EDUCATION_CREDIT_UNITS.find((u) => u.value === n.unit)?.label ??
+    "credit hours";
+  const creditPart =
+    n.credits != null
+      ? ` (${n.credits} ${unitLabel.toLowerCase()})`
+      : "";
+  const datePart = n.completed_date ? `; completed ${n.completed_date}` : "";
+  return `Education context: ${n.program}${creditPart}${datePart}. Action/details describe mission application of this education; impact should tie education to mission results.`;
+}
+
+export function educationContextSummary(
+  value: EducationContext | null | undefined
+): string | null {
+  const n = normalizeEducationContext(value ?? null);
+  if (!n) return null;
+  if (n.credits != null) {
+    const unit =
+      n.unit === "semester_hours"
+        ? "SH"
+        : n.unit === "contact_hours"
+          ? "hrs"
+          : "cr";
+    return `${n.program} (${n.credits} ${unit})`;
+  }
+  return n.program;
+}

--- a/src/lib/epb-generated-set-history.ts
+++ b/src/lib/epb-generated-set-history.ts
@@ -1,0 +1,200 @@
+/**
+ * Rolling History for AI-generated statement sets (Revise / Generate).
+ *
+ * Keeps the last {@link MAX_GENERATED_STATEMENT_SETS} sets × 3 options = 9
+ * statements in Snapshot History so unused alternatives remain recoverable
+ * after regenerating or applying one option.
+ */
+
+export const MAX_GENERATED_STATEMENT_SETS = 3;
+export const MAX_STATEMENTS_PER_GENERATED_SET = 3;
+/** Manual workspace snapshots stay under this cap (AI sets use a separate budget). */
+export const MAX_MANUAL_SNAPSHOTS = 10;
+
+export type GeneratedStatementSource = "revise" | "generate";
+
+/** Machine-readable note prefix stored on snapshot rows. */
+const AI_SET_NOTE_RE =
+  /^\[ai-set:(revise|generate):([^:\]]+):(\d+)\]\s*(.*)$/;
+
+export type SnapshotHistoryItem = {
+  id: string;
+  text: string;
+  note: string | null;
+  created_at: string;
+};
+
+export type SnapshotHistoryAiSetGroup = {
+  kind: "ai-set";
+  key: string;
+  batchId: string;
+  source: GeneratedStatementSource;
+  /** e.g. "Generated · Revise" */
+  title: string;
+  created_at: string;
+  items: Array<SnapshotHistoryItem & { optionIndex: number }>;
+};
+
+export type SnapshotHistoryManualGroup = {
+  kind: "manual";
+  key: string;
+  created_at: string;
+  item: SnapshotHistoryItem;
+};
+
+export type SnapshotHistoryGroup =
+  | SnapshotHistoryAiSetGroup
+  | SnapshotHistoryManualGroup;
+
+export function isGeneratedSetSnapshotNote(note: string | null | undefined): boolean {
+  return !!note && note.startsWith("[ai-set:");
+}
+
+export function buildGeneratedSetSnapshotNote(
+  source: GeneratedStatementSource,
+  batchId: string,
+  optionIndex: number,
+): string {
+  const label = source === "revise" ? "Revise" : "Generate";
+  return `[ai-set:${source}:${batchId}:${optionIndex}] Generated · ${label} · Option ${optionIndex}`;
+}
+
+export function parseGeneratedSetNote(
+  note: string | null | undefined,
+): {
+  source: GeneratedStatementSource;
+  batchId: string;
+  optionIndex: number;
+  label: string;
+} | null {
+  if (!note) return null;
+  const match = AI_SET_NOTE_RE.exec(note);
+  if (!match) return null;
+  return {
+    source: match[1] as GeneratedStatementSource,
+    batchId: match[2],
+    optionIndex: Number(match[3]),
+    label: match[4] || "Generated",
+  };
+}
+
+export function getGeneratedSetDisplayLabel(note: string | null | undefined): string | null {
+  const parsed = parseGeneratedSetNote(note);
+  if (parsed) return parsed.label;
+  return isGeneratedSetSnapshotNote(note) ? "Generated" : null;
+}
+
+export function parseGeneratedSetBatchId(note: string | null | undefined): string | null {
+  return parseGeneratedSetNote(note)?.batchId ?? null;
+}
+
+/** Newest-first list of unique AI batch ids (by newest snapshot in each batch). */
+export function listGeneratedSetBatchIdsNewestFirst(
+  snapshots: Array<{ note: string | null; created_at: string }>,
+): string[] {
+  const latestByBatch = new Map<string, number>();
+  for (const snap of snapshots) {
+    const batchId = parseGeneratedSetBatchId(snap.note);
+    if (!batchId) continue;
+    const t = new Date(snap.created_at).getTime();
+    const prev = latestByBatch.get(batchId);
+    if (prev === undefined || t > prev) latestByBatch.set(batchId, t);
+  }
+  return [...latestByBatch.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([batchId]) => batchId);
+}
+
+/** Snapshot ids belonging to AI sets older than the newest N batches. */
+export function idsOfGeneratedSetsBeyondLimit(
+  snapshots: Array<{ id: string; note: string | null; created_at: string }>,
+  maxSets: number = MAX_GENERATED_STATEMENT_SETS,
+): string[] {
+  const keep = new Set(listGeneratedSetBatchIdsNewestFirst(snapshots).slice(0, maxSets));
+  return snapshots
+    .filter((snap) => {
+      const batchId = parseGeneratedSetBatchId(snap.note);
+      return batchId !== null && !keep.has(batchId);
+    })
+    .map((snap) => snap.id);
+}
+
+/** Oldest manual (non-AI) snapshot ids beyond the manual cap. */
+export function idsOfManualSnapshotsBeyondLimit(
+  snapshots: Array<{ id: string; note: string | null; created_at: string }>,
+  maxManual: number = MAX_MANUAL_SNAPSHOTS,
+): string[] {
+  const manual = snapshots
+    .filter((snap) => !isGeneratedSetSnapshotNote(snap.note))
+    .sort(
+      (a, b) =>
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    );
+  if (manual.length <= maxManual) return [];
+  return manual.slice(0, manual.length - maxManual).map((snap) => snap.id);
+}
+
+/**
+ * Group flat snapshots into History rows: one expandable AI set per batch,
+ * one row per manual/workspace snapshot. Newest groups first.
+ */
+export function groupSnapshotsForHistory(
+  snapshots: SnapshotHistoryItem[],
+): SnapshotHistoryGroup[] {
+  const aiByBatch = new Map<
+    string,
+    {
+      source: GeneratedStatementSource;
+      items: Array<SnapshotHistoryItem & { optionIndex: number }>;
+    }
+  >();
+  const manuals: SnapshotHistoryManualGroup[] = [];
+
+  for (const snap of snapshots) {
+    const parsed = parseGeneratedSetNote(snap.note);
+    if (!parsed) {
+      manuals.push({
+        kind: "manual",
+        key: `manual:${snap.id}`,
+        created_at: snap.created_at,
+        item: snap,
+      });
+      continue;
+    }
+    const existing = aiByBatch.get(parsed.batchId);
+    if (existing) {
+      existing.items.push({ ...snap, optionIndex: parsed.optionIndex });
+    } else {
+      aiByBatch.set(parsed.batchId, {
+        source: parsed.source,
+        items: [{ ...snap, optionIndex: parsed.optionIndex }],
+      });
+    }
+  }
+
+  const aiGroups: SnapshotHistoryAiSetGroup[] = [...aiByBatch.entries()].map(
+    ([batchId, { source, items }]) => {
+      const sorted = [...items].sort((a, b) => a.optionIndex - b.optionIndex);
+      const newest = sorted.reduce((acc, item) =>
+        new Date(item.created_at).getTime() > new Date(acc.created_at).getTime()
+          ? item
+          : acc,
+      );
+      const sourceLabel = source === "revise" ? "Revise" : "Generate";
+      return {
+        kind: "ai-set" as const,
+        key: `ai-set:${batchId}`,
+        batchId,
+        source,
+        title: `Generated · ${sourceLabel}`,
+        created_at: newest.created_at,
+        items: sorted,
+      };
+    },
+  );
+
+  return [...aiGroups, ...manuals].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+}

--- a/src/lib/epb-generation-readiness.ts
+++ b/src/lib/epb-generation-readiness.ts
@@ -65,6 +65,23 @@ function isAcaEntry(entry: Accomplishment): boolean {
   return (ACA_PORTFOLIO_MPA_KEYS as readonly string[]).includes(entry.mpa);
 }
 
+/** ACA entries missing an assessment or edited after the last one. */
+export function entriesNeedingAssessment(
+  entries: Pick<
+    Accomplishment,
+    "id" | "mpa" | "assessment_scores" | "assessed_at" | "updated_at"
+  >[]
+): string[] {
+  return entries
+    .filter(isAcaEntry)
+    .filter(
+      (entry) =>
+        entry.assessment_scores === null ||
+        isAssessmentStale(entry.assessed_at, entry.updated_at)
+    )
+    .map((entry) => entry.id);
+}
+
 export function evaluateEpbGenerationReadiness(
   entries: Accomplishment[],
   options: ReadinessOptions = {}
@@ -139,21 +156,8 @@ export function evaluateEpbGenerationReadiness(
     );
   }
 
-  if (unassessedCount > 0) {
-    warnings.push(
-      `${unassessedCount} ${
-        unassessedCount === 1 ? "entry has" : "entries have"
-      } no AI assessment yet — they can still be used, but scoring won't guide selection.`
-    );
-  }
-
-  if (staleCount > 0) {
-    warnings.push(
-      `${staleCount} ${
-        staleCount === 1 ? "entry was" : "entries were"
-      } edited after assessment — re-assess for the most accurate selection.`
-    );
-  }
+  // Unassessed / stale entries are assessed automatically before planning —
+  // do not surface those as user-facing warnings.
 
   return {
     canGenerate: reasons.length === 0,

--- a/src/lib/generate-epb-run.ts
+++ b/src/lib/generate-epb-run.ts
@@ -23,8 +23,16 @@ export interface EditableMpaPlan {
   enabled: boolean;
   /** Each inner array is one sentence group (accomplishment ids to combine). */
   groups: string[][];
+  /**
+   * Parallel to `groups` — optional rater guidance folded into that sentence's
+   * generation context (metrics nuance, emphasis, what to leave out, etc.).
+   */
+  notes: string[];
 }
 export type EditablePlan = Record<string, EditableMpaPlan>;
+
+/** Cap free-text guidance per sentence so prompts stay bounded. */
+export const SENTENCE_NOTE_MAX_CHARS = 500;
 
 export interface MpaSelection {
   mpaKey: AcaPortfolioMpaKey;
@@ -35,8 +43,15 @@ export interface MpaSelection {
    * customContext / customContext2).
    */
   groups: string[][];
+  /** Parallel to non-empty `groups` — rater notes for each sentence. */
+  notes: string[];
   /** 1 or 2 — drives statementCount for /api/generate. */
   sentenceCount: 1 | 2;
+}
+
+export interface SentenceSlotRef {
+  mpaKey: string;
+  groupIdx: number;
 }
 
 export function mpaLabel(key: string): string {
@@ -47,16 +62,29 @@ function isAcaMpaKey(mpa: string): mpa is AcaPortfolioMpaKey {
   return (ACA_PORTFOLIO_MPA_KEYS as readonly string[]).includes(mpa);
 }
 
-/** Convert an AI plan into the editable structure (core MPAs, enabled). */
+function emptyMpaPlan(): EditableMpaPlan {
+  return { enabled: false, groups: [], notes: [] };
+}
+
+function syncNotesLength(groups: string[][], notes: string[]): string[] {
+  return groups.map((_, i) => notes[i] ?? "");
+}
+
+/** Convert an AI plan into the editable structure (all core MPAs present). */
 export function planToEditable(plan: EpbPlan): EditablePlan {
   const editable: EditablePlan = {};
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    editable[mpaKey] = emptyMpaPlan();
+  }
   for (const selection of plan.mpas) {
     if (!isAcaMpaKey(selection.mpaKey)) continue;
+    const groups = selection.sentences
+      .map((s) => [...s.accomplishmentIds])
+      .filter((ids) => ids.length > 0);
     editable[selection.mpaKey] = {
       enabled: true,
-      groups: selection.sentences
-        .map((s) => [...s.accomplishmentIds])
-        .filter((ids) => ids.length > 0),
+      groups,
+      notes: groups.map(() => ""),
     };
   }
   return editable;
@@ -83,12 +111,14 @@ export function editableToMpaSelections(editable: EditablePlan): MpaSelection[] 
     const entry = editable[mpaKey];
     if (!entry || !entry.enabled) continue;
 
-    const nonEmptyGroups = entry.groups.filter((g) => g.length > 0);
-    if (nonEmptyGroups.length === 0) continue;
+    const paired = entry.groups
+      .map((g, i) => ({ ids: g, note: entry.notes[i] ?? "" }))
+      .filter((p) => p.ids.length > 0);
+    if (paired.length === 0) continue;
 
     const seen = new Set<string>();
     const ids: string[] = [];
-    for (const group of nonEmptyGroups) {
+    for (const { ids: group } of paired) {
       for (const id of group) {
         if (!seen.has(id)) {
           seen.add(id);
@@ -100,31 +130,194 @@ export function editableToMpaSelections(editable: EditablePlan): MpaSelection[] 
     selections.push({
       mpaKey,
       accomplishmentIds: ids,
-      groups: nonEmptyGroups.map((g) => [...g]),
-      sentenceCount: nonEmptyGroups.length >= 2 ? 2 : 1,
+      groups: paired.map((p) => [...p.ids]),
+      notes: paired.map((p) => p.note.trim()),
+      sentenceCount: paired.length >= 2 ? 2 : 1,
     });
   }
   return selections;
 }
 
+/** Append optional rater guidance under the accomplishment body. */
+export function appendSentenceNote(body: string, note: string | undefined): string {
+  const trimmed = note?.trim() ?? "";
+  if (!trimmed) return body;
+  const capped = trimmed.slice(0, SENTENCE_NOTE_MAX_CHARS);
+  if (!body.trim()) {
+    return `ADDITIONAL GUIDANCE FROM RATER:\n${capped}`;
+  }
+  return `${body}\n\nADDITIONAL GUIDANCE FROM RATER:\n${capped}`;
+}
+
 /** Build customContext (+ optional customContext2) from per-sentence groups. */
 export function buildGroupedMpaContexts(
   groups: string[][],
-  recordsById: Map<string, PlanAccomplishmentRecord>
+  recordsById: Map<string, PlanAccomplishmentRecord>,
+  notes: string[] = []
 ): { customContext: string; customContext2?: string } {
   const resolve = (ids: string[]) =>
     ids
       .map((id) => recordsById.get(id))
       .filter((r): r is PlanAccomplishmentRecord => !!r);
 
-  const first = buildMpaCustomContext(resolve(groups[0] ?? []));
+  const first = appendSentenceNote(
+    buildMpaCustomContext(resolve(groups[0] ?? [])),
+    notes[0]
+  );
   if (groups.length < 2) {
     return { customContext: first };
   }
-  const second = buildMpaCustomContext(resolve(groups[1] ?? []));
+  const second = appendSentenceNote(
+    buildMpaCustomContext(resolve(groups[1] ?? [])),
+    notes[1]
+  );
   return second
     ? { customContext: first, customContext2: second }
     : { customContext: first };
+}
+
+/** Swap sentence order within one MPA (notes move with groups). */
+export function reorderSentenceGroups(
+  editable: EditablePlan,
+  mpaKey: string,
+  fromIdx: number,
+  toIdx: number
+): EditablePlan {
+  const entry = editable[mpaKey];
+  if (!entry) return editable;
+  if (
+    fromIdx < 0 ||
+    toIdx < 0 ||
+    fromIdx >= entry.groups.length ||
+    toIdx >= entry.groups.length ||
+    fromIdx === toIdx
+  ) {
+    return editable;
+  }
+  const groups = [...entry.groups];
+  const notes = syncNotesLength(groups, entry.notes);
+  const [movedGroup] = groups.splice(fromIdx, 1);
+  const [movedNote] = notes.splice(fromIdx, 1);
+  groups.splice(toIdx, 0, movedGroup!);
+  notes.splice(toIdx, 0, movedNote!);
+  return {
+    ...editable,
+    [mpaKey]: { ...entry, groups, notes },
+  };
+}
+
+/**
+ * Move one accomplishment into another sentence slot (any MPA).
+ * Enables the destination MPA and creates the target group if needed (max 2).
+ */
+export function moveAccomplishmentToSlot(
+  editable: EditablePlan,
+  from: SentenceSlotRef & { id: string },
+  to: SentenceSlotRef
+): EditablePlan {
+  if (from.mpaKey === to.mpaKey && from.groupIdx === to.groupIdx) {
+    return editable;
+  }
+
+  const source = editable[from.mpaKey];
+  if (!source) return editable;
+  const sourceGroup = source.groups[from.groupIdx];
+  if (!sourceGroup?.includes(from.id)) return editable;
+
+  let next: EditablePlan = { ...editable };
+
+  const stripSource = (): EditableMpaPlan => {
+    const groups = source.groups.map((g, i) =>
+      i === from.groupIdx ? g.filter((id) => id !== from.id) : [...g]
+    );
+    return {
+      ...source,
+      groups,
+      notes: syncNotesLength(groups, source.notes),
+    };
+  };
+
+  if (from.mpaKey === to.mpaKey) {
+    const afterStrip = stripSource();
+    let groups = afterStrip.groups.map((g) => [...g]);
+    if (to.groupIdx >= groups.length) {
+      if (to.groupIdx >= 2) return editable;
+      while (groups.length <= to.groupIdx && groups.length < 2) {
+        groups.push([]);
+      }
+    }
+    groups = groups.map((g, i) => {
+      if (i !== to.groupIdx) return g;
+      return g.includes(from.id) ? g : [...g, from.id];
+    });
+    next = {
+      ...next,
+      [from.mpaKey]: {
+        ...afterStrip,
+        groups,
+        notes: syncNotesLength(groups, afterStrip.notes),
+      },
+    };
+    return next;
+  }
+
+  const dest = next[to.mpaKey] ?? emptyMpaPlan();
+  let destGroups = dest.groups.map((g) => [...g]);
+  let destNotes = syncNotesLength(destGroups, dest.notes);
+
+  if (to.groupIdx >= destGroups.length) {
+    if (to.groupIdx >= 2) return editable;
+    while (destGroups.length <= to.groupIdx && destGroups.length < 2) {
+      destGroups.push([]);
+    }
+    destNotes = syncNotesLength(destGroups, destNotes);
+  }
+
+  destGroups = destGroups.map((g, i) => {
+    if (i !== to.groupIdx) return g;
+    return g.includes(from.id) ? g : [...g, from.id];
+  });
+
+  next = {
+    ...next,
+    [from.mpaKey]: stripSource(),
+    [to.mpaKey]: {
+      enabled: true,
+      groups: destGroups,
+      notes: destNotes,
+    },
+  };
+  return next;
+}
+
+/** List every sentence slot a chip can move into (excluding its current slot). */
+export function listMoveDestinations(
+  editable: EditablePlan,
+  from: SentenceSlotRef
+): Array<SentenceSlotRef & { label: string }> {
+  const destinations: Array<SentenceSlotRef & { label: string }> = [];
+  for (const mpaKey of ACA_PORTFOLIO_MPA_KEYS) {
+    const entry = editable[mpaKey] ?? emptyMpaPlan();
+    const groupCount = Math.max(entry.groups.length, entry.enabled ? 1 : 0);
+    const slots = Math.min(Math.max(groupCount, 1), 2);
+    for (let groupIdx = 0; groupIdx < slots; groupIdx++) {
+      if (mpaKey === from.mpaKey && groupIdx === from.groupIdx) continue;
+      destinations.push({
+        mpaKey,
+        groupIdx,
+        label: `${mpaLabel(mpaKey)} · Sentence ${groupIdx + 1}`,
+      });
+    }
+    // Offer creating sentence 2 when the MPA only has one group so far
+    if (entry.groups.length === 1) {
+      destinations.push({
+        mpaKey,
+        groupIdx: 1,
+        label: `${mpaLabel(mpaKey)} · Sentence 2 (new)`,
+      });
+    }
+  }
+  return destinations;
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -107,6 +107,14 @@ export interface StewardshipImpact {
   outcome?: string;
 }
 
+/** Optional education metadata — action/details remain mission application */
+export interface EducationContext {
+  program: string;
+  credits?: number;
+  unit?: "credit_hours" | "semester_hours" | "contact_hours";
+  completed_date?: string;
+}
+
 export interface Accomplishment {
   id: string;
   user_id: string;
@@ -119,6 +127,10 @@ export interface Accomplishment {
   metrics: string | null;
   /** Structured AF stewardship impact (man-hours / funds / resources / outcome) */
   stewardship_impact?: StewardshipImpact;
+  /** Optional education context (program/credits); not the bullet itself */
+  education_context?: EducationContext | null;
+  /** Linked award IDs used as recognition impact (join table; hydrated client-side) */
+  linked_award_ids?: string[];
   mpa: string;
   tags: string[];
   cycle_year: number;

--- a/supabase/migrations/210_accomplishment_awards_and_education.sql
+++ b/supabase/migrations/210_accomplishment_awards_and_education.sql
@@ -1,0 +1,84 @@
+-- Education context on accomplishments + join table for award impact links
+
+ALTER TABLE accomplishments
+  ADD COLUMN IF NOT EXISTS education_context JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN accomplishments.education_context IS
+  'Optional education metadata { program, credits, unit, completed_date }. Action/details remain mission application; impact ties education to mission.';
+
+CREATE TABLE IF NOT EXISTS accomplishment_awards (
+  accomplishment_id UUID NOT NULL REFERENCES accomplishments(id) ON DELETE CASCADE,
+  award_id UUID NOT NULL REFERENCES awards(id) ON DELETE CASCADE,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (accomplishment_id, award_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_accomplishment_awards_award
+  ON accomplishment_awards(award_id);
+
+CREATE INDEX IF NOT EXISTS idx_accomplishment_awards_accomplishment
+  ON accomplishment_awards(accomplishment_id);
+
+ALTER TABLE accomplishment_awards ENABLE ROW LEVEL SECURITY;
+
+-- View: same visibility as parent accomplishment
+CREATE POLICY "Users can view accomplishment awards for visible accomplishments"
+  ON accomplishment_awards FOR SELECT
+  USING (
+    accomplishment_id IN (
+      SELECT id FROM accomplishments WHERE user_id = (SELECT auth.uid()) AND team_member_id IS NULL
+    )
+    OR accomplishment_id IN (
+      SELECT id FROM accomplishments
+      WHERE user_id IN (SELECT subordinate_id FROM get_subordinate_chain((SELECT auth.uid())))
+    )
+    OR accomplishment_id IN (
+      SELECT id FROM accomplishments
+      WHERE team_member_id IN (SELECT id FROM get_visible_managed_members((SELECT auth.uid())))
+    )
+    OR accomplishment_id IN (
+      SELECT id FROM accomplishments WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- Insert: own / created subordinate / created managed accomplishments
+CREATE POLICY "Users can link awards to visible accomplishments"
+  ON accomplishment_awards FOR INSERT
+  WITH CHECK (
+    accomplishment_id IN (
+      SELECT id FROM accomplishments WHERE user_id = (SELECT auth.uid()) AND team_member_id IS NULL
+    )
+    OR accomplishment_id IN (
+      SELECT id FROM accomplishments
+      WHERE created_by = (SELECT auth.uid())
+        AND user_id IN (SELECT subordinate_id FROM get_subordinate_chain((SELECT auth.uid())))
+    )
+    OR accomplishment_id IN (
+      SELECT id FROM accomplishments
+      WHERE created_by = (SELECT auth.uid())
+        AND team_member_id IN (SELECT id FROM get_visible_managed_members((SELECT auth.uid())))
+    )
+  );
+
+-- Delete: same as insert ownership
+CREATE POLICY "Users can unlink awards from their accomplishments"
+  ON accomplishment_awards FOR DELETE
+  USING (
+    accomplishment_id IN (
+      SELECT id FROM accomplishments WHERE user_id = (SELECT auth.uid()) AND team_member_id IS NULL
+    )
+    OR accomplishment_id IN (
+      SELECT id FROM accomplishments WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- Allow members to log awards they received (self-entry from /entries)
+DROP POLICY IF EXISTS "Users can insert own received awards" ON awards;
+CREATE POLICY "Users can insert own received awards"
+  ON awards FOR INSERT
+  WITH CHECK (
+    created_by = (SELECT auth.uid())
+    AND recipient_profile_id = (SELECT auth.uid())
+    AND supervisor_id = (SELECT auth.uid())
+  );

--- a/supabase/migrations/211_harden_accomplishment_awards_rls.sql
+++ b/supabase/migrations/211_harden_accomplishment_awards_rls.sql
@@ -1,0 +1,38 @@
+-- Harden accomplishment_awards INSERT: award must belong to the accomplishment ratee
+
+DROP POLICY IF EXISTS "Users can link awards to visible accomplishments" ON accomplishment_awards;
+
+CREATE POLICY "Users can link awards to visible accomplishments"
+  ON accomplishment_awards FOR INSERT
+  WITH CHECK (
+    -- Accomplishment is writable by caller
+    (
+      accomplishment_id IN (
+        SELECT id FROM accomplishments WHERE user_id = (SELECT auth.uid()) AND team_member_id IS NULL
+      )
+      OR accomplishment_id IN (
+        SELECT id FROM accomplishments
+        WHERE created_by = (SELECT auth.uid())
+          AND user_id IN (SELECT subordinate_id FROM get_subordinate_chain((SELECT auth.uid())))
+      )
+      OR accomplishment_id IN (
+        SELECT id FROM accomplishments
+        WHERE created_by = (SELECT auth.uid())
+          AND team_member_id IN (SELECT id FROM get_visible_managed_members((SELECT auth.uid())))
+      )
+    )
+    -- Award recipient must match accomplishment ratee
+    AND EXISTS (
+      SELECT 1
+      FROM accomplishments a
+      JOIN awards w ON w.id = award_id
+      WHERE a.id = accomplishment_id
+        AND (
+          (a.team_member_id IS NOT NULL AND w.recipient_team_member_id = a.team_member_id)
+          OR (
+            a.team_member_id IS NULL
+            AND w.recipient_profile_id = a.user_id
+          )
+        )
+    )
+  );


### PR DESCRIPTION
## Summary
- Generate EPB review step: per-sentence rater notes, sentence reorder, and Move-to across MPAs; auto-assess missing/stale entries before Plan (no assessment warning banners).
- Entries enrichment: education context + award recognition linking (`210`/`211`), safer diff-based award-link replace, EPB generated-set snapshot history in the shell.
- Follow-ups tracked in `plans/024-entries-education-award-followups.md` (education→generate context, shared AwardFields, self-award RLS tighten).

## Test plan
- [ ] Entries: create/edit accomplishment with education + linked awards; save and reopen
- [ ] Generate EPB with 1+ unassessed/stale selected entries → Plan shows scoring progress then review
- [ ] Review: add sentence notes, reorder ↑↓, Move to… another MPA/sentence, then Generate
- [ ] Confirm generated statements reflect notes; EPB snapshot history panel works after generate
- [ ] `npx vitest run src/lib/__tests__/generate-epb-run.test.ts src/lib/__tests__/epb-generation-readiness.test.ts src/lib/__tests__/award-recognition-education.test.ts src/lib/__tests__/epb-generated-set-history.test.ts`
- [ ] `npx react-doctor@latest --verbose --scope changed` (pre-existing sacred-surface finding in `mpa-section-card` only)


Made with [Cursor](https://cursor.com)