### PR TITLE
Aim EPB statements within 5% of the character limit

### DIFF
--- a/src/app/api/generate-slot-statement/route.ts
+++ b/src/app/api/generate-slot-statement/route.ts
@@ -16,6 +16,7 @@ import { scanAccomplishmentsForLLM } from "@/lib/sensitive-data-scanner";
 import { resolveRequestedModel } from "@/app/actions/ai-models";
 import { checkAndTrackUsage } from "@/lib/usage-tracker";
 import { appendUserRulesToPrompt } from "@/lib/prompt-rules/server";
+import { withinLimitTargetMin } from "@/lib/revise-length-constraint";
 import {
   buildEpbVerbVarietyPromptSection,
   fetchOtherMpaStatements,
@@ -66,6 +67,7 @@ export async function POST(request: Request) {
 
     const body: GenerateSlotRequest = await request.json();
     const { accomplishments, targetChars, model, mpa, rateeRank, rateeAfsc, rateeId, cycleYear } = body;
+    const fillMin = withinLimitTargetMin(targetChars);
 
     if (!accomplishments || accomplishments.length === 0) {
       return NextResponse.json({ error: "No accomplishments provided" }, { status: 400 });
@@ -141,7 +143,7 @@ GOOD EXAMPLE (readable, strong ending):
 BAD EXAMPLE (run-on, laundry list):
 "Directed 12 Amn rebuilding 8 servers, advancing completion by 29 days, crafted assessment, fixed errors, purged data, averting outage, streamlining access"
 
-TARGET LENGTH: ${targetChars} characters maximum (aim for ${Math.floor(targetChars * 0.85)}-${targetChars})
+TARGET LENGTH: ${targetChars} characters maximum (aim for ${fillMin}-${targetChars}, within 5% of the max)
 ${verbVarietyBlock}
 Output ONLY the statement (no period at the end).`;
 
@@ -166,7 +168,7 @@ CRITICAL RULES:
 11. Output ONLY the statement text, no quotes or explanation
 12. BANNED FORMATTING: NEVER use "w/", "w/o", "b/c", "--", "—", ";", "<", or ">" — write "with"/"without"/"because", use commas, and write "under"/"over" for comparisons
 
-CHARACTER LIMIT: ${targetChars} (aim for ${Math.floor(targetChars * 0.85)}-${targetChars})`,
+CHARACTER LIMIT: ${targetChars} (aim for ${fillMin}-${targetChars}, within 5% of the max)`,
       user.id,
       "epb",
     );

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -14,6 +14,7 @@ import {
   resolveStoredSystemPrompt,
 } from "@/lib/default-llm-prompts";
 import { STANDARD_MGAS, DEFAULT_MPA_DESCRIPTIONS, formatMPAContext, MAX_STATEMENT_CHARACTERS, MAX_HLR_CHARACTERS } from "@/lib/constants";
+import { withinLimitTargetMin } from "@/lib/revise-length-constraint";
 import { getDecryptedApiKeys } from "@/app/actions/api-keys";
 import { getModelProvider } from "@/lib/llm-provider";
 import { resolveRequestedModel } from "@/app/actions/ai-models";
@@ -821,14 +822,16 @@ The primary impact MUST emphasize RESOURCE EFFICIENCY. Frame around:
         // Account for " " separator (1 char) when statements are combined on frontend
         const combinedLimit = stmtCount === 2 ? effectiveMaxChars - 2 : effectiveMaxChars; // Leave room for separator
         const charLimitPerStatement = stmtCount === 2 ? Math.floor(combinedLimit / 2) : effectiveMaxChars;
+        const fillMin = withinLimitTargetMin(stmtCount === 2 ? combinedLimit : effectiveMaxChars);
         const charLimitText = stmtCount === 2 
           ? `**HARD CHARACTER BUDGET (COUNT CHARACTERS, NOT WORDS):**
 - Statement 1 + Statement 2 COMBINED must be ≤ ${combinedLimit} characters (they share one ${effectiveMaxChars}-char box)
-- Aim ~${charLimitPerStatement} chars each (letters, spaces, punctuation all count)
-- After writing, COUNT the combined length. If over ${combinedLimit}, DELETE until it fits
+- Aim ${fillMin}–${combinedLimit} combined (within 5% of the shared budget — letters, spaces, punctuation all count)
+- Aim ~${charLimitPerStatement} chars each as a starting split
+- After writing, COUNT the combined length. If over ${combinedLimit}, DELETE until it fits. If under ${fillMin}, add density (metrics already in the source, abbreviations, chained impact) until it lands in range
 - Prefer dense abbreviations: hrs, mos, wks, sq, mbrs, ops, &
 - Example (~170 chars): "Led 5-mbr team overhauling network, installed 47 servers across 3 sites, slashed downtime 90%, saved $2.3M, boosting readiness."`
-          : `TARGET: Statement should be ${Math.floor(effectiveMaxChars * 0.8)}-${effectiveMaxChars} characters. HARD MAX: ${effectiveMaxChars}.`;
+          : `TARGET: ${fillMin}-${effectiveMaxChars} characters (within 5% of the ${effectiveMaxChars} max). HARD MAX: ${effectiveMaxChars}.`;
         
         // Set multi-statement flag for QC when generating 2 statements
         if (stmtCount === 2) {

--- a/src/app/api/revise-selection/route.ts
+++ b/src/app/api/revise-selection/route.ts
@@ -196,7 +196,7 @@ Your goal is to improve the duty description by:
 - Varying how the scope and responsibility are described
 - Each of your ${versionCount} alternatives should approach the role description from a different angle
 - KEEP PRESENT TENSE - this describes a current role, not a past accomplishment
-- Target length: ~similar to original (within 20%)`,
+- Target length: follow the HARD CHARACTER LIMIT block (within 5% of the field max when a max is provided)`,
   };
 
   const basePrompt = resolvePromptWithRulesMode(
@@ -521,7 +521,7 @@ Your goal is to SIGNIFICANTLY transform the selected text:
 - Reframe the accomplishment from a new angle using ONLY facts from the source
 - Preserve all quantification from the source — never add new metrics or impact
 - Each of your ${versionCount} alternatives should use DIFFERENT verbs from each other
-- Target length: ${lengthGuidance.targetMin}-${lengthGuidance.targetMax} characters${lengthGuidance.hardMax != null ? ` (HARD MAX ${lengthGuidance.selectionMax} — do not match an over-limit original)` : ` (within 20% of original)`}`,
+- Target length: ${lengthGuidance.targetMin}-${lengthGuidance.targetMax} characters${lengthGuidance.hardMax != null ? ` (HARD MAX ${lengthGuidance.selectionMax} — within 5% of the field max; do not match an over-limit original)` : ` (within 20% of original)`}`,
     };
     
     // Get available verbs (exclude used ones)

--- a/src/lib/__tests__/revise-length-constraint.test.ts
+++ b/src/lib/__tests__/revise-length-constraint.test.ts
@@ -3,6 +3,7 @@ import {
   buildReviseLengthGuidance,
   sanitizeMaxCharacters,
   selectionBudget,
+  withinLimitTargetMin,
 } from "@/lib/revise-length-constraint";
 
 describe("sanitizeMaxCharacters", () => {
@@ -31,6 +32,13 @@ describe("selectionBudget", () => {
   });
 });
 
+describe("withinLimitTargetMin", () => {
+  it("is 5% under the field max", () => {
+    expect(withinLimitTargetMin(350)).toBe(332);
+    expect(withinLimitTargetMin(250)).toBe(237);
+  });
+});
+
 describe("buildReviseLengthGuidance", () => {
   it("tells the model to match original length when no max is set (legacy)", () => {
     const g = buildReviseLengthGuidance({
@@ -53,9 +61,10 @@ describe("buildReviseLengthGuidance", () => {
     expect(g.selectionMax).toBe(350);
     expect(g.mustCompressToFit).toBe(true);
     expect(g.targetMax).toBe(350);
-    expect(g.targetMin).toBeLessThanOrEqual(350);
+    expect(g.targetMin).toBe(332);
     expect(g.promptBlock).toMatch(/NON-NEGOTIABLE/);
     expect(g.promptBlock).toMatch(/REMOVE at least 102/);
+    expect(g.promptBlock).toMatch(/within 5%/);
     expect(g.promptBlock).not.toMatch(/±20%/);
   });
 
@@ -66,7 +75,9 @@ describe("buildReviseLengthGuidance", () => {
       mode: "general",
     });
     expect(g.mustCompressToFit).toBe(false);
-    expect(g.targetMax).toBeLessThanOrEqual(350);
+    expect(g.targetMin).toBe(332);
+    expect(g.targetMax).toBe(350);
+    expect(g.promptBlock).toMatch(/within 5%/);
     expect(g.promptBlock).toMatch(/NEVER exceed 350/);
   });
 

--- a/src/lib/default-llm-prompts.ts
+++ b/src/lib/default-llm-prompts.ts
@@ -6,7 +6,7 @@
 import { PERSONNEL_REFERENCE_GUIDANCE } from "@/lib/personnel-reference";
 
 /** Bump when DEFAULT_EPB_SYSTEM_PROMPT changes materially — triggers one-time update flow per user. */
-export const EPB_SYSTEM_PROMPT_REVISION = 5;
+export const EPB_SYSTEM_PROMPT_REVISION = 6;
 
 const LEGACY_EPB_PROMPT_MARKERS = [
   "Minimum 340 characters",
@@ -58,7 +58,7 @@ CRITICAL RULES - NEVER VIOLATE THESE:
 - NEVER use semi-colons (;). Use commas to connect clauses into flowing sentences.
 - NEVER use em-dashes (--). Use commas to connect clauses into flowing sentences.
 - Every statement MUST contain: 1) a strong action AND 2) cascading impacts (immediate → unit → mission/AF-level).
-- Character range: AIM for {{max_characters_per_statement}} characters. Minimum 280 characters, maximum {{max_characters_per_statement}}.
+- Character range: AIM for {{max_characters_per_statement}} characters. Stay within 5% of the max (at least 95% of {{max_characters_per_statement}}), never exceed {{max_characters_per_statement}}.
 - Generate exactly 2–3 strong statements per Major Performance Area.
 - Output pure, clean text only — no formatting.
 
@@ -142,7 +142,7 @@ ACRONYMS REFERENCE:
 {{acronyms_list}}`;
 
 export const DEFAULT_EPB_STYLE_GUIDELINES =
-  "MAXIMIZE character usage (aim for 280-350 chars). Write in active voice. Chain impacts: action → immediate result → organizational benefit. Always quantify: numbers, percentages, dollars, time, personnel. Connect to mission readiness, compliance, or strategic goals. Use standard AF abbreviations for efficiency.";
+  "MAXIMIZE character usage (stay within 5% of the field max, never exceed it). Write in active voice. Chain impacts: action → immediate result → organizational benefit. Always quantify: numbers, percentages, dollars, time, personnel. Connect to mission readiness, compliance, or strategic goals. Use standard AF abbreviations for efficiency.";
 
 export const DEFAULT_DUTY_DESCRIPTION_PROMPT = `You are an expert Air Force writer helping to revise a DUTY DESCRIPTION for an EPB (Enlisted Performance Brief).
 

--- a/src/lib/revise-length-constraint.ts
+++ b/src/lib/revise-length-constraint.ts
@@ -22,6 +22,14 @@ const MIN_SANITY = 80;
 const MAX_SANITY = 5000;
 const MIN_SELECTION_BUDGET = 20;
 
+/** Stay within 5% of the field max (e.g. 332–350 for a 350 cap). */
+export const WITHIN_LIMIT_RATIO = 0.95;
+
+export function withinLimitTargetMin(maxChars: number): number {
+  const max = Math.max(0, Math.floor(maxChars));
+  return Math.min(max, Math.floor(max * WITHIN_LIMIT_RATIO));
+}
+
 /** Accept a client-supplied max; reject nonsense so we don't trust raw JSON. */
 export function sanitizeMaxCharacters(value: unknown): number | undefined {
   const n =
@@ -59,20 +67,20 @@ export function buildReviseLengthGuidance(opts: {
     const over = selectedLength > selMax;
     const charsOver = selectedLength - selMax;
     const targetMax = selMax;
+    const fillMin = withinLimitTargetMin(selMax);
     let targetMin: number;
 
-    if (over) {
-      targetMin = Math.max(0, selMax - 30);
-    } else if (opts.mode === "compress") {
+    if (opts.mode === "compress" && !over) {
       targetMin = Math.max(0, Math.round(Math.min(selectedLength, selMax) * 0.65));
-    } else if (opts.mode === "expand") {
-      targetMin = selectedLength;
+    } else if (opts.mode === "expand" && !over) {
+      targetMin = Math.min(selMax, Math.max(selectedLength, fillMin));
     } else {
-      targetMin = Math.max(0, Math.round(selectedLength * 0.8));
+      // General revise, or any mode that must compress to fit: fill to within 5% of the cap.
+      targetMin = fillMin;
     }
 
     if (targetMin > targetMax) {
-      targetMin = Math.max(0, targetMax - 30);
+      targetMin = fillMin;
     }
 
     const spliceNote =
@@ -92,9 +100,9 @@ How to compress (keep every metric, $, unit name, and acronym):
 - Merge clauses; drop the weakest impact phrase if still over
 - Count characters BEFORE returning. If any version is over ${selMax}, rewrite it shorter.
 
-Target: ${targetMin}–${targetMax} characters. MAXIMUM ${selMax}.`
+Target: ${targetMin}–${targetMax} characters (within 5% of the ${selMax} max). MAXIMUM ${selMax}. Do not land 15–20% under the cap.`
       : `**HARD CHARACTER LIMIT:** Revised selection MUST be ≤ ${selMax} characters (full field max ${hardMax}).${spliceNote}
-Target ${targetMin}–${targetMax} characters. NEVER exceed ${selMax}, even if that is shorter than ±20% of the original ${selectedLength} characters.`;
+Target ${targetMin}–${targetMax} characters (within 5% of the field max). NEVER exceed ${selMax}. Do not land 15–20% under the cap.`;
 
     return {
       hardMax,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

EPB generate/revise prompts were aiming **20% under** the field max (280–350). That is too short once we started enforcing the hard cap.

They now target **within 5% of the max** (332–350 for a 350 box) and still never exceed it. Explicit compress mode can still go shorter.

## Also

- Bumped `EPB_SYSTEM_PROMPT_REVISION` to 6 so saved default prompts pick up the new range.
- Award revise without `maxCharacters` still uses ±20% of the original (unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a11aa34-813c-4af1-a337-e87c938543d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a11aa34-813c-4af1-a337-e87c938543d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

