### PR TITLE
Bump to v0.4.0 for bulk EPB generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myepbuddy",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myepbuddy",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.81",
         "@ai-sdk/google": "^3.0.80",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myepbuddy",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "(docker ps --format '{{.Names}}' | grep -q 'supabase_db_myepbuddy' || supabase start) && next dev --turbopack",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Entries **bulk paste → Generate EPB** workflow is live. The app version was still `0.3.2` (unchanged since the initial commit), so the update prompt could not name this as a feature release.

## Change

- `package.json` / `package-lock.json`: **0.3.2 → 0.4.0** (minor bump for a new user-facing workflow)
- Next production build will bake `v0.4.0` into `/api/version` via `scripts/generate-version.js`

No runtime behavior change besides the version string shown in the update-required dialog.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a11aa34-813c-4af1-a337-e87c938543d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a11aa34-813c-4af1-a337-e87c938543d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

