### PR TITLE
Keep two complete EPB sentences when revising (no clause trim)

### DIFF
--- a/advisor-plans/028-fail-closed-when-revise-cannot-fit.md
+++ b/advisor-plans/028-fail-closed-when-revise-cannot-fit.md
@@ -1,0 +1,61 @@
+# Plan 028: Fail closed when revise cannot fit the cap without truncating
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `advisor-plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat origin/acceptance..HEAD -- src/app/api/revise-selection/route.ts src/lib/statement-char-enforce.ts src/components/epb/epb-shell-form.tsx`
+> If those files drifted, re-read the live fallback before editing.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none (this branch already removed clause-trim)
+- **Category**: bug
+- **Planned at**: branch `cursor/epb-revise-keep-two-sentences-43d2`
+
+## Why this matters
+
+Clause-boundary trim is gone on purpose: a chopped EPB sentence is worse than an over-limit one. When LLM compress still cannot land ≤ max, `/api/revise-selection` **drops** fitting versions, then if **none** fit it **returns the uncompressed drafts anyway** (see the `fitting.length > 0` else-branch). The user can still get 452/350 complete sentences with no error. Generate logs `STILL OVER` and also returns the over-limit package to the UI.
+
+The product rule is: complete sentences **and** ≤ field max. If the model cannot do both, the API should fail closed (error the client can retry), not silently offer over-limit text.
+
+## Current state
+
+- `src/lib/statement-char-enforce.ts` — `enforcePackageCharacterLimit` compresses with abbreviations + LLM only. `stillOver: true` when still over. No `trimToMaxAtClauseBoundary`.
+- `src/app/api/revise-selection/route.ts` — after enforce, drops still-over / collapsed two-sentence revisions; if the filtered list is empty, logs a warning and keeps the raw drafts.
+- `src/app/api/generate/route.ts` — same enforcer; `stillOver` is only `console.warn`.
+- Client: `src/components/epb/epb-shell-form.tsx` uses `result.revisions || []` with no `stillOver` / error field.
+
+Do **not** restore truncation. Do **not** edit `src/components/epb/mpa-section-card.tsx` (split view / sentence DnD are sacred).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests | `npm test -- src/lib/__tests__/statement-char-enforce.test.ts src/lib/__tests__/revise-length-constraint.test.ts` | pass |
+| Typecheck | `npx tsc --noEmit` | exit 0 |
+
+## Steps
+
+1. Add a structured flag on the revise JSON response when every version is still over or was dropped, e.g. `{ revisions, original, capFitFailed: true }` — **or** return HTTP 422 with a safe message like "Could not rewrite within the character limit. Try Revise again." Prefer 422 so the existing error toast path fires; only use a flag if the client already swallows non-2xx poorly — check `epb-shell-form.tsx` revise fetch error handling first.
+2. Do **not** return over-limit drafts as `revisions` in that failure case. Empty `revisions` plus an error is correct.
+3. Add a unit test for the filter logic if you extract it (e.g. `pickRevisionsThatFitCap(revisions, max, expectedSentenceCount)`). Do not add a live LLM test.
+4. Optional same-pass: if generate `stillOver`, omit that version from the version list or mark it unusable — only if the generate UI already skips empty versions safely. If unclear, STOP and leave generate as warn-only; do not guess.
+
+## Done criteria
+
+- No path in `statement-char-enforce.ts` truncates text to force `length <= max`.
+- Revise never returns a revision that is over `selectionMax` when enforce ran.
+- When none fit, the client shows an error, not 452/350 text.
+- Tests above pass. `mpa-section-card.tsx` untouched.
+
+## STOP conditions
+
+- Restoring `trimToMaxAtClauseBoundary` as a last resort.
+- Changing split-view / sentence DnD.
+- Charging extra credits for a retry loop beyond the existing 3 compress attempts.

--- a/advisor-plans/README.md
+++ b/advisor-plans/README.md
@@ -346,5 +346,6 @@ Landed on `cursor/epb-revise-char-limit-43d2` (`b8adb41`): revise no longer uses
 |------|-------|----------|--------|------------|--------|
 | 026  | Label EPB vs 1206 in revise-selection system prompt | P2 | S | — | TODO |
 | 027  | Pass remaining shared-budget when revising one of two EPB sentences | P2 | S | — | TODO |
+| 028  | Fail closed when revise cannot fit the cap without truncating | P2 | S | — | TODO |
 
-Recommended: **026** then **027** (independent; 026 is prompt-only).
+Recommended: **026** then **027** (independent; 026 is prompt-only). **028** after this branch’s no-trim enforce lands — do not reintroduce clause-trim.

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1665,7 +1665,7 @@ Rules:
               effectiveMaxChars,
               {
                 model: modelProvider as LanguageModel,
-                maxAttempts: 2,
+                maxAttempts: 3,
                 context: `${mpa.label} for ${rateeRank}`,
               }
             );

--- a/src/app/api/revise-selection/route.ts
+++ b/src/app/api/revise-selection/route.ts
@@ -37,6 +37,8 @@ import { PERSONNEL_REFERENCE_GUIDANCE } from "@/lib/personnel-reference";
 import { TIME_COMPRESSION_WRITING_GUIDANCE } from "@/lib/stewardship-impact";
 import {
   buildReviseLengthGuidance,
+  buildSentenceCountGuidance,
+  expectedRevisionSentenceCount,
   sanitizeMaxCharacters,
 } from "@/lib/revise-length-constraint";
 
@@ -292,7 +294,7 @@ ${availableVerbs.slice(0, 20).join(", ")}
 - Slashes: /
 - Comparison symbols: < or > (write "under 24 hrs" / "over 90%")
 
-**USE ONLY:** Commas (,) to connect clauses
+**USE ONLY:** Commas (,) inside a sentence. If the original has two sentences, keep a period between them.
 
 ${PERSONNEL_REFERENCE_GUIDANCE}
 
@@ -327,13 +329,14 @@ CRITICAL RULES:
 5. Output ONLY the revised text for the selected portion - no quotes, no explanation
 6. Maintain the same general meaning but with appropriately varied phrasing based on aggressiveness level
 7. Maintain grammatical coherence with surrounding text
-8. NEVER use em-dashes (--) - use COMMAS instead to connect clauses
+8. NEVER use em-dashes (--) - use COMMAS inside a sentence; keep a period between two sentences
 9. If the selection starts at the beginning of the statement and includes "- ", preserve the "- " prefix
 10. READABILITY: Revised text should flow naturally when read aloud
 11. PARALLELISM: Use consistent verb tense throughout (all past tense OR all present participles)
 12. AVOID creating run-on laundry lists of 5+ actions - keep it focused
 13. AVOID the word "the" - it wastes characters (e.g., "led the team" → "led 4-mbr team" - always quantify scope)
-14. CONSISTENCY: Use either "&" OR "and" throughout - NEVER mix them. Prefer "&" when saving space.`;
+14. CONSISTENCY: Use either "&" OR "and" throughout - NEVER mix them. Prefer "&" when saving space.
+15. SENTENCE COUNT: If the original selection is two sentences, each revision MUST remain two sentences. Do not collapse them into one.`;
 }
 
 export async function POST(request: Request) {
@@ -487,6 +490,12 @@ ${noReuseRule}`;
       mode,
       surroundingLength,
     });
+    const sentenceCount = isDutyDescription
+      ? 1
+      : expectedRevisionSentenceCount(selectedText);
+    const sentenceCountGuidance = isDutyDescription
+      ? ""
+      : buildSentenceCountGuidance(sentenceCount);
     const lengthCapNote = lengthGuidance.mustCompressToFit
       ? `COMPRESS to ≤ ${lengthGuidance.selectionMax} characters. Matching the original length is WRONG — the original is over the field limit.`
       : lengthGuidance.hardMax != null
@@ -512,7 +521,7 @@ Your goal is to make the selected text SHORTER by:
 - Using shorter, punchier words (e.g., "orchestrated" → "led", "established" → "built", "eliminated" → "cut", "approximately" → "~")
 - Removing unnecessary filler words while keeping meaning
 - Using more concise phrasing
-- Combining phrases where possible
+- Combining phrases where possible (within a sentence — never merge two sentences into one)
 - Target length: ${lengthGuidance.targetMin}-${lengthGuidance.targetMax} characters${lengthGuidance.hardMax != null ? ` (HARD MAX ${lengthGuidance.selectionMax})` : ""}`,
       
       general: `**MODE: IMPROVE (completely rewrite with fresh perspective)**
@@ -582,6 +591,10 @@ Your goal is to SIGNIFICANTLY transform the selected text:
       ? buildDutyDescriptionPrompt(featureFlags, mode, modeInstructions, aggressivenessInstructions, styleGuidance, fewShotExamples, versionCount, userDutyDescriptionPrompt, lengthGuidance.promptBlock)
       : buildStatementPrompt(mode, modeInstructions, aggressivenessInstructions, styleGuidance, fewShotExamples, verbsToAvoid, availableVerbs, versionCount, verbVarietySection || undefined, lengthGuidance.promptBlock);
 
+    if (sentenceCountGuidance) {
+      systemPrompt += `\n\n${sentenceCountGuidance}`;
+    }
+
     // Append style signature to system prompt if available
     if (styleSignatureSection) {
       systemPrompt += `\n\n${styleSignatureSection}`;
@@ -615,9 +628,10 @@ ${isDutyDescription ? "⚠️ DUTY DESCRIPTION - Use PRESENT TENSE only. Describ
 ${mode === "expand" && !lengthGuidance.mustCompressToFit ? "Make it LONGER with longer synonyms for existing content only — never add new facts." : mode === "compress" || lengthGuidance.mustCompressToFit ? "Make it SHORTER with concise words and abbreviations." : isDutyDescription ? "Rephrase with improved word economy and flow while keeping present tense and every factual element from the source." : "Improve quality while keeping the same facts."}
 AGGRESSIVENESS: ${aggressiveness}% (${aggressiveness <= 20 ? "minimal changes" : aggressiveness <= 40 ? "conservative" : aggressiveness <= 60 ? "moderate" : aggressiveness <= 80 ? "aggressive" : "maximum rewrite"})
 ${lengthGuidance.promptBlock}
+${sentenceCountGuidance}
 ${lengthCapNote ? `LENGTH OVERRIDE: ${lengthCapNote}` : ""}
 
-Generate ${versionCount} revisions of ONLY the selected portion.
+Generate ${versionCount} revisions of ONLY the selected portion${sentenceCount === 2 ? ". Each revision string MUST contain exactly two sentences." : ""}.
 
 Return JSON array only: [${Array.from({ length: versionCount }, (_, i) => `"revision${i + 1}"`).join(", ")}]`;
 
@@ -626,7 +640,7 @@ Return JSON array only: [${Array.from({ length: versionCount }, (_, i) => `"revi
       system: systemPrompt,
       prompt: userPrompt,
       temperature: isDutyDescription || lengthGuidance.mustCompressToFit ? 0.4 : 0.7,
-      maxOutputTokens: 500,
+      maxOutputTokens: sentenceCount === 2 ? 1400 : 800,
     });
 
     let revisions: string[] = [];
@@ -664,34 +678,45 @@ Return JSON array only: [${Array.from({ length: versionCount }, (_, i) => `"revi
       revisions = formattingRepair.statements;
     }
 
-    if (lengthGuidance.selectionMax != null) {
-      const { enforceRevisionText, trimToMaxAtClauseBoundary } = await import(
-        "@/lib/statement-char-enforce"
-      );
-      const selectionMax = lengthGuidance.selectionMax;
-      revisions = await Promise.all(
-        revisions.map(async (revision, index) => {
-          if (typeof revision !== "string") return String(revision ?? "");
-          const trimmed = revision.trim();
-          if (trimmed.length <= selectionMax) return trimmed;
-          try {
-            const enforced = await enforceRevisionText(trimmed, selectionMax, {
-              model: modelProvider,
-              maxAttempts: 2,
-              context: "revise-selection character cap",
-            });
-            console.log(
-              `[revise-selection] Char enforce v${index + 1}: ${trimmed.length} → ${enforced.length}/${selectionMax}`
-            );
-            return enforced.length > selectionMax
-              ? trimToMaxAtClauseBoundary(enforced, selectionMax)
-              : enforced;
-          } catch (err) {
-            console.error(`[revise-selection] Char enforce v${index + 1} failed:`, err);
-            return trimToMaxAtClauseBoundary(trimmed, selectionMax);
-          }
-        })
-      );
+    if (lengthGuidance.selectionMax != null || sentenceCount === 2) {
+      const {
+        enforceRevisionText,
+        repairCollapsedTwoSentenceRevisions,
+      } = await import("@/lib/statement-char-enforce");
+
+      if (sentenceCount === 2) {
+        revisions = await repairCollapsedTwoSentenceRevisions(
+          selectedText,
+          revisions.map((r) => (typeof r === "string" ? r.trim() : String(r ?? ""))),
+          lengthGuidance.selectionMax ?? selectedText.length,
+          { model: modelProvider }
+        );
+      }
+
+      if (lengthGuidance.selectionMax != null) {
+        const selectionMax = lengthGuidance.selectionMax;
+        revisions = await Promise.all(
+          revisions.map(async (revision, index) => {
+            if (typeof revision !== "string") return String(revision ?? "");
+            const trimmed = revision.trim();
+            if (trimmed.length <= selectionMax) return trimmed;
+            try {
+              const enforced = await enforceRevisionText(trimmed, selectionMax, {
+                model: modelProvider,
+                maxAttempts: 2,
+                context: "revise-selection character cap",
+              });
+              console.log(
+                `[revise-selection] Char enforce v${index + 1}: ${trimmed.length} → ${enforced.length}/${selectionMax}`
+              );
+              return enforced;
+            } catch (err) {
+              console.error(`[revise-selection] Char enforce v${index + 1} failed:`, err);
+              return await enforceRevisionText(trimmed, selectionMax);
+            }
+          })
+        );
+      }
     }
 
     // Trigger async style processing (fire-and-forget) — skip for default-key users

--- a/src/app/api/revise-selection/route.ts
+++ b/src/app/api/revise-selection/route.ts
@@ -41,6 +41,7 @@ import {
   expectedRevisionSentenceCount,
   sanitizeMaxCharacters,
 } from "@/lib/revise-length-constraint";
+import { parseStatement } from "@/lib/sentence-utils";
 
 // Allow up to 60s for LLM calls (initial generation + quality control pass)
 export const maxDuration = 60;
@@ -695,27 +696,46 @@ Return JSON array only: [${Array.from({ length: versionCount }, (_, i) => `"revi
 
       if (lengthGuidance.selectionMax != null) {
         const selectionMax = lengthGuidance.selectionMax;
-        revisions = await Promise.all(
+        const enforced = await Promise.all(
           revisions.map(async (revision, index) => {
-            if (typeof revision !== "string") return String(revision ?? "");
+            if (typeof revision !== "string") return null;
             const trimmed = revision.trim();
-            if (trimmed.length <= selectionMax) return trimmed;
+            if (!trimmed) return null;
+            if (trimmed.length <= selectionMax) {
+              if (sentenceCount === 2 && !parseStatement(trimmed).hasTwoSentences) {
+                return null;
+              }
+              return trimmed;
+            }
             try {
-              const enforced = await enforceRevisionText(trimmed, selectionMax, {
+              const result = await enforceRevisionText(trimmed, selectionMax, {
                 model: modelProvider,
-                maxAttempts: 2,
+                maxAttempts: 3,
                 context: "revise-selection character cap",
               });
               console.log(
-                `[revise-selection] Char enforce v${index + 1}: ${trimmed.length} → ${enforced.length}/${selectionMax}`
+                `[revise-selection] Char enforce v${index + 1}: ${trimmed.length} → ${result.text.length}/${selectionMax}` +
+                  (result.stillOver ? " STILL OVER (dropped)" : "")
               );
-              return enforced;
+              if (result.stillOver) return null;
+              if (sentenceCount === 2 && !parseStatement(result.text).hasTwoSentences) {
+                return null;
+              }
+              return result.text;
             } catch (err) {
               console.error(`[revise-selection] Char enforce v${index + 1} failed:`, err);
-              return await enforceRevisionText(trimmed, selectionMax);
+              return null;
             }
           })
         );
+        const fitting = enforced.filter((r): r is string => r != null);
+        if (fitting.length > 0) {
+          revisions = fitting;
+        } else {
+          console.warn(
+            "[revise-selection] No complete revision fit the character cap; returning uncompressed complete drafts"
+          );
+        }
       }
     }
 

--- a/src/lib/__tests__/revise-length-constraint.test.ts
+++ b/src/lib/__tests__/revise-length-constraint.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildReviseLengthGuidance,
+  buildSentenceCountGuidance,
+  expectedRevisionSentenceCount,
   sanitizeMaxCharacters,
   selectionBudget,
   withinLimitTargetMin,
@@ -62,6 +64,7 @@ describe("buildReviseLengthGuidance", () => {
     expect(g.mustCompressToFit).toBe(true);
     expect(g.targetMax).toBe(350);
     expect(g.targetMin).toBe(332);
+    expect(g.promptBlock).toMatch(/keep TWO sentences/);
     expect(g.promptBlock).toMatch(/NON-NEGOTIABLE/);
     expect(g.promptBlock).toMatch(/REMOVE at least 102/);
     expect(g.promptBlock).toMatch(/within 5%/);
@@ -88,6 +91,26 @@ describe("buildReviseLengthGuidance", () => {
       mode: "expand",
     });
     expect(g.mustCompressToFit).toBe(true);
+    expect(g.promptBlock).toMatch(/keep TWO sentences/);
     expect(g.targetMax).toBe(350);
+  });
+});
+
+describe("expectedRevisionSentenceCount", () => {
+  it("detects a two-sentence EPB package", () => {
+    const text =
+      "Led 5-mbr team overhauling network, cut downtime 90%, boosting readiness. Directed cyber center supporting 10 sites, vital for SOUTHCOM ops.";
+    expect(expectedRevisionSentenceCount(text)).toBe(2);
+    expect(buildSentenceCountGuidance(2)).toMatch(/TWO sentences/);
+    expect(buildSentenceCountGuidance(2)).toMatch(/Do NOT merge/);
+  });
+
+  it("detects a single sentence", () => {
+    expect(
+      expectedRevisionSentenceCount(
+        "Led 5-mbr team overhauling network, cut downtime 90%, boosting readiness."
+      )
+    ).toBe(1);
+    expect(buildSentenceCountGuidance(1)).toMatch(/ONE sentence/);
   });
 });

--- a/src/lib/__tests__/statement-char-enforce.test.ts
+++ b/src/lib/__tests__/statement-char-enforce.test.ts
@@ -7,7 +7,6 @@ import {
   enforcePackageCharacterLimit,
   enforceRevisionText,
   splitJoinedStatements,
-  trimToMaxAtClauseBoundary,
 } from "@/lib/statement-char-enforce";
 
 const OVER_A =
@@ -39,16 +38,6 @@ describe("applyDeterministicCompress", () => {
   });
 });
 
-describe("trimToMaxAtClauseBoundary", () => {
-  it("cuts at commas to fit max", () => {
-    const long =
-      "Led team rebuilding servers, installed 47 racks, cut downtime 90%, saved $2M, boosting readiness across the wing";
-    const out = trimToMaxAtClauseBoundary(long, 80);
-    expect(out.length).toBeLessThanOrEqual(80);
-    expect(out).toContain("Led team");
-  });
-});
-
 describe("enforcePackageCharacterLimit", () => {
   it("leaves compliant packages alone", async () => {
     const stmts = [
@@ -60,31 +49,31 @@ describe("enforcePackageCharacterLimit", () => {
     expect(result.statements[0]).toBe(stmts[0]);
   });
 
-  it("deterministically shrinks an over-limit two-statement package without LLM", async () => {
+  it("never truncates a two-statement package when no LLM is available", async () => {
     const before = combinedStatementLength([OVER_A, OVER_B]);
     expect(before).toBeGreaterThan(350);
 
     const result = await enforcePackageCharacterLimit([OVER_A, OVER_B], 350, {
-      // no model — deterministic + trim only
       maxAttempts: 2,
     });
 
-    expect(result.combinedLength).toBeLessThanOrEqual(350);
-    expect(result.stillOver).toBe(false);
-    expect(result.wasAdjusted).toBe(true);
-    expect(["deterministic", "trim_fallback"]).toContain(result.method);
     expect(result.statements).toHaveLength(2);
-    // Metrics should survive compression
+    expect(result.statements.every((s) => /[.!?]$/.test(s.trim()))).toBe(true);
     expect(result.statements.join(" ")).toMatch(/\$2M/);
-    expect(result.statements.join(" ")).toMatch(/24/);
+    expect(result.statements.join(" ")).toMatch(/Commanded/);
+    // Without an LLM, complete sentences may still be over — never cut to fake a fit
+    if (result.combinedLength > 350) {
+      expect(result.stillOver).toBe(true);
+    }
   });
 
-  it("trims a single over-long statement without LLM", async () => {
+  it("never truncates a single over-long statement when no LLM is available", async () => {
     const long = `${OVER_A} ${OVER_B}`;
     expect(long.length).toBeGreaterThan(350);
     const result = await enforcePackageCharacterLimit([long], 350);
-    expect(result.statements[0].length).toBeLessThanOrEqual(350);
-    expect(result.stillOver).toBe(false);
+    expect(result.statements[0]).toMatch(/Commanded/);
+    expect(result.statements[0].length).toBeGreaterThan(350);
+    expect(result.stillOver).toBe(true);
   });
 });
 
@@ -104,13 +93,15 @@ describe("splitJoinedStatements", () => {
 });
 
 describe("enforceRevisionText", () => {
-  it("fits the user's over-limit two-sentence revise example under 350 without LLM", async () => {
+  it("keeps both complete sentences instead of cutting the second to fit 350", async () => {
     const v1 =
       "Executed a $2M network expansion, transitioning 9 joint units to resilient IT, doubling bandwidth & extending air picture over 2.2M sq mi, this action supported 24 kinetic strikes & 42 vessel interdictions, enhancing USSOUTHCOM readiness. Directed AFSOUTH's inaugural Cyber Coordination Center, servicing 10 sites, and crafted the framework that allowed AFCYBER to resolve 12 MAJCOM issues in under 24 hours, proving vital for SOUTHCOM OPs deployments.";
     expect(v1.length).toBeGreaterThan(350);
     const out = await enforceRevisionText(v1, 350);
-    expect(out.length).toBeLessThanOrEqual(350);
-    expect(out).toMatch(/\$2M/);
-    expect(parseStatement(out).hasTwoSentences).toBe(true);
+    expect(out.text).toMatch(/\$2M/);
+    expect(out.text).toMatch(/Cyber Coordination Center/);
+    expect(parseStatement(out.text).hasTwoSentences).toBe(true);
+    expect(out.stillOver).toBe(true);
+    expect(out.text.length).toBeGreaterThan(350);
   });
 });

--- a/src/lib/__tests__/statement-char-enforce.test.ts
+++ b/src/lib/__tests__/statement-char-enforce.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseStatement } from "@/lib/sentence-utils";
 import {
   applyDeterministicCompress,
   combineStatementsForDisplay,
@@ -110,5 +111,6 @@ describe("enforceRevisionText", () => {
     const out = await enforceRevisionText(v1, 350);
     expect(out.length).toBeLessThanOrEqual(350);
     expect(out).toMatch(/\$2M/);
+    expect(parseStatement(out).hasTwoSentences).toBe(true);
   });
 });

--- a/src/lib/revise-length-constraint.ts
+++ b/src/lib/revise-length-constraint.ts
@@ -6,6 +6,8 @@
  * produced 450–540 char "improvements" that still cannot be saved.
  */
 
+import { parseStatement } from "@/lib/sentence-utils";
+
 export type ReviseMode = "expand" | "compress" | "general";
 
 export interface ReviseLengthGuidance {
@@ -28,6 +30,23 @@ export const WITHIN_LIMIT_RATIO = 0.95;
 export function withinLimitTargetMin(maxChars: number): number {
   const max = Math.max(0, Math.floor(maxChars));
   return Math.min(max, Math.floor(max * WITHIN_LIMIT_RATIO));
+}
+
+/** EPB packages are at most two sentences; match the split-view parser. */
+export function expectedRevisionSentenceCount(text: string): 1 | 2 {
+  return parseStatement(text).hasTwoSentences ? 2 : 1;
+}
+
+export function buildSentenceCountGuidance(count: 1 | 2): string {
+  if (count === 2) {
+    return `**SENTENCE COUNT (NON-NEGOTIABLE):** The original is TWO sentences that SHARE one character budget.
+Each revision MUST be exactly TWO sentences: "Sentence one. Sentence two."
+- Do NOT merge them into one comma-spliced sentence to save space
+- Do NOT drop the second sentence — compress BOTH until the combined length fits
+- Each sentence is its own standalone sentence with its own opening verb
+- Use a period + space BETWEEN the two sentences; commas only INSIDE a sentence`;
+  }
+  return `**SENTENCE COUNT:** The original is ONE sentence. Keep exactly one sentence — do not split it into two.`;
 }
 
 /** Accept a client-supplied max; reject nonsense so we don't trust raw JSON. */
@@ -97,7 +116,8 @@ How to compress (keep every metric, $, unit name, and acronym):
 - Prefer "&" over "and"; drop "the" where grammar still holds
 - Abbreviate: hrs, mos, wks, mbrs, sq, flt, gp, wg, ops, pers
 - Cut filler: "this action", "this initiative", "this directly", "resulting in", "providing support for"
-- Merge clauses; drop the weakest impact phrase if still over
+- Merge clauses WITHIN each sentence; drop the weakest impact phrase if still over
+- If the original has TWO sentences, keep TWO sentences — never merge or drop one
 - Count characters BEFORE returning. If any version is over ${selMax}, rewrite it shorter.
 
 Target: ${targetMin}–${targetMax} characters (within 5% of the ${selMax} max). MAXIMUM ${selMax}. Do not land 15–20% under the cap.`

--- a/src/lib/statement-char-enforce.ts
+++ b/src/lib/statement-char-enforce.ts
@@ -13,6 +13,7 @@ import {
   enforceCharacterLimits,
   validateCharacterCount,
 } from "@/lib/character-verification";
+import { parseStatement } from "@/lib/sentence-utils";
 
 /** Absolute max LLM compress attempts for a package (hard cap). */
 export const MAX_PACKAGE_COMPRESS_ATTEMPTS = 2;
@@ -32,15 +33,12 @@ export function combinedStatementLength(statements: string[]): number {
 
 /**
  * Split a joined two-sentence EPB package back into statements.
- * Requires a lowercase letter, digit, or ")" immediately before the period
- * so abbreviations like "U.S. Air Force" are not split.
+ * Uses the same parser as the EPB split-view UI so revise/enforce
+ * agree with what the user sees as sentence 1 vs sentence 2.
  */
 export function splitJoinedStatements(text: string): string[] {
-  const trimmed = text.trim();
-  if (!trimmed) return [];
-  const parts = trimmed.split(/(?<=[a-z0-9)]\.)\s+(?=[A-Z][a-z])/);
-  const cleaned = parts.map((s) => s.trim()).filter(Boolean);
-  return cleaned.length > 0 ? cleaned : [trimmed];
+  const parsed = parseStatement(text);
+  return parsed.sentences.map((s) => s.text).filter(Boolean);
 }
 
 /**
@@ -382,6 +380,7 @@ export async function enforcePackageCharacterLimit(
 /**
  * Enforce a hard max on one revised blob (one or two joined sentences).
  * Splits, compresses as a shared package, then re-joins for the UI.
+ * Never clause-trims a joined two-sentence blob (that drops sentence 2).
  */
 export async function enforceRevisionText(
   text: string,
@@ -395,6 +394,65 @@ export async function enforceRevisionText(
   const parts = splitJoinedStatements(text);
   const result = await enforcePackageCharacterLimit(parts, targetMax, options);
   return combineStatementsForDisplay(result.statements);
+}
+
+/**
+ * If revise collapsed a two-sentence package into one sentence, ask the model
+ * to restore two sentences without inventing facts. One batched LLM call.
+ */
+export async function repairCollapsedTwoSentenceRevisions(
+  original: string,
+  revisions: string[],
+  targetMax: number,
+  options: { model: LanguageModel }
+): Promise<string[]> {
+  const flags = revisions.map((r) => !parseStatement(r).hasTwoSentences);
+  if (!flags.some(Boolean)) return revisions;
+
+  const numbered = revisions
+    .map((r, i) => (flags[i] ? `[${i + 1}] ${r.trim()}` : null))
+    .filter((line): line is string => line !== null)
+    .join("\n\n");
+
+  try {
+    const { text } = await generateText({
+      model: options.model,
+      system:
+        "You restore EPB two-sentence packages that were wrongly merged into one sentence. Output JSON only.",
+      prompt: `ORIGINAL TWO-SENTENCE PACKAGE:
+"${original.trim()}"
+
+These revisions collapsed to ONE sentence. Rewrite EACH as EXACTLY TWO sentences (Sentence. Sentence.) that share a ${targetMax}-character combined budget. Keep every metric, $, unit name, and acronym. Do not invent facts. Do not merge back into one sentence.
+
+COLLAPSED REVISIONS:
+${numbered}
+
+Return a JSON array of strings — one restored two-sentence package per collapsed revision, in the same order:
+["restored 1", "restored 2"]`,
+      temperature: 0.2,
+      maxOutputTokens: 1200,
+    });
+
+    const parsed = parseStatementArray(text.trim(), flags.filter(Boolean).length);
+    if (!parsed) {
+      console.warn("[PackageChar] two-sentence restore returned unparseable output");
+      return revisions;
+    }
+
+    const next = [...revisions];
+    let p = 0;
+    for (let i = 0; i < next.length; i++) {
+      if (!flags[i]) continue;
+      const restored = parsed[p++]?.trim();
+      if (restored && parseStatement(restored).hasTwoSentences) {
+        next[i] = restored;
+      }
+    }
+    return next;
+  } catch (error) {
+    console.error("[PackageChar] two-sentence restore failed:", error);
+    return revisions;
+  }
 }
 
 /** Re-export validation helper for callers that only need a check. */

--- a/src/lib/statement-char-enforce.ts
+++ b/src/lib/statement-char-enforce.ts
@@ -16,7 +16,7 @@ import {
 import { parseStatement } from "@/lib/sentence-utils";
 
 /** Absolute max LLM compress attempts for a package (hard cap). */
-export const MAX_PACKAGE_COMPRESS_ATTEMPTS = 2;
+export const MAX_PACKAGE_COMPRESS_ATTEMPTS = 3;
 
 /** How the UI combines multi-statement packages (epb-shell-form / mpa cards). */
 export function combineStatementsForDisplay(statements: string[]): string {
@@ -105,38 +105,14 @@ export function applyDeterministicCompress(text: string): string {
   return result;
 }
 
-/**
- * Last-resort trim: drop trailing clauses at comma boundaries until ≤ max.
- * Prefer cutting from the end so the lead action stays intact.
- */
-export function trimToMaxAtClauseBoundary(
-  text: string,
-  maxChars: number
-): string {
-  let result = text.trim();
-  if (result.length <= maxChars) return result;
-
-  while (result.length > maxChars) {
-    const cut = result.lastIndexOf(",");
-    if (cut < Math.floor(maxChars * 0.45)) {
-      // No safe clause boundary — hard cut at word boundary
-      const slice = result.slice(0, maxChars);
-      const lastSpace = slice.lastIndexOf(" ");
-      result =
-        lastSpace > Math.floor(maxChars * 0.6)
-          ? slice.slice(0, lastSpace).trim()
-          : slice.trim();
-      break;
-    }
-    result = result.slice(0, cut).trim();
-  }
-
-  // Ensure we don't end mid-punctuation awkwardly
-  result = result.replace(/[,&\s]+$/, "").trim();
-  if (result && !/[.!?]$/.test(result)) {
-    // Keep as clause; UI may join with period
-  }
-  return result;
+function statementsAreComplete(statements: string[]): boolean {
+  return (
+    statements.length > 0 &&
+    statements.every((s) => {
+      const t = s.trim();
+      return t.length >= 8 && /[.!?]$/.test(t);
+    })
+  );
 }
 
 function buildPackageCompressPrompt(
@@ -163,9 +139,10 @@ RULES:
 2. Combined length of all statements (plus ~1–2 chars for the join) MUST be ≤ ${targetMax}
 3. Prefer denser abbreviations: hrs, mos, wks, sq, flt, mbrs, ops, &
 4. Keep EVERY metric, dollar amount, unit name, and acronym
-5. Keep one sentence per array item — no semicolons, no em-dashes (-- or —), no "<" or ">"
-6. Do NOT invent new facts
-7. Count characters carefully before answering
+5. Each array item MUST be a COMPLETE sentence ending with a period — never truncate, never drop a trailing clause mid-thought
+6. Keep one sentence per array item — no semicolons, no em-dashes (-- or —), no "<" or ">"
+7. Do NOT invent new facts. Do NOT merge two statements into one. Do NOT drop a statement
+8. Count characters carefully before answering
 
 OUTPUT (JSON only):
 ["compressed statement 1", "compressed statement 2"]`;
@@ -201,14 +178,45 @@ export interface PackageEnforceResult {
     | "none"
     | "deterministic"
     | "llm"
-    | "trim_fallback"
     | "per_statement";
   stillOver: boolean;
 }
 
+async function llmCompressPackage(opts: {
+  current: string[];
+  combined: number;
+  targetMax: number;
+  model: LanguageModel;
+}): Promise<string[] | null> {
+  const charsOver = opts.combined - opts.targetMax;
+  const { text } = await generateText({
+    model: opts.model,
+    system:
+      "You are a precise EPB editor. Compress statements to fit a hard combined character budget. Every statement must stay a complete sentence. Never truncate. Output JSON only.",
+    prompt: buildPackageCompressPrompt(
+      opts.current,
+      opts.combined,
+      opts.targetMax,
+      charsOver
+    ),
+    temperature: 0.2,
+    maxOutputTokens: opts.current.length >= 2 ? 1400 : 800,
+  });
+
+  const parsed = parseStatementArray(text.trim(), opts.current.length);
+  if (!parsed || !statementsAreComplete(parsed)) return null;
+
+  const next = parsed.map(applyDeterministicCompress);
+  if (!statementsAreComplete(next)) return null;
+  if (combinedStatementLength(next) >= opts.combined) return null;
+  return next;
+}
+
 /**
  * Best-effort enforce combined ≤ targetMax for a statement package.
- * Single-statement packages use enforceCharacterLimits when a model is provided.
+ * Compresses with abbreviations and LLM rewrite only — never truncates
+ * a sentence to fit. If still over after retries, stillOver is true and
+ * the returned statements stay complete.
  */
 export async function enforcePackageCharacterLimit(
   statements: string[],
@@ -248,14 +256,30 @@ export async function enforcePackageCharacterLimit(
         model: options.model,
         context: options.context,
       });
-      current = applyDeterministicCompress(result.statement);
-      attempts = result.attempts;
-      method = result.wasAdjusted ? "per_statement" : method;
+      const next = applyDeterministicCompress(result.statement);
+      if (statementsAreComplete([next])) {
+        current = next;
+        attempts = result.attempts;
+        method = result.wasAdjusted ? "per_statement" : method;
+      }
     }
 
-    if (current.length > targetMax) {
-      current = trimToMaxAtClauseBoundary(current, targetMax);
-      method = "trim_fallback";
+    if (current.length > targetMax && options.model) {
+      try {
+        attempts++;
+        const compressed = await llmCompressPackage({
+          current: [current],
+          combined: current.length,
+          targetMax,
+          model: options.model,
+        });
+        if (compressed) {
+          current = compressed[0];
+          method = "llm";
+        }
+      } catch (error) {
+        console.error("[PackageChar] single-statement compress failed:", error);
+      }
     }
 
     return {
@@ -299,71 +323,29 @@ export async function enforcePackageCharacterLimit(
   if (options.model && maxAttempts > 0) {
     while (combined > targetMax && attempts < maxAttempts) {
       attempts++;
-      const charsOver = combined - targetMax;
       try {
-        const { text } = await generateText({
+        const next = await llmCompressPackage({
+          current,
+          combined,
+          targetMax,
           model: options.model,
-          system:
-            "You are a precise EPB editor. Compress statements to fit a hard combined character budget. Output JSON only.",
-          prompt: buildPackageCompressPrompt(
-            current,
-            combined,
-            targetMax,
-            charsOver
-          ),
-          temperature: 0.2,
-          maxOutputTokens: 800,
         });
-
-        const parsed = parseStatementArray(text.trim(), current.length);
-        if (!parsed) {
+        if (!next) {
           console.warn(
-            `[PackageChar] LLM attempt ${attempts} returned unparseable output`
+            `[PackageChar] LLM attempt ${attempts} rejected (incomplete, unparseable, or not shorter)`
           );
-          break;
-        }
-
-        const next = parsed.map(applyDeterministicCompress);
-        const nextCombined = combinedStatementLength(next);
-
-        // Accept only if we improved (shorter) — never grow
-        if (nextCombined >= combined) {
-          console.warn(
-            `[PackageChar] LLM attempt ${attempts} did not shrink (${nextCombined} ≥ ${combined}), stopping`
-          );
-          break;
+          continue;
         }
 
         current = next;
-        combined = nextCombined;
+        combined = combinedStatementLength(current);
         wasAdjusted = true;
         method = "llm";
-
-        if (combined <= targetMax) break;
       } catch (error) {
         console.error(`[PackageChar] LLM attempt ${attempts} failed:`, error);
         break;
       }
     }
-  }
-
-  // Last resort: trim longest statement(s) at clause boundaries
-  if (combined > targetMax) {
-    const overhead = current.length > 1 ? (current[0].endsWith(".") ? 1 : 2) : 0;
-    // Budget each statement proportionally to current lengths
-    const bodyBudget = Math.max(40, targetMax - overhead);
-    const totalBody = current.reduce((sum, s) => sum + s.length, 0) || 1;
-
-    current = current.map((s) => {
-      const share = Math.max(
-        40,
-        Math.floor((s.length / totalBody) * bodyBudget)
-      );
-      return s.length > share ? trimToMaxAtClauseBoundary(s, share) : s;
-    });
-    combined = combinedStatementLength(current);
-    wasAdjusted = true;
-    method = "trim_fallback";
   }
 
   return {
@@ -377,10 +359,16 @@ export async function enforcePackageCharacterLimit(
   };
 }
 
+export interface RevisionEnforceResult {
+  text: string;
+  stillOver: boolean;
+  method: PackageEnforceResult["method"];
+}
+
 /**
  * Enforce a hard max on one revised blob (one or two joined sentences).
  * Splits, compresses as a shared package, then re-joins for the UI.
- * Never clause-trims a joined two-sentence blob (that drops sentence 2).
+ * Never truncates a sentence to fit the cap.
  */
 export async function enforceRevisionText(
   text: string,
@@ -390,10 +378,14 @@ export async function enforceRevisionText(
     maxAttempts?: number;
     context?: string;
   } = {}
-): Promise<string> {
+): Promise<RevisionEnforceResult> {
   const parts = splitJoinedStatements(text);
   const result = await enforcePackageCharacterLimit(parts, targetMax, options);
-  return combineStatementsForDisplay(result.statements);
+  return {
+    text: combineStatementsForDisplay(result.statements),
+    stillOver: result.stillOver,
+    method: result.method,
+  };
 }
 
 /**
@@ -422,7 +414,7 @@ export async function repairCollapsedTwoSentenceRevisions(
       prompt: `ORIGINAL TWO-SENTENCE PACKAGE:
 "${original.trim()}"
 
-These revisions collapsed to ONE sentence. Rewrite EACH as EXACTLY TWO sentences (Sentence. Sentence.) that share a ${targetMax}-character combined budget. Keep every metric, $, unit name, and acronym. Do not invent facts. Do not merge back into one sentence.
+These revisions collapsed to ONE sentence. Rewrite EACH as EXACTLY TWO complete sentences (Sentence. Sentence.) that share a ${targetMax}-character combined budget. Keep every metric, $, unit name, and acronym. Do not invent facts. Do not merge back into one sentence. Do not truncate a sentence to fit.
 
 COLLAPSED REVISIONS:
 ${numbered}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Revise of a two-sentence EPB package must return **two complete sentences** that **fit the myEval cap**. The previous last-resort path cut at commas (and could drop sentence 2) to fake a fit.

## Changes

- Prompt + parser: keep exactly N sentences (same `parseStatement` as split view).
- Restore collapsed one-sentence revisions with a dedicated LLM pass before char enforce.
- **Removed** `trimToMaxAtClauseBoundary` from package/revision enforce. Fit comes from abbreviations + LLM rewrite only.
- Revisions that are still over after compress are dropped rather than chopped. Generate also no longer trims to force the cap.
- Follow-up: `advisor-plans/028-fail-closed-when-revise-cannot-fit.md` (if *none* fit, return an error instead of uncompressed drafts).

## Test plan

- `npm test -- src/lib/__tests__/statement-char-enforce.test.ts src/lib/__tests__/revise-length-constraint.test.ts`
- On `/epb`, Revise a two-sentence 350-cap package: each version should be two full sentences, ≤ 350, no mid-clause cutoffs.

Sacred: `mpa-section-card.tsx` split/DnD untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a11aa34-813c-4af1-a337-e87c938543d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a11aa34-813c-4af1-a337-e87c938543d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

