### PR TITLE
Fix revise 500 from nested JSON .trim() TypeError

### DIFF
--- a/src/app/api/revise-selection/route.ts
+++ b/src/app/api/revise-selection/route.ts
@@ -41,7 +41,7 @@ import {
   expectedRevisionSentenceCount,
   sanitizeMaxCharacters,
 } from "@/lib/revise-length-constraint";
-import { parseStatement } from "@/lib/sentence-utils";
+import { asPlainText, parseRevisionList, parseStatement } from "@/lib/sentence-utils";
 
 // Allow up to 60s for LLM calls (initial generation + quality control pass)
 export const maxDuration = 60;
@@ -355,15 +355,14 @@ export async function POST(request: Request) {
     }
 
     const body: ReviseSelectionRequest = await request.json();
+    const fullStatement = asPlainText(body.fullStatement);
+    const selectedText = asPlainText(body.selectedText);
     const { 
-      fullStatement, 
-      selectedText, 
       selectionStart, 
       selectionEnd, 
       model, 
       mode = "general", 
       context, 
-      usedVerbs = [],
       rateeId,
       cycleYear,
       excludeMpa,
@@ -376,6 +375,9 @@ export async function POST(request: Request) {
       rateeRank,
       rateeAfsc,
     } = body;
+    const usedVerbs = Array.isArray(body.usedVerbs)
+      ? body.usedVerbs.map((v) => asPlainText(v)).filter(Boolean)
+      : [];
     const maxCharacters = sanitizeMaxCharacters(maxCharactersRaw);
     
     // Load user's custom duty description prompt if this is a duty description revision
@@ -632,9 +634,9 @@ ${lengthGuidance.promptBlock}
 ${sentenceCountGuidance}
 ${lengthCapNote ? `LENGTH OVERRIDE: ${lengthCapNote}` : ""}
 
-Generate ${versionCount} revisions of ONLY the selected portion${sentenceCount === 2 ? ". Each revision string MUST contain exactly two sentences." : ""}.
+Generate ${versionCount} revisions of ONLY the selected portion${sentenceCount === 2 ? ". Each revision MUST be one JSON string containing exactly two sentences joined by a period and a space — never a nested array." : ""}.
 
-Return JSON array only: [${Array.from({ length: versionCount }, (_, i) => `"revision${i + 1}"`).join(", ")}]`;
+Return a JSON array of strings only: [${Array.from({ length: versionCount }, (_, i) => `"revision${i + 1}"`).join(", ")}]`;
 
     const { text } = await generateText({
       model: modelProvider,
@@ -648,7 +650,7 @@ Return JSON array only: [${Array.from({ length: versionCount }, (_, i) => `"revi
     try {
       const jsonMatch = text.match(/\[[\s\S]*\]/);
       if (jsonMatch) {
-        revisions = JSON.parse(jsonMatch[0]);
+        revisions = parseRevisionList(JSON.parse(jsonMatch[0]), versionCount);
       }
     } catch {
       // Fallback: split by newlines if JSON parsing fails

--- a/src/lib/__tests__/sentence-utils.test.ts
+++ b/src/lib/__tests__/sentence-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  asPlainText,
+  parseRevisionList,
+  parseStatement,
+} from "@/lib/sentence-utils";
+
+describe("asPlainText", () => {
+  it("returns strings unchanged", () => {
+    expect(asPlainText("Led team.")).toBe("Led team.");
+  });
+
+  it("joins nested sentence arrays without throwing", () => {
+    expect(
+      asPlainText(["Executed a $2M expansion, boosting readiness.", "Commanded AFSOUTH cyber center."])
+    ).toBe("Executed a $2M expansion, boosting readiness. Commanded AFSOUTH cyber center.");
+  });
+
+  it("does not throw on null or objects", () => {
+    expect(asPlainText(null)).toBe("");
+    expect(asPlainText({ text: "Hello." })).toBe("Hello.");
+  });
+});
+
+describe("parseRevisionList", () => {
+  it("flattens nested two-sentence arrays from the model", () => {
+    const raw = [
+      ["Sent one about networks.", "Sent two about cyber."],
+      "Already a single string. With two sentences.",
+    ];
+    const out = parseRevisionList(raw, 3);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toContain("Sent one");
+    expect(out[0]).toContain("Sent two");
+    expect(out.every((s) => typeof s === "string")).toBe(true);
+  });
+
+  it("returns empty for garbage", () => {
+    expect(parseRevisionList(null, 3)).toEqual([]);
+    expect(parseRevisionList({}, 3)).toEqual([]);
+  });
+});
+
+describe("parseStatement", () => {
+  it("accepts a two-sentence string array without calling .trim on it", () => {
+    const parsed = parseStatement([
+      "Led 5-mbr team overhauling network, cut downtime 90%, boosting readiness.",
+      "Directed cyber center supporting 10 sites, vital for SOUTHCOM ops.",
+    ]);
+    expect(parsed.hasTwoSentences).toBe(true);
+    expect(parsed.sentences).toHaveLength(2);
+  });
+});

--- a/src/lib/banned-formatting.ts
+++ b/src/lib/banned-formatting.ts
@@ -11,6 +11,7 @@
  */
 
 import { generateText, type LanguageModel } from "ai";
+import { asPlainText } from "@/lib/sentence-utils";
 
 /** Absolute ceiling — never more than this many LLM revision calls. */
 export const MAX_BANNED_FORMATTING_REVISIONS = 2;
@@ -196,9 +197,10 @@ export function hasBannedFormatting(text: string): boolean {
 
 /** Instant, no-LLM replacement of known banned patterns. */
 export function applyDeterministicBannedFormattingFixes(
-  text: string
+  text: unknown
 ): DeterministicFixResult {
-  let result = text;
+  const original = asPlainText(text);
+  let result = original;
   const fixedLabels: string[] = [];
 
   for (const rule of BANNED_FORMATTING_RULES) {
@@ -225,7 +227,7 @@ export function applyDeterministicBannedFormattingFixes(
   return {
     text: result,
     fixedLabels,
-    changed: result !== text.trim(),
+    changed: result !== original.trim(),
   };
 }
 
@@ -267,14 +269,14 @@ ${statement}`;
  * 5. Stop — never loops beyond the cap
  */
 export async function repairBannedFormatting(
-  statement: string,
+  statement: unknown,
   options: {
     model?: LanguageModel;
     /** LLM revision attempts; hard-capped at MAX_BANNED_FORMATTING_REVISIONS */
     maxAttempts?: number;
   } = {}
 ): Promise<BannedFormattingRepairResult> {
-  const original = statement.trim();
+  const original = asPlainText(statement).trim();
   const initialViolations = findBannedFormattingViolations(original);
   const violationsFound = initialViolations.map((v) => v.label);
 
@@ -398,7 +400,7 @@ export async function repairBannedFormatting(
  * Repair an array of statements. Sequential to keep LLM attempt budget predictable.
  */
 export async function repairBannedFormattingBatch(
-  statements: string[],
+  statements: unknown[],
   options: {
     model?: LanguageModel;
     maxAttempts?: number;

--- a/src/lib/sentence-utils.ts
+++ b/src/lib/sentence-utils.ts
@@ -20,20 +20,56 @@ export interface ParsedStatement {
 }
 
 /**
+ * Coerce LLM / JSON payloads into a single string.
+ * Revise asked for two sentences and models sometimes return
+ * `["sent 1.", "sent 2."]` (or a nested array) instead of one string —
+ * calling `.trim()` on that throws TypeError.
+ */
+export function asPlainText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(asPlainText).filter(Boolean).join(" ");
+  }
+  if (value && typeof value === "object") {
+    const rec = value as Record<string, unknown>;
+    if (typeof rec.text === "string") return rec.text;
+    if (typeof rec.statement === "string") return rec.statement;
+  }
+  return "";
+}
+
+/** Flatten a JSON revision array into strings (max `limit` items). */
+export function parseRevisionList(raw: unknown, limit: number): string[] {
+  const cap = Math.max(1, Math.floor(limit) || 1);
+  if (!Array.isArray(raw)) {
+    const one = asPlainText(raw).trim();
+    return one ? [one] : [];
+  }
+  return raw
+    .map((item) => asPlainText(item).trim())
+    .filter(Boolean)
+    .slice(0, cap);
+}
+
+/**
  * Parse a statement into its component sentences
  * Handles edge cases like abbreviations, numbers with decimals, etc.
  */
-export function parseStatement(text: string): ParsedStatement {
-  if (!text || !text.trim()) {
+export function parseStatement(text: unknown): ParsedStatement {
+  const rawInput = asPlainText(text);
+  if (!rawInput.trim()) {
     return {
       sentences: [],
-      raw: text || "",
+      raw: rawInput,
       hasTwoSentences: false,
     };
   }
 
   // Normalize whitespace - replace multiple spaces/newlines with single space
-  const normalized = text.trim().replace(/\s+/g, ' ');
+  const normalized = rawInput.trim().replace(/\s+/g, ' ');
   
   // Find sentence boundaries - look for period followed by space and capital letter
   // or period at end of string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Production `POST /api/revise-selection` 500ed in ~1.7s:

`TypeError: a.trim is not a function`

The two-sentence revise prompt made the model return nested JSON (`[["sent 1.", "sent 2."], ...]`) instead of an array of strings. `parseStatement` / banned-formatting then called `.trim()` on an array.

## Fix

- `asPlainText` / `parseRevisionList` coerce nested arrays and non-strings
- `parseStatement` and banned-formatting no longer assume `string`
- Prompt now says each revision is **one JSON string**, never a nested array

## Test

`npm test -- src/lib/__tests__/sentence-utils.test.ts` — nested two-sentence arrays do not throw and flatten correctly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a11aa34-813c-4af1-a337-e87c938543d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a11aa34-813c-4af1-a337-e87c938543d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

