### PR TITLE
Fill short EPB revise packages to 332–350 chars

### DIFF
--- a/src/app/api/revise-selection/route.ts
+++ b/src/app/api/revise-selection/route.ts
@@ -41,7 +41,12 @@ import {
   expectedRevisionSentenceCount,
   sanitizeMaxCharacters,
 } from "@/lib/revise-length-constraint";
-import { asPlainText, parseRevisionList, parseStatement } from "@/lib/sentence-utils";
+import {
+  asPlainText,
+  coalesceTwoSentenceRevisions,
+  parseRevisionList,
+  parseStatement,
+} from "@/lib/sentence-utils";
 
 // Allow up to 60s for LLM calls (initial generation + quality control pass)
 export const maxDuration = 60;
@@ -293,6 +298,7 @@ ${availableVerbs.slice(0, 20).join(", ")}
 - Em-dashes: -- or — (ABSOLUTELY NEVER use these)
 - Semicolons: ;
 - Slashes: /
+- Parentheses: ( )
 - Comparison symbols: < or > (write "under 24 hrs" / "over 90%")
 
 **USE ONLY:** Commas (,) inside a sentence. If the original has two sentences, keep a period between them.
@@ -628,7 +634,7 @@ ${context ? `ADDITIONAL GUIDANCE: ${context}` : ""}
 
 MODE: ${mode.toUpperCase()}
 ${isDutyDescription ? "⚠️ DUTY DESCRIPTION - Use PRESENT TENSE only. Describe scope & responsibility factually. NO performance verbs, NO subjective adjectives, NO accomplishment results. REPHRASE ONLY — do not invent impact, personnel counts, or geographic scope." : "⚠️ REPHRASE ONLY — do not invent metrics, personnel counts, or impact not in the source."}
-${mode === "expand" && !lengthGuidance.mustCompressToFit ? "Make it LONGER with longer synonyms for existing content only — never add new facts." : mode === "compress" || lengthGuidance.mustCompressToFit ? "Make it SHORTER with concise words and abbreviations." : isDutyDescription ? "Rephrase with improved word economy and flow while keeping present tense and every factual element from the source." : "Improve quality while keeping the same facts."}
+${mode === "expand" && !lengthGuidance.mustCompressToFit ? "Make it LONGER with longer synonyms for existing content only — never add new facts." : mode === "compress" && !lengthGuidance.mustCompressToFit ? "Make it SHORTER with concise words and abbreviations." : lengthGuidance.mustCompressToFit ? `Fit ${lengthGuidance.targetMin}–${lengthGuidance.targetMax} characters. Do not undershoot into ~200 characters.` : isDutyDescription ? "Rephrase with improved word economy and flow while keeping present tense and every factual element from the source." : "Improve quality while keeping the same facts."}
 AGGRESSIVENESS: ${aggressiveness}% (${aggressiveness <= 20 ? "minimal changes" : aggressiveness <= 40 ? "conservative" : aggressiveness <= 60 ? "moderate" : aggressiveness <= 80 ? "aggressive" : "maximum rewrite"})
 ${lengthGuidance.promptBlock}
 ${sentenceCountGuidance}
@@ -650,7 +656,13 @@ Return a JSON array of strings only: [${Array.from({ length: versionCount }, (_,
     try {
       const jsonMatch = text.match(/\[[\s\S]*\]/);
       if (jsonMatch) {
-        revisions = parseRevisionList(JSON.parse(jsonMatch[0]), versionCount);
+        const parseLimit = sentenceCount === 2 ? versionCount * 2 : versionCount;
+        revisions = parseRevisionList(JSON.parse(jsonMatch[0]), parseLimit);
+        if (sentenceCount === 2) {
+          revisions = coalesceTwoSentenceRevisions(revisions, versionCount);
+        } else {
+          revisions = revisions.slice(0, versionCount);
+        }
       }
     } catch {
       // Fallback: split by newlines if JSON parsing fails
@@ -684,6 +696,7 @@ Return a JSON array of strings only: [${Array.from({ length: versionCount }, (_,
     if (lengthGuidance.selectionMax != null || sentenceCount === 2) {
       const {
         enforceRevisionText,
+        fillRevisionsTowardCap,
         repairCollapsedTwoSentenceRevisions,
       } = await import("@/lib/statement-char-enforce");
 
@@ -737,6 +750,21 @@ Return a JSON array of strings only: [${Array.from({ length: versionCount }, (_,
           console.warn(
             "[revise-selection] No complete revision fit the character cap; returning uncompressed complete drafts"
           );
+        }
+      }
+
+      if (lengthGuidance.selectionMax != null && !isDutyDescription) {
+        try {
+          revisions = await fillRevisionsTowardCap(
+            selectedText,
+            revisions.map((r) => (typeof r === "string" ? r.trim() : String(r ?? ""))),
+            lengthGuidance.targetMin,
+            lengthGuidance.selectionMax,
+            sentenceCount,
+            { model: modelProvider }
+          );
+        } catch (err) {
+          console.error("[revise-selection] fill-to-cap failed:", err);
         }
       }
     }

--- a/src/lib/__tests__/banned-formatting.test.ts
+++ b/src/lib/__tests__/banned-formatting.test.ts
@@ -49,6 +49,16 @@ describe("findBannedFormattingViolations", () => {
   it("flags > comparison shorthand", () => {
     expect(hasBannedFormatting("sustained >90% FMC")).toBe(true);
   });
+
+  it("flags and strips parentheses", () => {
+    expect(hasBannedFormatting("Commanded AFSOUTH CCC (10 sites)")).toBe(true);
+    const { text } = applyDeterministicBannedFormattingFixes(
+      "Commanded AFSOUTH CCC (10 sites), vital for SOUTHCOM ops."
+    );
+    expect(text).not.toContain("(");
+    expect(text).not.toContain(")");
+    expect(text).toMatch(/10 sites/);
+  });
 });
 
 describe("applyDeterministicBannedFormattingFixes", () => {

--- a/src/lib/__tests__/revise-length-constraint.test.ts
+++ b/src/lib/__tests__/revise-length-constraint.test.ts
@@ -66,7 +66,8 @@ describe("buildReviseLengthGuidance", () => {
     expect(g.targetMin).toBe(332);
     expect(g.promptBlock).toMatch(/keep TWO sentences/);
     expect(g.promptBlock).toMatch(/NON-NEGOTIABLE/);
-    expect(g.promptBlock).toMatch(/REMOVE at least 102/);
+    expect(g.promptBlock).toMatch(/332–350/);
+    expect(g.promptBlock).toMatch(/200 characters is a FAILURE/);
     expect(g.promptBlock).toMatch(/within 5%/);
     expect(g.promptBlock).not.toMatch(/±20%/);
   });

--- a/src/lib/__tests__/sentence-utils.test.ts
+++ b/src/lib/__tests__/sentence-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   asPlainText,
+  coalesceTwoSentenceRevisions,
   parseRevisionList,
   parseStatement,
 } from "@/lib/sentence-utils";
@@ -38,6 +39,34 @@ describe("parseRevisionList", () => {
   it("returns empty for garbage", () => {
     expect(parseRevisionList(null, 3)).toEqual([]);
     expect(parseRevisionList({}, 3)).toEqual([]);
+  });
+});
+
+describe("coalesceTwoSentenceRevisions", () => {
+  it("pairs a flat list of singles into two-sentence packages", () => {
+    const out = coalesceTwoSentenceRevisions(
+      [
+        "Led 5-mbr team overhauling network, cut downtime 90%, boosting readiness.",
+        "Directed cyber center supporting 10 sites, vital for SOUTHCOM ops.",
+        "Built backup circuit for 3 wings, restored comms in 2 hrs.",
+        "Authored cyber playbook resolving 12 MAJCOM tickets same day.",
+      ],
+      3
+    );
+    expect(out).toHaveLength(2);
+    expect(parseStatement(out[0]).hasTwoSentences).toBe(true);
+    expect(parseStatement(out[1]).hasTwoSentences).toBe(true);
+    expect(out[0]).toMatch(/Led 5-mbr/);
+    expect(out[0]).toMatch(/Directed cyber/);
+  });
+
+  it("leaves already-joined two-sentence revisions alone", () => {
+    const joined =
+      "Led 5-mbr team overhauling network, cut downtime 90%, boosting readiness. Directed cyber center supporting 10 sites, vital for SOUTHCOM ops.";
+    expect(coalesceTwoSentenceRevisions([joined, joined], 3)).toEqual([
+      joined,
+      joined,
+    ]);
   });
 });
 

--- a/src/lib/__tests__/statement-char-enforce.test.ts
+++ b/src/lib/__tests__/statement-char-enforce.test.ts
@@ -6,6 +6,7 @@ import {
   combinedStatementLength,
   enforcePackageCharacterLimit,
   enforceRevisionText,
+  fillRevisionsTowardCap,
   splitJoinedStatements,
 } from "@/lib/statement-char-enforce";
 
@@ -103,5 +104,23 @@ describe("enforceRevisionText", () => {
     expect(parseStatement(out.text).hasTwoSentences).toBe(true);
     expect(out.stillOver).toBe(true);
     expect(out.text.length).toBeGreaterThan(350);
+  });
+});
+
+describe("fillRevisionsTowardCap", () => {
+  it("leaves short revisions unchanged when no model is provided", async () => {
+    const short =
+      "Led 5-mbr team overhauling network, cut downtime 90%. Directed cyber center for 10 sites.";
+    expect(short.length).toBeLessThan(332);
+    const out = await fillRevisionsTowardCap(
+      `${OVER_A} ${OVER_B}`,
+      [short],
+      332,
+      350,
+      2,
+      { model: undefined as never }
+    );
+    expect(out[0]).toBe(short);
+    expect(parseStatement(out[0]).hasTwoSentences).toBe(true);
   });
 });

--- a/src/lib/banned-formatting.ts
+++ b/src/lib/banned-formatting.ts
@@ -24,7 +24,8 @@ export type BannedFormattingRuleId =
   | "unicode_dash"
   | "less_than"
   | "greater_than"
-  | "semicolon";
+  | "semicolon"
+  | "parentheses";
 
 export interface BannedFormattingRule {
   id: BannedFormattingRuleId;
@@ -98,6 +99,12 @@ export const BANNED_FORMATTING_RULES: BannedFormattingRule[] = [
     pattern: /;/g,
     replacement: ", ",
   },
+  {
+    id: "parentheses",
+    label: "(",
+    pattern: /[()]/g,
+    replacement: "",
+  },
 ];
 
 /**
@@ -141,6 +148,7 @@ export interface BannedFormattingRepairResult {
 
 function normalizeAfterReplace(text: string): string {
   return text
+    .replace(/[()]/g, "")
     .replace(/\s{2,}/g, " ")
     .replace(/,\s*,\s*/g, ", ")
     .replace(/,\s*\./g, ".")
@@ -245,6 +253,7 @@ REQUIRED REPLACEMENTS:
 - "b/c" → "because"
 - "--" / "—" / "–" → commas
 - ";" → commas
+- "(" / ")" → remove (never use parentheses)
 - "<24" / "< 24" → "under 24" (never use "<")
 - ">90" / "> 90" → "over 90" (never use ">")
 

--- a/src/lib/revise-length-constraint.ts
+++ b/src/lib/revise-length-constraint.ts
@@ -42,9 +42,10 @@ export function buildSentenceCountGuidance(count: 1 | 2): string {
     return `**SENTENCE COUNT (NON-NEGOTIABLE):** The original is TWO sentences that SHARE one character budget.
 Each revision MUST be exactly TWO sentences: "Sentence one. Sentence two."
 - Do NOT merge them into one comma-spliced sentence to save space
-- Do NOT drop the second sentence — compress BOTH until the combined length fits
+- Do NOT drop the second sentence
 - Each sentence is its own standalone sentence with its own opening verb
-- Use a period + space BETWEEN the two sentences; commas only INSIDE a sentence`;
+- Use a period + space BETWEEN the two sentences; commas only INSIDE a sentence
+- Do NOT put the second accomplishment in parentheses`
   }
   return `**SENTENCE COUNT:** The original is ONE sentence. Keep exactly one sentence — do not split it into two.`;
 }
@@ -109,20 +110,19 @@ export function buildReviseLengthGuidance(opts: {
 
     const promptBlock = over
       ? `**HARD CHARACTER LIMIT (NON-NEGOTIABLE):**
-The revised selection MUST be ≤ ${selMax} characters. The original selection is ${selectedLength} characters (${charsOver} OVER). Over-limit text cannot be used in myEval.${spliceNote}
+The revised selection MUST be ${targetMin}–${targetMax} characters. The original is ${selectedLength} (${charsOver} OVER the ${selMax} max). Over-limit text cannot be used in myEval.${spliceNote}
 
-Do NOT stay near the original length. You must REMOVE at least ${charsOver} characters.
-How to compress (keep every metric, $, unit name, and acronym):
-- Prefer "&" over "and"; drop "the" where grammar still holds
-- Abbreviate: hrs, mos, wks, mbrs, sq, flt, gp, wg, ops, pers
-- Cut filler: "this action", "this initiative", "this directly", "resulting in", "providing support for"
-- Merge clauses WITHIN each sentence; drop the weakest impact phrase if still over
+Compress TO the band — not as short as possible. Landing near 200 characters is a FAILURE.
+Keep every metric, $, unit name, and acronym. After cutting filler, EXPAND remaining clauses with longer synonyms until you are ≥ ${targetMin}.
+- Prefer "&" over "and" only if you are still over ${selMax}
+- Cut filler: "this action", "this initiative", "this directly", "resulting in"
+- Merge clauses WITHIN each sentence if still over ${selMax}
 - If the original has TWO sentences, keep TWO sentences — never merge or drop one
-- Count characters BEFORE returning. If any version is over ${selMax}, rewrite it shorter.
+- Count characters BEFORE returning. If under ${targetMin}, add density. If over ${selMax}, cut more.
 
-Target: ${targetMin}–${targetMax} characters (within 5% of the ${selMax} max). MAXIMUM ${selMax}. Do not land 15–20% under the cap.`
-      : `**HARD CHARACTER LIMIT:** Revised selection MUST be ≤ ${selMax} characters (full field max ${hardMax}).${spliceNote}
-Target ${targetMin}–${targetMax} characters (within 5% of the field max). NEVER exceed ${selMax}. Do not land 15–20% under the cap.`;
+Target: ${targetMin}–${targetMax} characters (within 5% of the ${selMax} max). MAXIMUM ${selMax}.`
+      : `**HARD CHARACTER LIMIT:** Revised selection MUST be ${targetMin}–${targetMax} characters (full field max ${hardMax}).${spliceNote}
+Stay within 5% of the field max. NEVER exceed ${selMax}. Landing ~200 characters when the max is ${selMax} is a FAILURE.`;
 
     return {
       hardMax,

--- a/src/lib/sentence-utils.ts
+++ b/src/lib/sentence-utils.ts
@@ -55,6 +55,35 @@ export function parseRevisionList(raw: unknown, limit: number): string[] {
 }
 
 /**
+ * Models often emit two-sentence packages as a flat list of singles:
+ * [v1s1, v1s2, v2s1, v2s2, ...]. Pair those so each revision is one package.
+ */
+export function coalesceTwoSentenceRevisions(
+  items: string[],
+  versionCount: number
+): string[] {
+  const cap = Math.max(1, Math.floor(versionCount) || 1);
+  const cleaned = items.map((s) => asPlainText(s).trim()).filter(Boolean);
+  if (cleaned.length === 0) return [];
+  if (cleaned.every((s) => parseStatement(s).hasTwoSentences)) {
+    return cleaned.slice(0, cap);
+  }
+  if (
+    cleaned.length >= 2 &&
+    cleaned.length % 2 === 0 &&
+    cleaned.every((s) => !parseStatement(s).hasTwoSentences)
+  ) {
+    const paired: string[] = [];
+    for (let i = 0; i < cleaned.length && paired.length < cap; i += 2) {
+      const a = cleaned[i].endsWith(".") ? cleaned[i] : `${cleaned[i]}.`;
+      paired.push(`${a} ${cleaned[i + 1]}`.trim());
+    }
+    return paired;
+  }
+  return cleaned.slice(0, cap);
+}
+
+/**
  * Parse a statement into its component sentences
  * Handles edge cases like abbreviations, numbers with decimals, etc.
  */

--- a/src/lib/statement-char-enforce.ts
+++ b/src/lib/statement-char-enforce.ts
@@ -366,10 +366,76 @@ export interface RevisionEnforceResult {
 }
 
 /**
- * Enforce a hard max on one revised blob (one or two joined sentences).
- * Splits, compresses as a shared package, then re-joins for the UI.
- * Never truncates a sentence to fit the cap.
+ * Expand revisions that landed far under the field max (e.g. ~200 of 350).
+ * One batched LLM call. Never invents facts. Keeps sentence count.
  */
+export async function fillRevisionsTowardCap(
+  original: string,
+  revisions: string[],
+  targetMin: number,
+  targetMax: number,
+  expectedSentences: 1 | 2,
+  options: { model: LanguageModel }
+): Promise<string[]> {
+  const shortFlags = revisions.map((r) => {
+    const t = typeof r === "string" ? r.trim() : "";
+    return t.length > 0 && t.length < targetMin;
+  });
+  if (!shortFlags.some(Boolean) || !options.model) return revisions;
+
+  const numbered = revisions
+    .map((r, i) => (shortFlags[i] ? `[${i + 1}] (${r.trim().length} chars) ${r.trim()}` : null))
+    .filter((line): line is string => line !== null)
+    .join("\n\n");
+
+  try {
+    const { text } = await generateText({
+      model: options.model,
+      system:
+        "You expand EPB revisions that are too short. Keep every fact. Output JSON only.",
+      prompt: `ORIGINAL (source of facts — do not invent new metrics, units, or impact):
+"${original.trim()}"
+
+These revisions are TOO SHORT. Rewrite EACH so the combined length is ${targetMin}–${targetMax} characters.
+- Keep EXACTLY ${expectedSentences} sentence${expectedSentences === 2 ? "s" : ""} (period + space between two sentences)
+- Use longer synonyms and restore clauses from the original — do not add new facts
+- No parentheses, semicolons, em-dashes, or "<" / ">"
+- Count characters before answering. Under ${targetMin} is a failure. Over ${targetMax} is a failure.
+
+SHORT REVISIONS:
+${numbered}
+
+Return a JSON array of strings — one filled revision per short input, in the same order:
+["filled 1", "filled 2"]`,
+      temperature: 0.2,
+      maxOutputTokens: expectedSentences === 2 ? 1400 : 800,
+    });
+
+    const parsed = parseStatementArray(text.trim(), shortFlags.filter(Boolean).length);
+    if (!parsed) {
+      console.warn("[PackageChar] fill-to-cap returned unparseable output");
+      return revisions;
+    }
+
+    const next = [...revisions];
+    let p = 0;
+    for (let i = 0; i < next.length; i++) {
+      if (!shortFlags[i]) continue;
+      const filled = parsed[p++]?.trim();
+      if (!filled) continue;
+      if (filled.length > targetMax) continue;
+      if (filled.length <= next[i].trim().length) continue;
+      if (expectedSentences === 2 && !parseStatement(filled).hasTwoSentences) continue;
+      next[i] = filled;
+    }
+    return next;
+  } catch (error) {
+    console.error("[PackageChar] fill-to-cap failed:", error);
+    return revisions;
+  }
+}
+
+/** Enforce a hard max on one revised blob. Never truncates a sentence to fit. */
 export async function enforceRevisionText(
   text: string,
   targetMax: number,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Revise of a two-sentence EPB package was returning **two very short sentences (~200 chars)** against a 350 cap. The over-limit prompt said “compress / make it shorter” and never filled back up. The model also stuffed the second thought into **parentheses**, which EPB forbids.

A second bug: the model sometimes emitted a flat JSON list of singles (`[v1s1, v1s2, v2s1, …]`). We kept the first 3 items as separate revisions, so each looked like a stub.

## Fix

- Target band is **332–350**. Landing ~200 is called out as a failure in the prompt.
- After generate, **pair** flat one-sentence JSON items into two-sentence packages.
- One batched **fill-to-cap** pass restores density from the original facts only (no new metrics).
- Parentheses are banned and stripped deterministically.

## Test

`npm test -- src/lib/__tests__/sentence-utils.test.ts src/lib/__tests__/revise-length-constraint.test.ts src/lib/__tests__/statement-char-enforce.test.ts src/lib/__tests__/banned-formatting.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a11aa34-813c-4af1-a337-e87c938543d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a11aa34-813c-4af1-a337-e87c938543d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

