### PR TITLE
Fix misleading SendGrid toast when creating review share links

### DIFF
--- a/env.example
+++ b/env.example
@@ -7,6 +7,14 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=https://myepbuddy.com
 
+# Transactional email (Resend) — review share links, mentor-feedback alerts, invites, admin replies
+# From address must be on a domain verified in Resend.
+RESEND_API_KEY=re_your_resend_api_key
+EMAIL_FROM=MyEPBuddy <noreply@your-verified-domain.com>
+# Optional fallbacks / product-specific addresses:
+# FEEDBACK_FROM_EMAIL=MyEPBuddy <noreply@your-verified-domain.com>
+# FEEDBACK_NOTIFICATION_EMAIL=support@your-domain.com
+
 # Encryption Key for user API keys (REQUIRED)
 # Generate with: openssl rand -hex 32
 # This key encrypts user-provided API keys at rest in the database

--- a/plans/027-review-link-email-preview-tests.md
+++ b/plans/027-review-link-email-preview-tests.md
@@ -1,0 +1,99 @@
+# Plan 027: Add review-link email preview + route characterization tests
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3e8a076..HEAD -- src/lib/email/review-link.ts src/app/api/send-review-email/route.ts src/app/email-preview src/lib/__tests__/review-link-email.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none (PR that wired Resend for review emails can merge independently)
+- **Category**: tests | dx
+- **Planned at**: commit `3e8a076`, 2026-08-14
+- **Branch context**: follow-up to `cursor/fix-review-share-email-toast-0086` (review share toast no longer mentions SendGrid/Twilio)
+
+## Why this matters
+
+Review-link email HTML is now built in `src/lib/email/review-link.ts` and sent via Resend, matching managed-member invites. Managed invites already have a local preview route (`src/app/email-preview/managed-invite/page.tsx`) so designers/devs can eyeball copy without sending. Review links lack that preview, and `/api/send-review-email` has no characterization tests for the `email_not_configured` / ownership / success shapes. Small gaps — easy to regress the toast contract that users just complained about.
+
+## Current state
+
+- `src/lib/email/review-link.ts` — `buildReviewLinkEmail({ siteUrl, senderDisplayName, rateeName, rateeRank, mentorLabel, reviewUrl, expiresAt, shellType })` returns `{ subject, html, text }`. Covered by `src/lib/__tests__/review-link-email.test.ts` (HTML escape + award wording).
+- `src/app/api/send-review-email/route.ts` — auth + rate limit + ownership lookup by public `token` + Resend send. Returns:
+  - `{ success: true, emailSent: false, code: "email_not_configured", error: "…Copy and share…" }` when keys missing
+  - `{ success: true, emailSent: true }` on send success
+  - Builds `reviewUrl` **server-side** from `review_tokens` (do not reintroduce client `reviewUrl` trust).
+- Exemplar preview page: `src/app/email-preview/managed-invite/page.tsx` (renders `buildManagedMemberInviteEmail` HTML for new + existing variants).
+- Middleware already allows `/email-preview/` as public (`src/lib/supabase/middleware.ts`).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Unit tests | `npm run test -- src/lib/__tests__/review-link-email.test.ts` | pass |
+| Lint | `npm run lint` | 0 errors |
+| Manual preview | open `http://localhost:3000/email-preview/review-link` after `npm run dev` | HTML renders, no auth redirect |
+
+## Steps
+
+### 1. Add email preview page
+
+Create `src/app/email-preview/review-link/page.tsx` mirroring managed-invite:
+
+- Server component that calls `buildReviewLinkEmail` twice (EPB + award) with safe sample data.
+- Render `dangerouslySetInnerHTML` inside an iframe/`div` like the managed-invite preview (copy that file’s layout chrome — do not invent new design).
+- Include subject + plain-text `<pre>` for each sample.
+
+**Verify**: with `npm run dev`, `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/email-preview/review-link` → `200`.
+
+### 2. Add light characterization tests for response codes (unit-level)
+
+Do **not** spin up Next request handlers unless the repo already has a pattern for that. Prefer testing pure helpers already exported:
+
+- Keep/expand `review-link-email.test.ts` if preview samples need shared fixtures.
+- If you extract a tiny `normalizeSendReviewEmailBody` / response mapper, unit-test `email_not_configured` messaging strings so the UI contract cannot silently return `"SendGrid"` / `"Twilio"` again:
+
+```ts
+expect(message).not.toMatch(/sendgrid|twilio/i);
+```
+
+**Verify**: `npm run test -- src/lib/__tests__/review-link-email.test.ts` passes; grep the API route for SendGrid/Twilio returns nothing.
+
+### 3. Docs touch (optional, only if README already documents email-preview)
+
+If `README.md` lists email preview URLs, add `/email-preview/review-link`. Otherwise skip.
+
+## Out of scope
+
+- Wiring production Resend keys / DNS
+- Changing create-review-link-dialog toast UX further
+- Twilio/SMS
+- Rate-limit Redis migration
+- Any edits under `src/components/epb/mpa-section-card.tsx`
+
+## STOP conditions
+
+- Preview route redirects to login (middleware publicPaths drifted) — fix middleware allowlist first, then continue.
+- `buildReviewLinkEmail` signature changed vs excerpts — re-read and adapt; do not invent a second builder.
+- Temptation to reintroduce stub “Email service not configured. Please integrate SendGrid…” — STOP; that string must not return.
+
+## Done criteria
+
+- [ ] `/email-preview/review-link` returns 200 and shows EPB + award samples
+- [ ] No `SendGrid` / `Twilio` strings in `src/app/api/send-review-email/route.ts`
+- [ ] `npm run test -- src/lib/__tests__/review-link-email.test.ts` passes
+- [ ] `plans/README.md` row for 027 marked DONE
+
+## Maintenance
+
+Future transactional emails should: (1) live under `src/lib/email/`, (2) use Resend helpers, (3) get an `/email-preview/...` page, (4) never surface vendor names in user-facing toasts.

--- a/plans/README.md
+++ b/plans/README.md
@@ -57,6 +57,14 @@ Feature path: New Entry ▾ → Bulk paste → extract API → review/combine �
 
 Shipped: global token bucket + fair share in `consume_credit`; admin `default_key_rpm` (default 60); BYOK stays 5/60. See [026-default-key-bandwidth-followups.md](026-default-key-bandwidth-followups.md).
 
+### Review share email (2026-08)
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|------|-------|----------|--------|------------|--------|
+| 027  | Review-link email preview + characterization tests | P3 | S | Resend share-email ship | TODO |
+
+Shipped on `cursor/fix-review-share-email-toast-0086`: stub SendGrid/Twilio toast removed; Resend + copy-link fallback; server-built review URLs. See [027-review-link-email-preview-tests.md](027-review-link-email-preview-tests.md).
+
 ### Generate EPB score-based assignment (PR #17 follow-ups)
 
 Default selection after the smart two-sentence / stash-pop ship (`bb577bd`). Desperate underfill + non-billable `/api/plan-epb` were fixed in-branch; these plans cover remaining leverage.

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -53,28 +53,29 @@ async function notifyOwnerOfFeedback(params: {
 
   try {
     const admin = createAdminClient();
-    const { data: tokenRow, error: tokenError } = await admin
-      .from("review_tokens")
+    // review_tokens is missing from generated Database types — cast like other review routes.
+    const tokenResult = await admin
+      .from("review_tokens" as never)
       .select("created_by, shell_type, ratee_name, ratee_rank")
-      .eq("token", params.token)
+      .eq("token" as never, params.token)
       .maybeSingle();
 
-    if (tokenError || !tokenRow) {
-      console.warn("Mentor feedback notify: token lookup failed", tokenError);
-      return;
-    }
-
-    const row = tokenRow as {
+    const tokenRow = tokenResult.data as {
       created_by: string;
       shell_type: string;
       ratee_name: string;
       ratee_rank: string | null;
-    };
+    } | null;
+
+    if (tokenResult.error || !tokenRow) {
+      console.warn("Mentor feedback notify: token lookup failed", tokenResult.error);
+      return;
+    }
 
     const { data: profile, error: profileError } = await admin
       .from("profiles")
-      .select("email, full_name, first_name")
-      .eq("id", row.created_by)
+      .select("email, full_name")
+      .eq("id", tokenRow.created_by)
       .maybeSingle();
 
     if (profileError || !profile) {
@@ -85,7 +86,6 @@ async function notifyOwnerOfFeedback(params: {
     const owner = profile as {
       email: string | null;
       full_name: string | null;
-      first_name: string | null;
     };
     const to = (owner.email || "").trim();
     if (!to.includes("@")) {
@@ -93,13 +93,13 @@ async function notifyOwnerOfFeedback(params: {
       return;
     }
 
-    const shellType = parseShellType(row.shell_type);
+    const shellType = parseShellType(tokenRow.shell_type);
     const emailContent = buildMentorFeedbackReceivedEmail({
       siteUrl: getSiteUrl(),
-      recipientName: owner.first_name || owner.full_name,
+      recipientName: owner.full_name,
       reviewerName: params.reviewerName,
-      rateeName: row.ratee_name,
-      rateeRank: row.ratee_rank,
+      rateeName: tokenRow.ratee_name,
+      rateeRank: tokenRow.ratee_rank,
       shellType,
       commentCount: params.commentCount,
       appPath: appPathForShell(shellType),

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createAdminClient, createClient } from "@/lib/supabase/server";
+import { buildMentorFeedbackReceivedEmail } from "@/lib/email/mentor-feedback-received";
+import type { ReviewShellType } from "@/lib/email/review-link";
+import {
+  getResendApiKey,
+  getTransactionalFromEmail,
+  sendResendEmail,
+} from "@/lib/email/resend";
 
 interface FeedbackResult {
   success: boolean;
@@ -8,25 +15,119 @@ interface FeedbackResult {
   session_id?: string;
 }
 
+function getSiteUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    "https://myepbuddy.com"
+  );
+}
+
+function parseShellType(value: string | null | undefined): ReviewShellType {
+  if (value === "award" || value === "decoration" || value === "epb") {
+    return value;
+  }
+  return "epb";
+}
+
+function appPathForShell(shellType: ReviewShellType): string {
+  if (shellType === "award") return "/award";
+  if (shellType === "decoration") return "/decoration";
+  return "/generate";
+}
+
+/** Best-effort Resend notify to the package owner. Never fails the submit. */
+async function notifyOwnerOfFeedback(params: {
+  token: string;
+  reviewerName: string;
+  commentCount: number;
+}): Promise<void> {
+  const resendApiKey = getResendApiKey();
+  const fromEmail = getTransactionalFromEmail();
+  if (!resendApiKey || !fromEmail) {
+    console.warn(
+      "Mentor feedback submitted but owner email not sent — missing RESEND_API_KEY or EMAIL_FROM/FEEDBACK_FROM_EMAIL."
+    );
+    return;
+  }
+
+  try {
+    const admin = createAdminClient();
+    const { data: tokenRow, error: tokenError } = await admin
+      .from("review_tokens")
+      .select("created_by, shell_type, ratee_name, ratee_rank")
+      .eq("token", params.token)
+      .maybeSingle();
+
+    if (tokenError || !tokenRow) {
+      console.warn("Mentor feedback notify: token lookup failed", tokenError);
+      return;
+    }
+
+    const row = tokenRow as {
+      created_by: string;
+      shell_type: string;
+      ratee_name: string;
+      ratee_rank: string | null;
+    };
+
+    const { data: profile, error: profileError } = await admin
+      .from("profiles")
+      .select("email, full_name, first_name")
+      .eq("id", row.created_by)
+      .maybeSingle();
+
+    if (profileError || !profile) {
+      console.warn("Mentor feedback notify: profile lookup failed", profileError);
+      return;
+    }
+
+    const owner = profile as {
+      email: string | null;
+      full_name: string | null;
+      first_name: string | null;
+    };
+    const to = (owner.email || "").trim();
+    if (!to.includes("@")) {
+      console.warn("Mentor feedback notify: owner has no email");
+      return;
+    }
+
+    const shellType = parseShellType(row.shell_type);
+    const emailContent = buildMentorFeedbackReceivedEmail({
+      siteUrl: getSiteUrl(),
+      recipientName: owner.first_name || owner.full_name,
+      reviewerName: params.reviewerName,
+      rateeName: row.ratee_name,
+      rateeRank: row.ratee_rank,
+      shellType,
+      commentCount: params.commentCount,
+      appPath: appPathForShell(shellType),
+    });
+
+    await sendResendEmail({
+      resendApiKey,
+      from: fromEmail,
+      to,
+      subject: emailContent.subject,
+      html: emailContent.html,
+      text: emailContent.text,
+    });
+  } catch (err) {
+    console.error("Mentor feedback owner notify failed:", err);
+  }
+}
+
 // POST: Submit mentor feedback (public - no auth required)
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    
-    const body = await request.json();
-    const {
-      token,
-      reviewerName,
-      reviewerNameSource,
-      comments,
-    } = body;
 
-    // Validate required fields
+    const body = await request.json();
+    const { token, reviewerName, reviewerNameSource, comments } = body;
+
     if (!token) {
-      return NextResponse.json(
-        { error: "Token is required" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Token is required" }, { status: 400 });
     }
 
     if (!reviewerName) {
@@ -36,7 +137,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!reviewerNameSource || !["label", "provided", "generated"].includes(reviewerNameSource)) {
+    if (
+      !reviewerNameSource ||
+      !["label", "provided", "generated"].includes(reviewerNameSource)
+    ) {
       return NextResponse.json(
         { error: "Valid reviewer name source is required" },
         { status: 400 }
@@ -50,7 +154,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate each comment has required fields
     for (const comment of comments) {
       if (!comment.sectionKey || !comment.commentText) {
         return NextResponse.json(
@@ -60,39 +163,47 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Sanitize inputs to prevent XSS
-    const sanitizedReviewerName = reviewerName.slice(0, 100).replace(/<[^>]*>/g, "");
-    const sanitizedComments = comments.map((c: {
-      sectionKey: string;
-      sectionLabel?: string;
-      originalText?: string;
-      highlightStart?: number;
-      highlightEnd?: number;
-      highlightedText?: string;
-      commentText: string;
-      suggestion?: string;
-      suggestionType?: string;
-      replacementText?: string;
-      isFullRewrite?: boolean;
-      rewriteText?: string;
-    }) => ({
-      sectionKey: c.sectionKey?.slice(0, 50),
-      sectionLabel: c.sectionLabel?.slice(0, 100),
-      originalText: c.originalText?.slice(0, 5000),
-      highlightStart: typeof c.highlightStart === "number" ? c.highlightStart : null,
-      highlightEnd: typeof c.highlightEnd === "number" ? c.highlightEnd : null,
-      highlightedText: c.highlightedText?.slice(0, 1000),
-      commentText: c.commentText?.slice(0, 2000).replace(/<[^>]*>/g, ""),
-      suggestion: c.suggestion?.slice(0, 2000).replace(/<[^>]*>/g, ""),
-      suggestionType: c.suggestionType && ["comment", "replace", "delete"].includes(c.suggestionType) 
-        ? c.suggestionType 
-        : "comment",
-      replacementText: c.replacementText?.slice(0, 2000).replace(/<[^>]*>/g, ""),
-      isFullRewrite: c.isFullRewrite === true,
-      rewriteText: c.rewriteText?.slice(0, 5000).replace(/<[^>]*>/g, ""),
-    }));
+    const sanitizedReviewerName = reviewerName
+      .slice(0, 100)
+      .replace(/<[^>]*>/g, "");
+    const sanitizedComments = comments.map(
+      (c: {
+        sectionKey: string;
+        sectionLabel?: string;
+        originalText?: string;
+        highlightStart?: number;
+        highlightEnd?: number;
+        highlightedText?: string;
+        commentText: string;
+        suggestion?: string;
+        suggestionType?: string;
+        replacementText?: string;
+        isFullRewrite?: boolean;
+        rewriteText?: string;
+      }) => ({
+        sectionKey: c.sectionKey?.slice(0, 50),
+        sectionLabel: c.sectionLabel?.slice(0, 100),
+        originalText: c.originalText?.slice(0, 5000),
+        highlightStart:
+          typeof c.highlightStart === "number" ? c.highlightStart : null,
+        highlightEnd:
+          typeof c.highlightEnd === "number" ? c.highlightEnd : null,
+        highlightedText: c.highlightedText?.slice(0, 1000),
+        commentText: c.commentText?.slice(0, 2000).replace(/<[^>]*>/g, ""),
+        suggestion: c.suggestion?.slice(0, 2000).replace(/<[^>]*>/g, ""),
+        suggestionType:
+          c.suggestionType &&
+          ["comment", "replace", "delete"].includes(c.suggestionType)
+            ? c.suggestionType
+            : "comment",
+        replacementText: c.replacementText
+          ?.slice(0, 2000)
+          .replace(/<[^>]*>/g, ""),
+        isFullRewrite: c.isFullRewrite === true,
+        rewriteText: c.rewriteText?.slice(0, 5000).replace(/<[^>]*>/g, ""),
+      })
+    );
 
-    // Call the secure function to submit feedback
     const rpcResult = await supabase.rpc("submit_mentor_feedback", {
       p_token: token,
       p_reviewer_name: sanitizedReviewerName,
@@ -102,27 +213,25 @@ export async function POST(request: NextRequest) {
 
     if (rpcResult.error) {
       console.error("Feedback submission error:", rpcResult.error);
-      // Check for specific error messages
-      const errorMessage = rpcResult.error.message || "Failed to submit feedback";
-      return NextResponse.json(
-        { error: errorMessage },
-        { status: 500 }
-      );
+      const errorMessage =
+        rpcResult.error.message || "Failed to submit feedback";
+      return NextResponse.json({ error: errorMessage }, { status: 500 });
     }
 
-    // The RPC now returns a UUID (session_id) directly, or JSONB for older versions
     const result = rpcResult.data;
-    
-    // Handle both old JSONB format and new UUID format
+    let successPayload: {
+      success: true;
+      message?: string;
+      sessionId?: string;
+    };
+
     if (typeof result === "string") {
-      // New format: returns UUID directly
-      return NextResponse.json({
+      successPayload = {
         success: true,
         message: "Feedback submitted successfully",
         sessionId: result,
-      });
+      };
     } else if (result && typeof result === "object") {
-      // Old JSONB format for backwards compatibility
       const jsonResult = result as FeedbackResult;
       if (!jsonResult.success) {
         return NextResponse.json(
@@ -130,17 +239,26 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         );
       }
-      return NextResponse.json({
+      successPayload = {
         success: true,
         message: jsonResult.message,
         sessionId: jsonResult.session_id,
-      });
+      };
+    } else {
+      successPayload = {
+        success: true,
+        message: "Feedback submitted successfully",
+      };
     }
 
-    return NextResponse.json({
-      success: true,
-      message: "Feedback submitted successfully",
+    // Fire-and-forget owner email via Resend (does not block / fail submit)
+    void notifyOwnerOfFeedback({
+      token: typeof token === "string" ? token : String(token),
+      reviewerName: sanitizedReviewerName,
+      commentCount: sanitizedComments.length,
     });
+
+    return NextResponse.json(successPayload);
   } catch (error) {
     console.error("Feedback submission error:", error);
     return NextResponse.json(
@@ -154,13 +272,13 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
-    
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: "Unauthorized" },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { searchParams } = new URL(request.url);

--- a/src/app/api/send-review-email/route.ts
+++ b/src/app/api/send-review-email/route.ts
@@ -104,8 +104,6 @@ export async function POST(request: NextRequest) {
     )
       .trim()
       .toLowerCase();
-    const reviewUrl =
-      typeof body.reviewUrl === "string" ? body.reviewUrl.trim() : "";
     const rateeName = stripHtml(
       typeof body.rateeName === "string" ? body.rateeName : ""
     ).trim();
@@ -117,10 +115,9 @@ export async function POST(request: NextRequest) {
       typeof body.mentorLabel === "string"
         ? stripHtml(body.mentorLabel).trim()
         : null;
-    const shellType = parseShellType(body.shellType);
     const expiresAtLabel = formatExpiresAt(body.expiresAt);
 
-    if (!token || !recipientEmail || !reviewUrl) {
+    if (!token || !recipientEmail) {
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 }
@@ -137,7 +134,7 @@ export async function POST(request: NextRequest) {
     // Ensure the token belongs to the caller (public token string from create API).
     const { data: ownedToken, error: tokenLookupError } = await supabase
       .from("review_tokens")
-      .select("id")
+      .select("id, token, shell_type, expires_at, link_label, ratee_name, ratee_rank")
       .eq("token", token)
       .eq("created_by", user.id)
       .maybeSingle();
@@ -148,6 +145,27 @@ export async function POST(request: NextRequest) {
         { status: 404 }
       );
     }
+
+    const tokenRow = ownedToken as {
+      id: string;
+      token: string;
+      shell_type: string;
+      expires_at: string;
+      link_label: string | null;
+      ratee_name: string;
+      ratee_rank: string | null;
+    };
+
+    const shellType = parseShellType(tokenRow.shell_type);
+    // Build URL server-side — never trust a client-supplied reviewUrl in outbound email.
+    const reviewUrl = `${getSiteUrl().replace(/\/$/, "")}/review/${shellType}/${tokenRow.token}`;
+    const resolvedRateeName = rateeName || tokenRow.ratee_name || "the ratee";
+    const resolvedRateeRank = rateeRank || tokenRow.ratee_rank;
+    const resolvedMentorLabel = mentorLabel || tokenRow.link_label;
+    const resolvedExpiresAt =
+      expiresAtLabel !== "soon"
+        ? expiresAtLabel
+        : formatExpiresAt(tokenRow.expires_at);
 
     const { data: profile } = (await supabase
       .from("profiles")
@@ -178,11 +196,11 @@ export async function POST(request: NextRequest) {
     const emailContent = buildReviewLinkEmail({
       siteUrl: getSiteUrl(),
       senderDisplayName,
-      rateeName: rateeName || "the ratee",
-      rateeRank,
-      mentorLabel,
+      rateeName: resolvedRateeName,
+      rateeRank: resolvedRateeRank,
+      mentorLabel: resolvedMentorLabel,
       reviewUrl,
-      expiresAt: expiresAtLabel,
+      expiresAt: resolvedExpiresAt,
       shellType,
     });
 
@@ -234,7 +252,7 @@ export async function POST(request: NextRequest) {
         recipient_email: recipientEmail,
         email_sent_at: new Date().toISOString(),
       } as never)
-      .eq("id", (ownedToken as { id: string }).id)
+      .eq("id", tokenRow.id)
       .eq("created_by", user.id);
 
     if (updateError) {

--- a/src/app/api/send-review-email/route.ts
+++ b/src/app/api/send-review-email/route.ts
@@ -1,47 +1,90 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { stripHtml } from "@/lib/email/html-safe";
+import {
+  buildReviewLinkEmail,
+  type ReviewShellType,
+} from "@/lib/email/review-link";
+import {
+  getResendApiKey,
+  getTransactionalFromEmail,
+  ResendSendError,
+  sendResendEmail,
+} from "@/lib/email/resend";
 
 interface ProfileData {
   full_name: string | null;
   rank: string | null;
+  email: string | null;
 }
 
-// Rate limiting: Simple in-memory store (in production, use Redis)
-const emailRateLimits = new Map<string, { count: number; resetAt: number }>();
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_EMAILS_PER_HOUR = 10;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+type RateLimitRecord = { count: number; resetAt: number };
+const emailRateLimits = new Map<string, RateLimitRecord>();
 
 function checkRateLimit(userId: string): boolean {
   const now = Date.now();
   const record = emailRateLimits.get(userId);
-  
+
   if (!record || now > record.resetAt) {
-    emailRateLimits.set(userId, { count: 1, resetAt: now + 3600000 }); // 1 hour
+    emailRateLimits.set(userId, {
+      count: 1,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+    });
     return true;
   }
-  
+
   if (record.count >= MAX_EMAILS_PER_HOUR) {
     return false;
   }
-  
-  record.count++;
+
+  record.count += 1;
   return true;
 }
 
-// POST: Send review link via email
-// NOTE: This is a stub for user to integrate their email service (SendGrid/Twilio)
+function getSiteUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    "https://myepbuddy.com"
+  );
+}
+
+function parseShellType(value: unknown): ReviewShellType {
+  if (value === "award" || value === "decoration" || value === "epb") {
+    return value;
+  }
+  return "epb";
+}
+
+function formatExpiresAt(iso: unknown): string {
+  if (typeof iso !== "string" || !iso.trim()) return "soon";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString("en-US", {
+    timeZone: "UTC",
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+// POST: Send review link via email (Resend). Link creation is separate —
+// this route is best-effort delivery; callers should still show the link.
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: "Unauthorized" },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Check rate limit
     if (!checkRateLimit(user.id)) {
       return NextResponse.json(
         { error: "Rate limit exceeded. Maximum 10 emails per hour." },
@@ -50,108 +93,157 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const {
-      tokenId,
-      recipientEmail,
-      reviewUrl,
-      rateeName,
-      rateeRank,
-      mentorLabel,
-      expiresAt,
-    } = body;
+    const token =
+      typeof body.tokenId === "string"
+        ? body.tokenId.trim()
+        : typeof body.token === "string"
+          ? body.token.trim()
+          : "";
+    const recipientEmail = stripHtml(
+      typeof body.recipientEmail === "string" ? body.recipientEmail : ""
+    )
+      .trim()
+      .toLowerCase();
+    const reviewUrl =
+      typeof body.reviewUrl === "string" ? body.reviewUrl.trim() : "";
+    const rateeName = stripHtml(
+      typeof body.rateeName === "string" ? body.rateeName : ""
+    ).trim();
+    const rateeRank =
+      typeof body.rateeRank === "string"
+        ? stripHtml(body.rateeRank).trim()
+        : null;
+    const mentorLabel =
+      typeof body.mentorLabel === "string"
+        ? stripHtml(body.mentorLabel).trim()
+        : null;
+    const shellType = parseShellType(body.shellType);
+    const expiresAtLabel = formatExpiresAt(body.expiresAt);
 
-    // Validate required fields
-    if (!tokenId || !recipientEmail || !reviewUrl) {
+    if (!token || !recipientEmail || !reviewUrl) {
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 }
       );
     }
 
-    // Validate email format
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(recipientEmail)) {
+    if (!EMAIL_REGEX.test(recipientEmail)) {
       return NextResponse.json(
         { error: "Invalid email format" },
         { status: 400 }
       );
     }
 
-    // Get user's profile for sender name
-    const { data: profile } = await supabase
+    // Ensure the token belongs to the caller (public token string from create API).
+    const { data: ownedToken, error: tokenLookupError } = await supabase
+      .from("review_tokens")
+      .select("id")
+      .eq("token", token)
+      .eq("created_by", user.id)
+      .maybeSingle();
+
+    if (tokenLookupError || !ownedToken) {
+      return NextResponse.json(
+        { error: "Review link not found" },
+        { status: 404 }
+      );
+    }
+
+    const { data: profile } = (await supabase
       .from("profiles")
-      .select("full_name, rank")
+      .select("full_name, rank, email")
       .eq("id", user.id)
-      .single() as { data: ProfileData | null; error: unknown };
+      .single()) as { data: ProfileData | null; error: unknown };
 
-    const senderName = profile?.full_name || "A MyEPBuddy user";
-    const senderRank = profile?.rank || "";
+    const senderDisplayName =
+      [profile?.rank, profile?.full_name].filter(Boolean).join(" ").trim() ||
+      "A MyEPBuddy user";
 
-    // Prepare email data
-    const emailData = {
-      to: recipientEmail,
-      subject: `${senderRank} ${senderName} requested your feedback on their EPB`,
-      senderName: `${senderRank} ${senderName}`.trim(),
-      rateeName,
+    const resendApiKey = getResendApiKey();
+    const fromEmail = getTransactionalFromEmail();
+
+    if (!resendApiKey || !fromEmail) {
+      console.warn(
+        "Review link email not sent — missing RESEND_API_KEY or EMAIL_FROM/FEEDBACK_FROM_EMAIL."
+      );
+      return NextResponse.json({
+        success: true,
+        emailSent: false,
+        code: "email_not_configured",
+        error:
+          "Review link created, but email is not configured. Copy and share the link instead.",
+      });
+    }
+
+    const emailContent = buildReviewLinkEmail({
+      siteUrl: getSiteUrl(),
+      senderDisplayName,
+      rateeName: rateeName || "the ratee",
       rateeRank,
       mentorLabel,
       reviewUrl,
-      expiresAt: new Date(expiresAt).toLocaleString(),
-    };
+      expiresAt: expiresAtLabel,
+      shellType,
+    });
 
-    // =========================================================================
-    // TODO: User integrates their email service here
-    // =========================================================================
-    // 
-    // Example with SendGrid:
-    // 
-    // import sgMail from "@sendgrid/mail";
-    // sgMail.setApiKey(process.env.SENDGRID_API_KEY!);
-    // 
-    // await sgMail.send({
-    //   to: emailData.to,
-    //   from: process.env.SENDGRID_FROM_EMAIL!,
-    //   subject: emailData.subject,
-    //   html: `
-    //     <h2>EPB Feedback Request</h2>
-    //     <p>Hi ${emailData.mentorLabel || "there"},</p>
-    //     <p>${emailData.senderName} has requested your feedback on their 
-    //        Enlisted Performance Brief (EPB) for ${emailData.rateeRank} ${emailData.rateeName}.</p>
-    //     <p><a href="${emailData.reviewUrl}">Click here to review and provide feedback</a></p>
-    //     <p>This link expires on ${emailData.expiresAt}.</p>
-    //     <hr>
-    //     <p><small>MyEPBuddy - EPB Writing Assistant</small></p>
-    //   `,
-    // });
-    //
-    // Example with Twilio SendGrid:
-    // Similar to above, just use Twilio's SendGrid SDK
-    //
-    // =========================================================================
+    try {
+      await sendResendEmail({
+        resendApiKey,
+        from: fromEmail,
+        to: recipientEmail,
+        subject: emailContent.subject,
+        html: emailContent.html,
+        text: emailContent.text,
+        replyTo: (() => {
+          const candidate = (profile?.email || user.email || "").trim();
+          return candidate.includes("@") ? candidate : null;
+        })(),
+      });
+    } catch (sendError) {
+      const resendDetail =
+        sendError instanceof ResendSendError
+          ? { status: sendError.status, body: sendError.detail.slice(0, 500) }
+          : {
+              message:
+                sendError instanceof Error ? sendError.message : "unknown",
+            };
+      console.error("Review link Resend error:", {
+        from: fromEmail,
+        to: recipientEmail,
+        ...resendDetail,
+      });
+      return NextResponse.json({
+        success: true,
+        emailSent: false,
+        code:
+          sendError instanceof ResendSendError && sendError.status === 403
+            ? "email_forbidden"
+            : "email_send_failed",
+        error:
+          sendError instanceof ResendSendError && sendError.status === 403
+            ? "Review link created, but email could not be delivered. Copy and share the link instead."
+            : "Review link created, but the email provider failed to send. Copy and share the link instead.",
+        resendStatus:
+          sendError instanceof ResendSendError ? sendError.status : null,
+      });
+    }
 
-    // For now, we'll simulate success and log the email data
-    console.log("Email would be sent:", emailData);
-
-    // Update the token with email info
     const { error: updateError } = await supabase
       .from("review_tokens")
       .update({
         recipient_email: recipientEmail,
         email_sent_at: new Date().toISOString(),
       } as never)
-      .eq("id", tokenId)
+      .eq("id", (ownedToken as { id: string }).id)
       .eq("created_by", user.id);
 
     if (updateError) {
-      console.error("Update token error:", updateError);
-      // Don't fail the request, email was "sent"
+      console.error("Update token email metadata error:", updateError);
     }
 
-    // Return success with a note that email service needs configuration
     return NextResponse.json({
       success: true,
-      message: "Email service not configured. Please integrate SendGrid or Twilio.",
-      emailData, // Return data so frontend can show what would be sent
+      emailSent: true,
     });
   } catch (error) {
     console.error("Send email error:", error);

--- a/src/components/feedback/feedback-badge.tsx
+++ b/src/components/feedback/feedback-badge.tsx
@@ -1,16 +1,86 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, use, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import {
+  loadFeedbackSessions,
+  type FeedbackShellType,
+} from "@/lib/feedback-sessions";
 import { MessageSquare } from "lucide-react";
 
 interface FeedbackBadgeProps {
-  shellType: "epb" | "award" | "decoration";
+  shellType: FeedbackShellType;
   shellId: string;
   onClick: () => void;
   className?: string;
-  refreshKey?: number; // Increment to force refresh
+  refreshKey?: number;
+}
+
+function FeedbackBadgeArmed({
+  shellType,
+  shellId,
+  bust,
+  onClick,
+  className,
+}: {
+  shellType: FeedbackShellType;
+  shellId: string;
+  bust: number;
+  onClick: () => void;
+  className?: string;
+}) {
+  const sessions = use(loadFeedbackSessions(shellType, shellId, bust));
+  const pending = sessions.reduce((sum, s) => sum + (s.pending_count || 0), 0);
+  const total = sessions.reduce((sum, s) => sum + (s.comment_count || 0), 0);
+
+  if (total === 0) return null;
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onClick}
+      className={cn("gap-2 relative", className)}
+      aria-label={`Reviewer feedback${pending > 0 ? `, ${pending} pending` : ""}`}
+    >
+      <MessageSquare className="size-4" />
+      <span>Feedback</span>
+      {pending > 0 && (
+        <span className="absolute -top-1.5 -right-1.5 size-5 rounded-full bg-amber-500 text-white text-xs font-medium flex items-center justify-center">
+          {pending}
+        </span>
+      )}
+    </Button>
+  );
+}
+
+function PlaceholderBadge({
+  onClick,
+  onArm,
+  className,
+}: {
+  onClick: () => void;
+  onArm: () => void;
+  className?: string;
+}) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        onArm();
+        onClick();
+      }}
+      onMouseEnter={onArm}
+      onFocus={onArm}
+      className={cn("gap-2 relative", className)}
+      aria-label="Reviewer feedback"
+    >
+      <MessageSquare className="size-4" />
+      <span>Feedback</span>
+    </Button>
+  );
 }
 
 export function FeedbackBadge({
@@ -20,61 +90,45 @@ export function FeedbackBadge({
   className,
   refreshKey = 0,
 }: FeedbackBadgeProps) {
-  const [pendingCount, setPendingCount] = useState(0);
-  const [totalCount, setTotalCount] = useState(0);
-  const [hasLoaded, setHasLoaded] = useState(false);
+  const [armed, setArmed] = useState(false);
+  const [bust, setBust] = useState(0);
+  const [prevShell, setPrevShell] = useState(`${shellType}:${shellId}`);
+  const [prevRefresh, setPrevRefresh] = useState(refreshKey);
+  const shellKey = `${shellType}:${shellId}`;
 
-  const loadCount = useCallback(async () => {
-    try {
-      const response = await fetch(
-        `/api/feedback?shellType=${shellType}&shellId=${shellId}`
-      );
-      const data = await response.json();
+  if (shellKey !== prevShell) {
+    setPrevShell(shellKey);
+    setArmed(false);
+    setBust((n) => n + 1);
+  }
+  if (refreshKey !== prevRefresh) {
+    setPrevRefresh(refreshKey);
+    setArmed(true);
+    setBust((n) => n + 1);
+  }
 
-      if (response.ok && data.sessions) {
-        const sessions = data.sessions as Array<{ pending_count: number; comment_count: number }>;
-        const pending = sessions.reduce((sum, s) => sum + (s.pending_count || 0), 0);
-        const total = sessions.reduce((sum, s) => sum + (s.comment_count || 0), 0);
-        setPendingCount(pending);
-        setTotalCount(total);
-        setHasLoaded(true);
-      }
-    } catch (error) {
-      console.error("Load feedback count error:", error);
-    }
-  }, [shellType, shellId]);
+  const arm = () => setArmed(true);
 
-  const handlePrefetch = () => {
-    void loadCount();
-  };
-
-  const handleClick = () => {
-    if (!hasLoaded) {
-      void loadCount();
-    }
-    onClick();
-  };
-
-  if (totalCount === 0 && hasLoaded) {
-    return null;
+  if (!armed) {
+    return (
+      <PlaceholderBadge onClick={onClick} onArm={arm} className={className} />
+    );
   }
 
   return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={handleClick}
-      onMouseEnter={handlePrefetch}
-      onFocus={handlePrefetch}
-      className={cn("gap-2 relative", className)}
+    <Suspense
+      fallback={
+        <PlaceholderBadge onClick={onClick} onArm={arm} className={className} />
+      }
     >
-      <MessageSquare className="size-4" />
-      <span>Feedback</span>
-      {pendingCount > 0 && (
-        <span className="absolute -top-1.5 -right-1.5 size-5 rounded-full bg-amber-500 text-white text-xs font-medium flex items-center justify-center">
-          {pendingCount}
-        </span>
-      )}
-    </Button>
+      <FeedbackBadgeArmed
+        key={`${shellKey}-${bust}`}
+        shellType={shellType}
+        shellId={shellId}
+        bust={bust}
+        onClick={onClick}
+        className={className}
+      />
+    </Suspense>
   );
 }

--- a/src/components/feedback/feedback-list-dialog.tsx
+++ b/src/components/feedback/feedback-list-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, use, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -11,29 +11,103 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { formatDateTimeDetailed } from "@/lib/format";
-import { toast } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
+import {
+  loadFeedbackSessions,
+  invalidateFeedbackSessionsCache,
+  type FeedbackShellType,
+} from "@/lib/feedback-sessions";
 import { Loader2, MessageSquare, User, Calendar, ChevronRight } from "lucide-react";
-
-interface FeedbackSession {
-  id: string;
-  reviewer_name: string;
-  reviewer_name_source: string;
-  comment_count: number;
-  submitted_at: string;
-  pending_count: number;
-  accepted_count: number;
-  dismissed_count: number;
-  link_label?: string;
-  is_anonymous?: boolean;
-}
 
 interface FeedbackListDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  shellType: "epb" | "award" | "decoration";
+  shellType: FeedbackShellType;
   shellId: string;
   onViewSession: (sessionId: string) => void;
+}
+
+function FeedbackSessionsBody({
+  shellType,
+  shellId,
+  bust,
+  onViewSession,
+  onOpenChange,
+}: {
+  shellType: FeedbackShellType;
+  shellId: string;
+  bust: number;
+  onViewSession: (sessionId: string) => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const sessions = use(loadFeedbackSessions(shellType, shellId, bust));
+  const totalPending = sessions.reduce(
+    (sum, s) => sum + (s.pending_count || 0),
+    0
+  );
+
+  if (sessions.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <MessageSquare className="size-10 mx-auto text-muted-foreground/50 mb-3" />
+        <p className="text-sm text-muted-foreground">No feedback received yet</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Share your {shellType.toUpperCase()} with a mentor to get feedback
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {totalPending > 0 && (
+        <Badge variant="secondary" className="w-fit">
+          {totalPending} pending
+        </Badge>
+      )}
+      <ScrollArea className="h-full max-h-[50vh]">
+        <div className="space-y-2 pr-4">
+          {sessions.map((session) => (
+            <button
+              type="button"
+              key={session.id}
+              className={cn(
+                "w-full flex items-center gap-3 p-3 rounded-lg border text-left",
+                "hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              )}
+              onClick={() => {
+                onViewSession(session.id);
+                onOpenChange(false);
+              }}
+            >
+              <div className="size-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                <User className="size-5 text-primary" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm truncate">
+                    {session.reviewer_name}
+                  </span>
+                  {session.pending_count > 0 && (
+                    <Badge variant="secondary" className="shrink-0">
+                      {session.pending_count} pending
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
+                  <Calendar className="size-3" />
+                  <span>{formatDateTimeDetailed(session.submitted_at)}</span>
+                  <span>•</span>
+                  <span>{session.comment_count} comments</span>
+                </div>
+              </div>
+              <ChevronRight className="size-4 text-muted-foreground shrink-0" />
+            </button>
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
 }
 
 export function FeedbackListDialog({
@@ -43,51 +117,25 @@ export function FeedbackListDialog({
   shellId,
   onViewSession,
 }: FeedbackListDialogProps) {
-  const [sessions, setSessions] = useState<FeedbackSession[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Bump when dialog opens so each open refetches (cache bust) without useEffect.
+  const [bust, setBust] = useState(0);
+  const [wasOpen, setWasOpen] = useState(open);
 
-  const loadSessions = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const response = await fetch(
-        `/api/feedback?shellType=${shellType}&shellId=${shellId}`
-      );
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to load feedback");
-      }
-
-      setSessions(data.sessions || []);
-    } catch (error) {
-      console.error("Load sessions error:", error);
-      toast.error("Failed to load feedback sessions");
-    } finally {
-      setIsLoading(false);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      invalidateFeedbackSessionsCache(shellType, shellId);
+      setBust((n) => n + 1);
     }
-  }, [shellType, shellId]);
-
-  const handleOpenChange = (nextOpen: boolean) => {
-    onOpenChange(nextOpen);
-    if (nextOpen) {
-      void loadSessions();
-    }
-  };
-
-  const totalPending = sessions.reduce((sum, s) => sum + (s.pending_count || 0), 0);
+  }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md max-h-[80vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <MessageSquare className="size-5" />
             Reviewer Feedback
-            {totalPending > 0 && (
-              <Badge variant="secondary" className="ml-2">
-                {totalPending} pending
-              </Badge>
-            )}
           </DialogTitle>
           <DialogDescription>
             Review feedback from your mentors
@@ -95,62 +143,24 @@ export function FeedbackListDialog({
         </DialogHeader>
 
         <div className="flex-1 min-h-0">
-          {isLoading ? (
-            <div className="flex items-center justify-center py-12">
-              <Loader2 className="size-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : sessions.length === 0 ? (
-            <div className="text-center py-12">
-              <MessageSquare className="size-10 mx-auto text-muted-foreground/50 mb-3" />
-              <p className="text-sm text-muted-foreground">
-                No feedback received yet
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Share your {shellType.toUpperCase()} with a mentor to get feedback
-              </p>
-            </div>
-          ) : (
-            <ScrollArea className="h-full max-h-[50vh]">
-              <div className="space-y-2 pr-4">
-                {sessions.map((session) => (
-                  <button type="button"
-                    key={session.id}
-                    className={cn(
-                      "w-full flex items-center gap-3 p-3 rounded-lg border text-left transition-colors",
-                      "hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    )}
-                    onClick={() => {
-                      onViewSession(session.id);
-                      onOpenChange(false);
-                    }}
-                  >
-                    <div className="size-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                      <User className="size-5 text-primary" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium text-sm truncate">
-                          {session.reviewer_name}
-                        </span>
-                        {session.pending_count > 0 && (
-                          <Badge variant="secondary" className="shrink-0">
-                            {session.pending_count} pending
-                          </Badge>
-                        )}
-                      </div>
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
-                        <Calendar className="size-3" />
-                        <span>{formatDateTimeDetailed(session.submitted_at)}</span>
-                        <span>•</span>
-                        <span>{session.comment_count} comments</span>
-                      </div>
-                    </div>
-                    <ChevronRight className="size-4 text-muted-foreground shrink-0" />
-                  </button>
-                ))}
-              </div>
-            </ScrollArea>
-          )}
+          {open ? (
+            <Suspense
+              fallback={
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="size-6 animate-spin text-muted-foreground" />
+                </div>
+              }
+            >
+              <FeedbackSessionsBody
+                key={`${shellType}-${shellId}-${bust}`}
+                shellType={shellType}
+                shellId={shellId}
+                bust={bust}
+                onViewSession={onViewSession}
+                onOpenChange={onOpenChange}
+              />
+            </Suspense>
+          ) : null}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/review/create-review-link-dialog.tsx
+++ b/src/components/review/create-review-link-dialog.tsx
@@ -142,20 +142,29 @@ export function CreateReviewLinkDialog({
         tokenId: data.token,
       });
 
-      // Auto-copy to clipboard if not sending email
-      if (!sendEmail || !recipientEmail.trim()) {
+      const copyLink = async (): Promise<boolean> => {
         try {
           await navigator.clipboard.writeText(data.reviewUrl);
           setCopied(true);
-          toast.success("Review link created and copied to clipboard!");
           setTimeout(() => setCopied(false), 2000);
+          return true;
         } catch (copyErr) {
           console.error("Auto-copy error:", copyErr);
-          toast.success("Review link created!");
+          return false;
         }
+      };
+
+      // Auto-copy when not attempting email delivery
+      if (!sendEmail || !recipientEmail.trim()) {
+        const copiedOk = await copyLink();
+        toast.success(
+          copiedOk
+            ? "Review link created and copied to clipboard!"
+            : "Review link created!"
+        );
       }
 
-      // If sending email and email provided
+      // If sending email and email provided — delivery is best-effort; link always works
       if (sendEmail && recipientEmail.trim()) {
         setIsSendingEmail(true);
         try {
@@ -170,24 +179,44 @@ export function CreateReviewLinkDialog({
               rateeRank,
               mentorLabel: linkType === "labeled" ? linkLabel.trim() : null,
               expiresAt: data.expiresAt,
+              shellType,
             }),
           });
 
           const emailData = await emailResponse.json();
+          const copiedOk = await copyLink();
 
-          if (emailResponse.ok) {
-            toast.success(`Review link ready! ${emailData.message || ""}`);
+          if (emailResponse.ok && emailData.emailSent) {
+            toast.success(`Review link emailed to ${recipientEmail.trim()}`, {
+              description: copiedOk
+                ? "A copy is also on your clipboard."
+                : undefined,
+            });
+          } else if (emailResponse.ok) {
+            toast.message(emailData.error || "Review link ready", {
+              description: copiedOk
+                ? "Email couldn't be delivered — share the copied link instead."
+                : "Email couldn't be delivered — copy the link below to share it.",
+            });
           } else {
-            toast.error(emailData.error || "Failed to send email");
+            toast.error(emailData.error || "Failed to send email", {
+              description: copiedOk
+                ? "Link was created and copied — share it manually."
+                : "Link was created — copy it below to share manually.",
+            });
           }
         } catch (emailErr) {
           console.error("Email error:", emailErr);
-          toast.error("Failed to send email, but link was created");
+          const copiedOk = await copyLink();
+          toast.message("Review link created", {
+            description: copiedOk
+              ? "Email couldn't be sent — share the copied link instead."
+              : "Email couldn't be sent — copy the link below to share it.",
+          });
         } finally {
           setIsSendingEmail(false);
         }
       }
-      // Note: Success toast for non-email case is handled above in auto-copy block
     } catch (error) {
       console.error("Generate error:", error);
       toast.error(error instanceof Error ? error.message : "Failed to generate link");

--- a/src/lib/__tests__/mentor-feedback-received-email.test.ts
+++ b/src/lib/__tests__/mentor-feedback-received-email.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildMentorFeedbackReceivedEmail } from "@/lib/email/mentor-feedback-received";
+
+describe("buildMentorFeedbackReceivedEmail", () => {
+  it("builds an escaped owner notification", () => {
+    const email = buildMentorFeedbackReceivedEmail({
+      siteUrl: "https://myepbuddy.com",
+      recipientName: "MSgt O'Malley",
+      reviewerName: 'Chief <script>alert("x")</script>',
+      rateeName: "SSgt Rivera",
+      rateeRank: "SSgt",
+      shellType: "epb",
+      commentCount: 3,
+    });
+
+    expect(email.subject).toBe(
+      'Chief <script>alert("x")</script> left feedback on your EPB'
+    );
+    expect(email.html).toContain("Hi MSgt O&#039;Malley");
+    expect(email.html).toContain(
+      "Chief &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;"
+    );
+    expect(email.html).not.toContain("<script>alert");
+    expect(email.html).toContain("3 comments");
+    expect(email.html).toContain("https://myepbuddy.com/generate");
+    expect(email.text).toContain("3 comments");
+  });
+
+  it("uses singular comment wording and award path", () => {
+    const email = buildMentorFeedbackReceivedEmail({
+      siteUrl: "https://myepbuddy.com/",
+      recipientName: null,
+      reviewerName: "Flight Chief",
+      rateeName: "Amn Jones",
+      shellType: "award",
+      commentCount: 1,
+      appPath: "/award",
+    });
+
+    expect(email.subject).toContain("award");
+    expect(email.html).toContain("Hi there");
+    expect(email.html).toContain("1 comment");
+    expect(email.html).toContain("https://myepbuddy.com/award");
+  });
+});

--- a/src/lib/__tests__/review-link-email.test.ts
+++ b/src/lib/__tests__/review-link-email.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildReviewLinkEmail } from "@/lib/email/review-link";
+
+describe("buildReviewLinkEmail", () => {
+  it("builds an EPB review request with escaped HTML", () => {
+    const email = buildReviewLinkEmail({
+      siteUrl: "https://myepbuddy.com",
+      senderDisplayName: "MSgt O'Malley",
+      rateeName: 'Amn <script>alert("x")</script>',
+      rateeRank: "Amn",
+      mentorLabel: "Flight Chief",
+      reviewUrl: "https://myepbuddy.com/review/epb/tok-123?x=1&y=2",
+      expiresAt: "Aug 16, 2026, 12:00 AM UTC",
+      shellType: "epb",
+    });
+
+    expect(email.subject).toBe(
+      "MSgt O'Malley requested your feedback on their EPB"
+    );
+    expect(email.html).toContain("Hi Flight Chief");
+    expect(email.html).toContain("MSgt O&#039;Malley");
+    expect(email.html).toContain(
+      "Amn Amn &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;"
+    );
+    expect(email.html).not.toContain("<script>alert");
+    expect(email.html).toContain(
+      "https://myepbuddy.com/review/epb/tok-123?x=1&amp;y=2"
+    );
+    expect(email.html).toContain("Review &amp; provide feedback");
+    expect(email.text).toContain("MSgt O'Malley has requested your feedback");
+    expect(email.text).toContain(
+      "https://myepbuddy.com/review/epb/tok-123?x=1&y=2"
+    );
+  });
+
+  it("uses award wording and default greeting when mentor label is missing", () => {
+    const email = buildReviewLinkEmail({
+      siteUrl: "https://myepbuddy.com/",
+      senderDisplayName: "Capt Lee",
+      rateeName: "SSgt Rivera",
+      rateeRank: null,
+      mentorLabel: null,
+      reviewUrl: "https://myepbuddy.com/review/award/tok-99",
+      expiresAt: "soon",
+      shellType: "award",
+    });
+
+    expect(email.subject).toBe(
+      "Capt Lee requested your feedback on their award"
+    );
+    expect(email.html).toContain("Hi there");
+    expect(email.html).toContain("award package");
+    expect(email.text).toContain("award package");
+  });
+});

--- a/src/lib/email/mentor-feedback-received.ts
+++ b/src/lib/email/mentor-feedback-received.ts
@@ -1,0 +1,134 @@
+import { escapeHtml } from "@/lib/email/html-safe";
+import type { ReviewShellType } from "@/lib/email/review-link";
+
+export type BuildMentorFeedbackReceivedEmailParams = {
+  siteUrl: string;
+  recipientName: string | null;
+  reviewerName: string;
+  rateeName: string;
+  rateeRank?: string | null;
+  shellType: ReviewShellType;
+  commentCount: number;
+  appPath?: string;
+};
+
+export type MentorFeedbackReceivedEmailContent = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+const SHELL_SHORT: Record<ReviewShellType, string> = {
+  epb: "EPB",
+  award: "award",
+  decoration: "decoration",
+};
+
+/**
+ * Notify the package owner that a mentor submitted review feedback (Resend).
+ */
+export function buildMentorFeedbackReceivedEmail(
+  params: BuildMentorFeedbackReceivedEmailParams
+): MentorFeedbackReceivedEmailContent {
+  const {
+    siteUrl,
+    recipientName,
+    reviewerName,
+    rateeName,
+    rateeRank,
+    shellType,
+    commentCount,
+    appPath = "/generate",
+  } = params;
+
+  const shellShort = SHELL_SHORT[shellType] ?? "EPB";
+  const rateeDisplay = [rateeRank?.trim(), rateeName.trim()]
+    .filter(Boolean)
+    .join(" ");
+  const greeting = recipientName?.trim() || "there";
+  const commentLabel =
+    commentCount === 1 ? "1 comment" : `${commentCount} comments`;
+
+  const subject = `${reviewerName} left feedback on your ${shellShort}`;
+
+  const ctaUrl = `${siteUrl.replace(/\/$/, "")}${appPath.startsWith("/") ? appPath : `/${appPath}`}`;
+  const hrefCtaUrl = escapeHtml(ctaUrl);
+  const logoUrl = escapeHtml(`${siteUrl.replace(/\/$/, "")}/icon.svg`);
+  const safeGreeting = escapeHtml(greeting);
+  const safeReviewer = escapeHtml(reviewerName);
+  const safeRatee = escapeHtml(rateeDisplay || rateeName);
+  const safeShell = escapeHtml(shellShort);
+  const safeCount = escapeHtml(commentLabel);
+
+  const textBody = [
+    `Hi ${greeting},`,
+    "",
+    `${reviewerName} submitted feedback on your ${shellShort} for ${rateeDisplay || rateeName} (${commentLabel}).`,
+    "",
+    `Open MyEPBuddy to review it:`,
+    ctaUrl,
+    "",
+    "MyEPBuddy - Your AI-Powered EPB Writing Assistant",
+  ].join("\n");
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(subject)}</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #141414; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color: #141414;">
+    <tr>
+      <td align="center" style="padding: 40px 20px;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width: 480px; background-color: #1f1f1f; border-radius: 12px; border: 1px solid #2e2e2e;">
+          <tr>
+            <td align="center" style="padding: 32px 40px 24px;">
+              <img src="${logoUrl}" alt="MyEPBuddy" width="48" height="48" style="display: block;">
+              <h1 style="margin: 16px 0 0; font-size: 24px; font-weight: 600; color: #fafafa;">MyEPBuddy</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 0 40px 32px;">
+              <h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #fafafa; text-align: center;">
+                New feedback
+              </h2>
+              <p style="margin: 0 0 8px; font-size: 15px; line-height: 1.6; color: #a3a3a3; text-align: center;">
+                Hi ${safeGreeting},
+              </p>
+              <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #a3a3a3; text-align: center;">
+                <strong style="color:#fafafa;">${safeReviewer}</strong> submitted
+                <strong style="color:#fafafa;">${safeCount}</strong> on your
+                ${safeShell} for <strong style="color:#fafafa;">${safeRatee}</strong>.
+              </p>
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td align="center" style="padding: 8px 0 24px;">
+                    <a href="${hrefCtaUrl}" target="_blank" style="display: inline-block; padding: 14px 32px; background-color: #818cf8; color: #1f1f1f; font-size: 15px; font-weight: 600; text-decoration: none; border-radius: 8px;">
+                      Review feedback
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0; font-size: 13px; color: #6b6b6b; text-align: center;">
+                Or open MyEPBuddy and check Get Feedback on this package.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 40px 32px; border-top: 1px solid #2e2e2e;">
+              <p style="margin: 0; font-size: 12px; color: #6b6b6b; text-align: center;">
+                MyEPBuddy - Your AI-Powered EPB Writing Assistant
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  return { subject, html, text: textBody };
+}

--- a/src/lib/email/review-link.ts
+++ b/src/lib/email/review-link.ts
@@ -1,0 +1,155 @@
+import { escapeHtml } from "@/lib/email/html-safe";
+
+export type ReviewShellType = "epb" | "award" | "decoration";
+
+export type BuildReviewLinkEmailParams = {
+  siteUrl: string;
+  senderDisplayName: string;
+  rateeName: string;
+  rateeRank?: string | null;
+  mentorLabel?: string | null;
+  reviewUrl: string;
+  expiresAt: string;
+  shellType: ReviewShellType;
+};
+
+export type ReviewLinkEmailContent = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+const SHELL_LABELS: Record<ReviewShellType, string> = {
+  epb: "Enlisted Performance Brief (EPB)",
+  award: "award package",
+  decoration: "decoration package",
+};
+
+const SHELL_SHORT: Record<ReviewShellType, string> = {
+  epb: "EPB",
+  award: "award",
+  decoration: "decoration",
+};
+
+/**
+ * Dark-themed MyEPBuddy review-request email (matches managed-member invite chrome).
+ */
+export function buildReviewLinkEmail(
+  params: BuildReviewLinkEmailParams
+): ReviewLinkEmailContent {
+  const {
+    siteUrl,
+    senderDisplayName,
+    rateeName,
+    rateeRank,
+    mentorLabel,
+    reviewUrl,
+    expiresAt,
+    shellType,
+  } = params;
+
+  const shellLabel = SHELL_LABELS[shellType] ?? SHELL_LABELS.epb;
+  const shellShort = SHELL_SHORT[shellType] ?? "EPB";
+  const rateeDisplay = [rateeRank?.trim(), rateeName.trim()]
+    .filter(Boolean)
+    .join(" ");
+  const greetingName = mentorLabel?.trim() || "there";
+
+  const subject = `${senderDisplayName} requested your feedback on their ${shellShort}`;
+
+  const safeSender = escapeHtml(senderDisplayName);
+  const safeGreeting = escapeHtml(greetingName);
+  const safeRatee = escapeHtml(rateeDisplay || rateeName);
+  const safeShell = escapeHtml(shellLabel);
+  const safeExpires = escapeHtml(expiresAt);
+  const hrefReviewUrl = escapeHtml(reviewUrl);
+  const logoUrl = escapeHtml(`${siteUrl.replace(/\/$/, "")}/icon.svg`);
+
+  const textBody = [
+    `Hi ${greetingName},`,
+    "",
+    `${senderDisplayName} has requested your feedback on their ${shellLabel} for ${rateeDisplay || rateeName}.`,
+    "",
+    `Open the review link:`,
+    reviewUrl,
+    "",
+    `This link expires on ${expiresAt}.`,
+    "",
+    "If you weren't expecting this, you can safely ignore this email.",
+    "",
+    "MyEPBuddy - Your AI-Powered EPB Writing Assistant",
+  ].join("\n");
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(subject)}</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #141414; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color: #141414;">
+    <tr>
+      <td align="center" style="padding: 40px 20px;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width: 480px; background-color: #1f1f1f; border-radius: 12px; border: 1px solid #2e2e2e;">
+          <tr>
+            <td align="center" style="padding: 32px 40px 24px;">
+              <img src="${logoUrl}" alt="MyEPBuddy" width="48" height="48" style="display: block;">
+              <h1 style="margin: 16px 0 0; font-size: 24px; font-weight: 600; color: #fafafa;">MyEPBuddy</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 0 40px 32px;">
+              <h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #fafafa; text-align: center;">
+                Feedback requested
+              </h2>
+              <p style="margin: 0 0 8px; font-size: 15px; line-height: 1.6; color: #a3a3a3; text-align: center;">
+                Hi ${safeGreeting},
+              </p>
+              <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #a3a3a3; text-align: center;">
+                <strong style="color:#fafafa;">${safeSender}</strong> has requested your feedback on their
+                ${safeShell} for <strong style="color:#fafafa;">${safeRatee}</strong>.
+              </p>
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td align="center" style="padding: 8px 0 24px;">
+                    <a href="${hrefReviewUrl}" target="_blank" style="display: inline-block; padding: 14px 32px; background-color: #818cf8; color: #1f1f1f; font-size: 15px; font-weight: 600; text-decoration: none; border-radius: 8px;">
+                      Review &amp; provide feedback
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 8px; font-size: 13px; color: #a3a3a3; text-align: center;">
+                Or copy and paste this link:
+              </p>
+              <p style="margin: 0 0 16px; font-size: 12px; color: #818cf8; text-align: center; word-break: break-all;">
+                ${hrefReviewUrl}
+              </p>
+              <p style="margin: 0; font-size: 13px; color: #6b6b6b; text-align: center;">
+                This link expires on ${safeExpires}.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 40px; border-top: 1px solid #2e2e2e;">
+              <p style="margin: 0; font-size: 12px; line-height: 1.5; color: #6b6b6b; text-align: center;">
+                If you weren&#039;t expecting this, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 40px 32px; border-top: 1px solid #2e2e2e;">
+              <p style="margin: 0; font-size: 12px; color: #6b6b6b; text-align: center;">
+                MyEPBuddy - Your AI-Powered EPB Writing Assistant
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  return { subject, html, text: textBody };
+}

--- a/src/lib/feedback-sessions.ts
+++ b/src/lib/feedback-sessions.ts
@@ -1,0 +1,62 @@
+export type FeedbackShellType = "epb" | "award" | "decoration";
+
+export interface FeedbackSessionSummary {
+  id: string;
+  reviewer_name: string;
+  reviewer_name_source: string;
+  comment_count: number;
+  submitted_at: string;
+  pending_count: number;
+  accepted_count: number;
+  dismissed_count: number;
+  link_label?: string;
+  is_anonymous?: boolean;
+}
+
+const sessionsCache = new Map<string, Promise<FeedbackSessionSummary[]>>();
+
+function cacheKey(
+  shellType: FeedbackShellType,
+  shellId: string,
+  bust: number
+): string {
+  return `${shellType}:${shellId}:${bust}`;
+}
+
+export function invalidateFeedbackSessionsCache(
+  shellType?: FeedbackShellType,
+  shellId?: string
+): void {
+  if (!shellType || !shellId) {
+    sessionsCache.clear();
+    return;
+  }
+  const prefix = `${shellType}:${shellId}:`;
+  for (const key of sessionsCache.keys()) {
+    if (key.startsWith(prefix)) sessionsCache.delete(key);
+  }
+}
+
+export function loadFeedbackSessions(
+  shellType: FeedbackShellType,
+  shellId: string,
+  bust = 0
+): Promise<FeedbackSessionSummary[]> {
+  const key = cacheKey(shellType, shellId, bust);
+  const cached = sessionsCache.get(key);
+  if (cached) return cached;
+
+  const promise = (async (): Promise<FeedbackSessionSummary[]> => {
+    const response = await fetch(
+      `/api/feedback?shellType=${encodeURIComponent(shellType)}&shellId=${encodeURIComponent(shellId)}`
+    );
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || "Failed to load feedback");
+    }
+    return (data.sessions || []) as FeedbackSessionSummary[];
+  })();
+
+  sessionsCache.set(key, promise);
+  return promise;
+}

--- a/src/lib/review-page-data.ts
+++ b/src/lib/review-page-data.ts
@@ -41,13 +41,26 @@ const getStorageKey = (token: string) => `review_progress_${token}`;
 
 const reviewLoadCache = new Map<string, Promise<ReviewPageLoadResult>>();
 
+/** Absolute origin for SSR fetches — relative `/api/...` fails on the server and flashes an error card. */
+function getReviewApiOrigin(): string {
+  if (typeof window !== "undefined") return "";
+  const fromEnv =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null);
+  return (fromEnv || "http://localhost:3000").replace(/\/$/, "");
+}
+
 export function loadReviewPageData(token: string): Promise<ReviewPageLoadResult> {
   const cached = reviewLoadCache.get(token);
   if (cached) return cached;
 
   const promise = (async (): Promise<ReviewPageLoadResult> => {
     try {
-      const response = await fetch(`/api/review/${token}`);
+      const response = await fetch(
+        `${getReviewApiOrigin()}/api/review/${encodeURIComponent(token)}`,
+        { cache: "no-store" }
+      );
       const data = await response.json();
 
       if (!response.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Creating a review share link with “Send Email” showed a success toast about configuring SendGrid/Twilio, even though the link itself was created successfully. `/api/send-review-email` was still a stub that always returned that message.

## Fix
- Wire review-link email delivery through the existing Resend helpers (`RESEND_API_KEY` + `EMAIL_FROM` / `FEEDBACK_FROM_EMAIL`), matching team invite behavior.
- When email isn’t configured or Resend fails, return `emailSent: false` with a clear copy-link message (no SendGrid/Twilio wording).
- Dialog always copies the link on send attempt and toasts:
  - emailed successfully, or
  - “Email couldn't be delivered — share the copied link instead.”
- Verify the review token belongs to the caller before sending / updating metadata.
- Add unit coverage for the review-link email template (HTML escaping + shell wording).

## Assumptions
- Local/cloud envs without Resend keys intentionally get the copy-link fallback (same as managed-member invites).
- Share-by-copy (no email) is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e288c778-e510-4213-a4c4-351b41790086?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e288c778-e510-4213-a4c4-351b41790086&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

