### PR TITLE
Swap sentence order within each EPB MPA

### DIFF
--- a/src/components/epb/mpa-section-card.tsx
+++ b/src/components/epb/mpa-section-card.tsx
@@ -79,7 +79,7 @@ import {
   seedImpactBoosterDraftFields,
   type ImpactBoosterDraftFields,
 } from "@/lib/impact-booster";
-import { parseStatement } from "@/lib/sentence-utils";
+import { parseStatement, swapStatementSentences } from "@/lib/sentence-utils";
 import { MpaDescriptionToggleButton, scrollMpaDescriptionPanelTo } from "./mpa-description-editor";
 import { getEpbZenModeClassName } from "./epb-zen-mode";
 import {
@@ -885,6 +885,18 @@ export function MPASectionCard({
     }
   };
 
+  const handleSwapSentenceOrder = () => {
+    if (isLockedByOther || isHLR) return;
+    const swapped = swapStatementSentences(localTextRef.current);
+    if (swapped === localTextRef.current) return;
+    handleTextChange(swapped);
+    updateSectionState(section.mpa, {
+      draftText: swapped,
+      isDirty: swapped !== section.statement_text,
+    });
+    Analytics.sentenceOrderSwapped(section.mpa);
+  };
+
   // Set presence when textarea gains focus (no blocking, collaborative editing)
   const handleTextFocus = async () => {
     // Store the original text before editing begins (for idle snapshot)
@@ -1554,6 +1566,7 @@ export function MPASectionCard({
                     onDragStart={onSentenceDragStart}
                     onDragEnd={onSentenceDragEnd}
                     onDrop={(data, targetIndex) => onSentenceDrop?.(data, section.mpa, targetIndex)}
+                    onReorder={handleSwapSentenceOrder}
                     draggedSentence={draggedSentence}
                     isClosing={isSplitViewClosing}
                     onFocus={handleTextFocus}
@@ -1606,6 +1619,7 @@ export function MPASectionCard({
                         onDragStart={onSentenceDragStart}
                         onDragEnd={onSentenceDragEnd}
                         onDrop={(data, targetIndex) => onSentenceDrop?.(data, section.mpa, targetIndex)}
+                        onReorder={handleSwapSentenceOrder}
                         draggedSentence={draggedSentence}
                         disabled={isLockedByOther}
                       />

--- a/src/components/epb/sentence-pills.tsx
+++ b/src/components/epb/sentence-pills.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { parseStatement, type ParsedSentence } from "@/lib/sentence-utils";
-import { GripVertical } from "lucide-react";
+import { motionPressable } from "@/lib/motion/classes";
+import { ArrowLeftRight, GripVertical } from "lucide-react";
 
 export interface DraggedSentence {
   sentence: ParsedSentence;
@@ -19,8 +20,37 @@ interface SentencePillsProps {
   onDragStart?: (data: DraggedSentence) => void;
   onDragEnd?: () => void;
   onDrop?: (data: DraggedSentence, targetIndex: number) => void;
+  /** Swap S1 and S2 inside this MPA (no AI resize). */
+  onReorder?: () => void;
   draggedSentence?: DraggedSentence | null;
   disabled?: boolean;
+}
+
+export function SentenceOrderSwapButton({
+  disabled,
+  onClick,
+  className,
+}: {
+  disabled?: boolean;
+  onClick: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label="Swap sentence order"
+      title="Swap sentence 1 and sentence 2"
+      className={cn(
+        "inline-flex items-center justify-center rounded-md size-6 shrink-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-40 disabled:pointer-events-none",
+        motionPressable,
+        className,
+      )}
+    >
+      <ArrowLeftRight className="size-3.5" aria-hidden="true" />
+    </button>
+  );
 }
 
 export function SentencePills({
@@ -29,6 +59,7 @@ export function SentencePills({
   onDragStart,
   onDragEnd,
   onDrop,
+  onReorder,
   draggedSentence,
   disabled = false,
 }: SentencePillsProps) {
@@ -38,6 +69,8 @@ export function SentencePills({
 
   // Check if we're a valid drop target (different MPA)
   const isValidDropTarget = draggedSentence && draggedSentence.sourceMpa !== mpaKey;
+  const isIntraMpaDrag =
+    !!draggedSentence && draggedSentence.sourceMpa === mpaKey;
 
   // Don't render if disabled
   if (disabled) {
@@ -80,9 +113,11 @@ export function SentencePills({
     
     try {
       const data = JSON.parse(e.dataTransfer.getData("application/json")) as DraggedSentence;
-      
-      // Don't allow dropping on same MPA
+
       if (data.sourceMpa === mpaKey) {
+        if (data.sourceIndex !== targetIndex) {
+          onReorder?.();
+        }
         return;
       }
       
@@ -144,11 +179,16 @@ export function SentencePills({
     return null;
   }
 
+  const canReorder = parsed.hasTwoSentences && parsed.sentences.length >= 2;
+
   return (
     <div className="flex items-center gap-1">
       {parsed.sentences.map((sentence, index) => {
         const charCount = sentence.text.length;
         const isBeingDragged = draggedSentence?.sourceMpa === mpaKey && draggedSentence?.sourceIndex === index;
+        const isIntraDropTarget =
+          isIntraMpaDrag && draggedSentence?.sourceIndex !== index;
+        const isHovering = dragOverIndex === index && isIntraDropTarget;
         
         return (
           <div
@@ -156,14 +196,26 @@ export function SentencePills({
             draggable={true}
             onDragStart={(e) => handleDragStart(e, sentence, index)}
             onDragEnd={handleDragEnd}
+            onDragOver={
+              isIntraDropTarget
+                ? (e) => handleDragOver(e, index)
+                : undefined
+            }
+            onDragLeave={isIntraDropTarget ? handleDragLeave : undefined}
+            onDrop={isIntraDropTarget ? (e) => handleDrop(e, index) : undefined}
             onMouseDown={(e) => e.stopPropagation()}
             className={cn(
               "group flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] font-medium cursor-grab active:cursor-grabbing transition-all select-none",
               "border bg-background hover:bg-accent hover:border-primary/40",
               "relative z-10",
               isBeingDragged && "opacity-50 border-dashed border-primary/60",
+              isHovering && "border-primary bg-primary/10",
             )}
-            title={`Drag to swap with another MPA. "${sentence.text.slice(0, 60)}..."`}
+            title={
+              canReorder
+                ? `Drag onto the other sentence to reorder, or onto another MPA to move. "${sentence.text.slice(0, 60)}..."`
+                : `Drag to swap with another MPA. "${sentence.text.slice(0, 60)}..."`
+            }
           >
             <GripVertical className="size-2.5 text-muted-foreground group-hover:text-primary transition-colors" />
             <span className="text-primary">
@@ -175,6 +227,9 @@ export function SentencePills({
           </div>
         );
       })}
+      {canReorder && onReorder && (
+        <SentenceOrderSwapButton onClick={onReorder} />
+      )}
     </div>
   );
 }

--- a/src/components/epb/split-view-editor.tsx
+++ b/src/components/epb/split-view-editor.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { parseStatement, combineSentences, type ParsedSentence } from "@/lib/sentence-utils";
 import { getCharacterCountColor } from "@/lib/utils";
 import { GripVertical } from "lucide-react";
+import { SentenceOrderSwapButton } from "./sentence-pills";
 
 // Re-export compatible type for drag-drop
 export interface DraggedSentence {
@@ -24,6 +25,8 @@ interface SplitViewEditorProps {
   onDragStart?: (data: DraggedSentence) => void;
   onDragEnd?: () => void;
   onDrop?: (data: DraggedSentence, targetIndex: number) => void;
+  /** Swap S1 and S2 in this MPA (no AI resize). */
+  onReorder?: () => void;
   draggedSentence?: DraggedSentence | null;
   // Animation props
   isClosing?: boolean;
@@ -52,6 +55,7 @@ export function SplitViewEditor({
   onDragStart,
   onDragEnd,
   onDrop,
+  onReorder,
   draggedSentence,
   isClosing = false,
   onFocus,
@@ -181,6 +185,14 @@ export function SplitViewEditor({
   
   // Check if we're a valid drop target (different MPA is dragging)
   const isValidDropTarget = draggedSentence && mpaKey && draggedSentence.sourceMpa !== mpaKey;
+  const canReorder = !disabled && !!s1Trimmed && !!s2Trimmed;
+  const isIntraMpaDrag =
+    !!draggedSentence && !!mpaKey && draggedSentence.sourceMpa === mpaKey;
+
+  const handleSwapOrder = () => {
+    if (!canReorder) return;
+    onReorder?.();
+  };
   
   // Drag handlers for initiating drag from this split view
   const handleDragStart = (e: React.DragEvent, index: number) => {
@@ -220,7 +232,8 @@ export function SplitViewEditor({
   
   // Drop handlers for receiving drops
   const handleDragOver = (e: React.DragEvent, index: number) => {
-    if (!isValidDropTarget) return;
+    const intraTarget = isIntraMpaDrag && draggedSentence?.sourceIndex !== index;
+    if (!isValidDropTarget && !intraTarget) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
     setDragOverIndex(index);
@@ -236,9 +249,13 @@ export function SplitViewEditor({
     
     try {
       const data = JSON.parse(e.dataTransfer.getData("application/json")) as DraggedSentence;
-      if (data.sourceMpa !== mpaKey) {
-        onDrop?.(data, targetIndex);
+      if (data.sourceMpa === mpaKey) {
+        if (data.sourceIndex !== targetIndex) {
+          onReorder?.();
+        }
+        return;
       }
+      onDrop?.(data, targetIndex);
     } catch (err) {
       console.error("Failed to parse drag data:", err);
     }
@@ -251,7 +268,8 @@ export function SplitViewEditor({
         className={cn(
           "space-y-1 rounded-lg p-2 -m-2 transition-all",
           isClosing ? "animate-elevator-close-up" : "animate-elevator-up",
-          isValidDropTarget && dragOverIndex === 0 && "bg-primary/10 ring-2 ring-primary ring-dashed",
+          (isValidDropTarget || (isIntraMpaDrag && draggedSentence?.sourceIndex !== 0)) &&
+            dragOverIndex === 0 && "bg-primary/10 ring-2 ring-primary ring-dashed",
           isValidDropTarget && dragOverIndex !== 0 && "bg-muted/30"
         )}
         onDragOver={(e) => handleDragOver(e, 0)}
@@ -262,9 +280,10 @@ export function SplitViewEditor({
           <div className="flex items-center gap-1.5">
           
             {/* Drop indicator */}
-            {isValidDropTarget && dragOverIndex === 0 && (
+            {((isValidDropTarget && dragOverIndex === 0) ||
+              (isIntraMpaDrag && draggedSentence?.sourceIndex !== 0 && dragOverIndex === 0)) && (
               <span className="text-[10px] text-primary font-medium animate-pulse">
-                Drop here
+                {isIntraMpaDrag ? "Drop to swap" : "Drop here"}
               </span>
             )}
           </div>
@@ -283,7 +302,7 @@ export function SplitViewEditor({
                 "text-muted-foreground hover:text-primary",
                 isDraggingFrom === 0 && "opacity-50 bg-primary/10 border-primary/30 text-primary"
               )}
-              title="Drag to swap with another MPA"
+              title="Drag onto sentence 2 to reorder, or onto another MPA to move"
             >
               <GripVertical className="size-5" />
             </div>
@@ -318,7 +337,11 @@ export function SplitViewEditor({
         "flex items-center gap-2 w-full justify-center mb-0",
         isClosing ? "animate-elevator-divider-close" : "animate-elevator-divider"
       )}>
-        <span className="text-[15px] text-muted-foreground">+</span>
+        {canReorder && onReorder ? (
+          <SentenceOrderSwapButton onClick={handleSwapOrder} className="size-7" />
+        ) : (
+          <span className="text-[15px] text-muted-foreground">+</span>
+        )}
       </div>
       
       {/* Sentence 2 - slides down like elevator door opening/closing */}
@@ -326,7 +349,8 @@ export function SplitViewEditor({
         className={cn(
           "space-y-1 rounded-lg p-2 -m-2 transition-all",
           isClosing ? "animate-elevator-close-down" : "animate-elevator-down",
-          isValidDropTarget && dragOverIndex === 1 && "bg-primary/10 ring-2 ring-primary ring-dashed",
+          (isValidDropTarget || (isIntraMpaDrag && draggedSentence?.sourceIndex !== 1)) &&
+            dragOverIndex === 1 && "bg-primary/10 ring-2 ring-primary ring-dashed",
           isValidDropTarget && dragOverIndex !== 1 && "bg-muted/30"
         )}
         onDragOver={(e) => handleDragOver(e, 1)}
@@ -337,9 +361,10 @@ export function SplitViewEditor({
           <div className="flex items-center gap-1.5">
            
             {/* Drop indicator */}
-            {isValidDropTarget && dragOverIndex === 1 && (
+            {((isValidDropTarget && dragOverIndex === 1) ||
+              (isIntraMpaDrag && draggedSentence?.sourceIndex !== 1 && dragOverIndex === 1)) && (
               <span className="text-[10px] text-primary font-medium animate-pulse">
-                Drop here
+                {isIntraMpaDrag ? "Drop to swap" : "Drop here"}
               </span>
             )}
           </div>
@@ -357,7 +382,7 @@ export function SplitViewEditor({
                 "text-muted-foreground hover:text-primary",
                 isDraggingFrom === 1 && "opacity-50 bg-primary/10 border-primary/30 text-primary"
               )}
-              title="Drag to swap with another MPA"
+              title="Drag onto sentence 1 to reorder, or onto another MPA to move"
             >
               <GripVertical className="size-5" />
             </div>

--- a/src/lib/__tests__/sentence-utils.test.ts
+++ b/src/lib/__tests__/sentence-utils.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   asPlainText,
   coalesceTwoSentenceRevisions,
+  combineSentences,
   ensureRevisionCount,
   parseRevisionList,
   parseStatement,
+  swapStatementSentences,
 } from "@/lib/sentence-utils";
 
 describe("asPlainText", () => {
@@ -124,5 +126,42 @@ describe("parseStatement", () => {
     ]);
     expect(parsed.hasTwoSentences).toBe(true);
     expect(parsed.sentences).toHaveLength(2);
+  });
+});
+
+describe("swapStatementSentences", () => {
+  it("swaps a two-sentence statement", () => {
+    const original =
+      "Led 12 Airmen through a 96-hour surge. Cut backlog 40% and restored combat sorties.";
+    const swapped = swapStatementSentences(original);
+    const parsed = parseStatement(swapped);
+    expect(parsed.hasTwoSentences).toBe(true);
+    expect(parsed.sentences[0].text).toBe(
+      "Cut backlog 40% and restored combat sorties."
+    );
+    expect(parsed.sentences[1].text).toBe(
+      "Led 12 Airmen through a 96-hour surge."
+    );
+  });
+
+  it("is reversible", () => {
+    const original =
+      "Directed wing inspection prep across 4 squadrons. Zero write-ups at higher HQ.";
+    expect(swapStatementSentences(swapStatementSentences(original))).toBe(
+      combineSentences(
+        parseStatement(original).sentences[0].text,
+        parseStatement(original).sentences[1].text
+      )
+    );
+  });
+
+  it("leaves a single sentence unchanged", () => {
+    const one = "Led 12 Airmen through a 96-hour surge.";
+    expect(swapStatementSentences(one)).toBe(one);
+  });
+
+  it("leaves empty text unchanged", () => {
+    expect(swapStatementSentences("")).toBe("");
+    expect(swapStatementSentences("   ")).toBe("   ");
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -184,6 +184,9 @@ export const Analytics = {
   sentenceSwapped: (sourceMpa: string, targetMpa: string) =>
     trackEvent("sentence_swapped", { source_mpa: sourceMpa, target_mpa: targetMpa }),
 
+  sentenceOrderSwapped: (mpa: string) =>
+    trackEvent("sentence_order_swapped", { mpa }),
+
   // ── Statement Sharing ──────────────────────────
   statementShared: (shareType: "team" | "community" | "user") => 
     trackEvent("statement_shared", { share_type: shareType }),

--- a/src/lib/sentence-utils.ts
+++ b/src/lib/sentence-utils.ts
@@ -288,6 +288,18 @@ export function combineSentences(sentence1: string, sentence2: string): string {
 }
 
 /**
+ * Reverse S1 and S2 in a two-sentence EPB statement.
+ * One-sentence (or empty) text is returned unchanged.
+ */
+export function swapStatementSentences(text: string): string {
+  const parsed = parseStatement(text);
+  if (!parsed.hasTwoSentences || parsed.sentences.length < 2) {
+    return parsed.raw || text || "";
+  }
+  return combineSentences(parsed.sentences[1].text, parsed.sentences[0].text);
+}
+
+/**
  * Calculate how many characters need to be trimmed/added to fit a target
  */
 function calculateCharacterDelta(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Two-sentence MPA statements can now reverse S1/S2 **inside the same MPA**, without going through the cross-MPA move dialog or AI resize.

## How
- **Swap button** next to the S1/S2 pills (combined editor) and in the split-view divider when both sentences exist
- **Same-card DnD**: drop one sentence onto the other in that MPA to reorder
- Cross-MPA drag/drop is unchanged (still opens Replace / Swap with AI resize)

## Tests
- `swapStatementSentences` in `src/lib/__tests__/sentence-utils.test.ts` — 16 tests passing
- React Doctor `--scope changed`: 0 issues (score 83)

## Notes
- No AI resize for in-MPA reorder (length unchanged)
- Impact Booster per-sentence notes are not swapped with the statement text

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80cfa086-4ef3-4a99-834f-15aa87b73de4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80cfa086-4ef3-4a99-834f-15aa87b73de4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

