### PR TITLE
Fix EPB reviewer feedback viewer spinner

### DIFF
--- a/src/components/feedback/feedback-comment-card.tsx
+++ b/src/components/feedback/feedback-comment-card.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { FeedbackComment } from "@/lib/feedback-sessions";
+import { motionLinkHover, motionPressOnly } from "@/lib/motion/classes";
+import {
+  Loader2,
+  Check,
+  MessageSquare,
+  ArrowRightLeft,
+  Trash2,
+  FileEdit,
+  ArrowRight,
+  Eye,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+
+function CollapsibleStatement({
+  children,
+  defaultOpen = true,
+}: {
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          motionPressOnly,
+          motionLinkHover,
+          "flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mb-2"
+        )}
+        aria-expanded={isOpen}
+      >
+        {isOpen ? (
+          <ChevronUp className="size-3" />
+        ) : (
+          <ChevronDown className="size-3" />
+        )}
+        <Eye className="size-3" />
+        {isOpen ? "Hide statement" : "Show statement"}
+      </button>
+      {isOpen && children}
+    </div>
+  );
+}
+
+function renderTextWithHighlight(
+  text: string,
+  highlightStart?: number,
+  highlightEnd?: number,
+  suggestionType?: string
+) {
+  if (!text) {
+    return (
+      <span className="text-muted-foreground italic">No content available</span>
+    );
+  }
+
+  if (highlightStart === undefined || highlightEnd === undefined) {
+    return <span className="whitespace-pre-wrap">{text}</span>;
+  }
+
+  const before = text.slice(0, highlightStart);
+  const highlighted = text.slice(highlightStart, highlightEnd);
+  const after = text.slice(highlightEnd);
+
+  return (
+    <span className="whitespace-pre-wrap">
+      {before}
+      <mark
+        className={cn(
+          "px-0.5 rounded",
+          suggestionType === "delete"
+            ? "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
+            : "bg-amber-200 dark:bg-amber-900/50"
+        )}
+      >
+        {highlighted}
+      </mark>
+      {after}
+    </span>
+  );
+}
+
+export function FeedbackCommentCard({
+  comment,
+  sectionText,
+  currentText,
+  isUpdating,
+  onMarkRead,
+  onIgnore,
+  onApply,
+}: {
+  comment: FeedbackComment;
+  sectionText: string;
+  currentText: string;
+  isUpdating: boolean;
+  onMarkRead: () => void;
+  onIgnore: () => void;
+  onApply?: () => void | Promise<void>;
+}) {
+  const isActionable =
+    comment.suggestion_type === "replace" ||
+    comment.suggestion_type === "delete" ||
+    comment.is_full_rewrite;
+  const isPending = comment.status === "pending";
+  const textHasChanged = currentText !== sectionText;
+
+  return (
+    <div className={cn("space-y-4", !isPending && "opacity-60")}>
+      {!isPending && (
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          <Check className="size-3" />
+          {comment.status === "accepted" ? "Reviewed" : "Ignored"}
+        </div>
+      )}
+
+      {isPending && isActionable && textHasChanged && (
+        <div className="flex items-start gap-2 p-2 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg text-xs text-blue-700 dark:text-blue-300">
+          <MessageSquare className="size-4 shrink-0 mt-0.5" />
+          <div>
+            <p className="font-medium">Text has been edited since review</p>
+            <p className="text-blue-600 dark:text-blue-400">
+              AI will attempt to apply this change intelligently. If the text
+              cannot be found, you&apos;ll be notified.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {isActionable && (
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          {comment.is_full_rewrite ? (
+            <>
+              <FileEdit className="size-3" /> Suggested rewrite
+            </>
+          ) : comment.suggestion_type === "delete" ? (
+            <>
+              <Trash2 className="size-3" /> Suggested deletion
+            </>
+          ) : (
+            <>
+              <ArrowRightLeft className="size-3" /> Suggested replacement
+            </>
+          )}
+        </div>
+      )}
+
+      {comment.is_full_rewrite && comment.rewrite_text ? (
+        <CollapsibleStatement defaultOpen={isPending}>
+          <div className="grid md:grid-cols-2 gap-4">
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1">
+                <Eye className="size-3" /> Original Statement
+              </p>
+              <div className="text-sm bg-muted/50 p-3 rounded-lg border max-h-60 overflow-auto whitespace-pre-wrap">
+                {sectionText || comment.original_text || "No content"}
+              </div>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1">
+                <FileEdit className="size-3" /> Suggested Rewrite
+              </p>
+              <div className="text-sm bg-blue-50 dark:bg-blue-950/30 p-3 rounded-lg border max-h-60 overflow-auto whitespace-pre-wrap">
+                {comment.rewrite_text}
+              </div>
+            </div>
+          </div>
+        </CollapsibleStatement>
+      ) : (
+        <CollapsibleStatement defaultOpen={isPending}>
+          <div className="text-sm bg-muted/50 p-3 rounded-lg border max-h-48 overflow-auto">
+            {renderTextWithHighlight(
+              sectionText || comment.original_text || "",
+              comment.highlight_start,
+              comment.highlight_end,
+              comment.suggestion_type
+            )}
+          </div>
+        </CollapsibleStatement>
+      )}
+
+      {comment.suggestion_type === "replace" && comment.replacement_text && (
+        <div className="flex items-start gap-2 pl-2">
+          <ArrowRight className="size-4 text-blue-500 mt-0.5 shrink-0" />
+          <div className="flex-1">
+            <p className="text-xs font-medium text-muted-foreground mb-1">
+              Replace with:
+            </p>
+            <div className="text-sm bg-blue-50 dark:bg-blue-950/30 p-2 rounded border">
+              {comment.replacement_text}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {comment.comment_text && (
+        <div className="bg-card border rounded-lg p-3">
+          <p className="text-xs font-medium text-muted-foreground mb-1">
+            Reviewer&apos;s Comment:
+          </p>
+          <p className="text-sm">{comment.comment_text}</p>
+        </div>
+      )}
+
+      {isPending && (
+        <div className="flex gap-2 pt-2">
+          {isActionable ? (
+            <>
+              <Button
+                size="sm"
+                onClick={onApply || onMarkRead}
+                disabled={isUpdating}
+                className="gap-1"
+              >
+                {isUpdating ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Check className="size-3" />
+                )}
+                Accept
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onIgnore}
+                disabled={isUpdating}
+              >
+                Ignore
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onMarkRead}
+              disabled={isUpdating}
+              className="gap-1"
+            >
+              {isUpdating ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Check className="size-3" />
+              )}
+              Mark as Read
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/feedback/feedback-viewer-dialog.tsx
+++ b/src/components/feedback/feedback-viewer-dialog.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { Suspense, use, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -20,56 +21,36 @@ import { Separator } from "@/components/ui/separator";
 import { formatShortDateWithYear } from "@/lib/format";
 import { toast } from "@/components/ui/sonner";
 import { cn, normalizeText } from "@/lib/utils";
-import { 
-  Loader2, 
-  Check, 
-  MessageSquare, 
-  ArrowLeft, 
-  ArrowRightLeft, 
-  Trash2, 
-  FileEdit, 
-  ArrowRight,
-  Eye,
+import {
+  loadFeedbackSessions,
+  loadFeedbackSessionDetail,
+  invalidateFeedbackSessionsCache,
+  invalidateFeedbackSessionDetailCache,
+  resolveFeedbackViewerSessionId,
+  type FeedbackComment,
+  type FeedbackShellType,
+} from "@/lib/feedback-sessions";
+import { FeedbackCommentCard } from "@/components/feedback/feedback-comment-card";
+import {
+  motionCollapseGrid,
+  motionEnter,
+  motionEnterFade,
+  motionEnterDurList,
+  motionEnterDurNormal,
+  motionListEnterStagger,
+  motionPressable,
+  motionTransitionColors,
+} from "@/lib/motion/classes";
+import {
+  Loader2,
+  Check,
+  MessageSquare,
+  ArrowLeft,
   ChevronDown,
   ChevronUp,
   AlertTriangle,
 } from "lucide-react";
 
-interface FeedbackComment {
-  id: string;
-  section_key: string;
-  original_text?: string;
-  highlight_start?: number;
-  highlight_end?: number;
-  highlighted_text?: string;
-  comment_text: string;
-  suggestion?: string;
-  status: "pending" | "accepted" | "dismissed";
-  created_at: string;
-  suggestion_type?: "comment" | "replace" | "delete";
-  replacement_text?: string;
-  is_full_rewrite?: boolean;
-  rewrite_text?: string;
-}
-
-interface FeedbackSession {
-  id: string;
-  reviewer_name: string;
-  comment_count: number;
-  submitted_at: string;
-  pending_count: number;
-}
-
-interface ContentSnapshot {
-  duty_description?: string;
-  cycle_year?: string;
-  sections?: Array<{
-    mpa: string;
-    statement_text: string;
-  }>;
-}
-
-// MPA labels
 const MPA_LABELS: Record<string, string> = {
   executing_mission: "Executing the Mission",
   leading_people: "Leading People",
@@ -84,27 +65,25 @@ interface FeedbackViewerDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   sessionId: string | null;
-  shellType: "epb" | "award" | "decoration";
+  shellType: FeedbackShellType;
   shellId: string;
   onBack?: () => void;
   onApplySuggestion?: (sectionKey: string, newText: string) => void;
   getCurrentText?: (sectionKey: string) => string;
 }
 
-// Apply suggestion using LLM API for intelligent text matching
 async function applySuggestionWithLLM(
   snapshotText: string,
   currentText: string,
   comment: FeedbackComment
-): Promise<{ 
-  success: boolean; 
-  newText: string; 
-  aborted?: boolean; 
+): Promise<{
+  success: boolean;
+  newText: string;
+  aborted?: boolean;
   reason?: string;
   needsReview?: boolean;
   reviewReason?: string;
 }> {
-  // Full rewrite - always safe, just replace everything
   if (comment.is_full_rewrite && comment.rewrite_text) {
     return { success: true, newText: comment.rewrite_text };
   }
@@ -112,13 +91,15 @@ async function applySuggestionWithLLM(
   const highlightedText = comment.highlighted_text;
   const suggestionType = comment.suggestion_type;
 
-  // No highlight info, can't apply
-  if (!highlightedText || (suggestionType !== "delete" && suggestionType !== "replace")) {
-    return { 
-      success: false, 
-      newText: currentText, 
+  if (
+    !highlightedText ||
+    (suggestionType !== "delete" && suggestionType !== "replace")
+  ) {
+    return {
+      success: false,
+      newText: currentText,
       aborted: true,
-      reason: "Missing highlight information or unsupported suggestion type" 
+      reason: "Missing highlight information or unsupported suggestion type",
     };
   }
 
@@ -139,57 +120,214 @@ async function applySuggestionWithLLM(
     const result = await response.json();
 
     if (result.success && result.newText) {
-      return { 
-        success: true, 
+      return {
+        success: true,
         newText: result.newText,
         needsReview: result.needsReview,
-        reviewReason: result.reviewReason
-      };
-    } else if (result.aborted) {
-      return { 
-        success: false, 
-        newText: currentText, 
-        aborted: true, 
-        reason: result.reason || "Could not apply the suggested change" 
-      };
-    } else {
-      return { 
-        success: false, 
-        newText: currentText, 
-        aborted: true, 
-        reason: result.error || "Failed to apply suggestion" 
+        reviewReason: result.reviewReason,
       };
     }
+    if (result.aborted) {
+      return {
+        success: false,
+        newText: currentText,
+        aborted: true,
+        reason: result.reason || "Could not apply the suggested change",
+      };
+    }
+    return {
+      success: false,
+      newText: currentText,
+      aborted: true,
+      reason: result.error || "Failed to apply suggestion",
+    };
   } catch (error) {
     console.error("Error calling apply feedback API:", error);
-    return { 
-      success: false, 
-      newText: currentText, 
-      aborted: true, 
-      reason: "Network error - please try again" 
+    return {
+      success: false,
+      newText: currentText,
+      aborted: true,
+      reason: "Network error - please try again",
     };
   }
 }
 
-export function FeedbackViewerDialog({
-  open,
-  onOpenChange,
-  sessionId,
+function FeedbackViewerFallback({
+  onBack,
+}: {
+  onBack?: () => void;
+}) {
+  return (
+    <>
+      <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
+        <div className="flex items-center gap-3">
+          {onBack && (
+            <Button variant="ghost" size="icon" onClick={onBack} aria-label="Back to feedback list">
+              <ArrowLeft className="size-4" />
+            </Button>
+          )}
+          <DialogTitle className="flex items-center gap-2">
+            <MessageSquare className="size-5" />
+            Feedback from Reviewer
+          </DialogTitle>
+        </div>
+        <DialogDescription className="sr-only">
+          Loading reviewer comments
+        </DialogDescription>
+      </DialogHeader>
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    </>
+  );
+}
+
+function FeedbackViewerBody({
   shellType,
   shellId,
+  preferredSessionId,
+  bust,
   onBack,
+  onSessionChange,
   onApplySuggestion,
   getCurrentText,
-}: FeedbackViewerDialogProps) {
-  const [sessions, setSessions] = useState<FeedbackSession[]>([]);
-  const [currentSessionId, setCurrentSessionId] = useState<string | null>(sessionId);
-  const [comments, setComments] = useState<FeedbackComment[]>([]);
-  const [contentSnapshot, setContentSnapshot] = useState<ContentSnapshot | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+}: {
+  shellType: FeedbackShellType;
+  shellId: string;
+  preferredSessionId: string | null;
+  bust: number;
+  onBack?: () => void;
+  onSessionChange: (sessionId: string) => void;
+  onApplySuggestion?: (sectionKey: string, newText: string) => void;
+  getCurrentText?: (sectionKey: string) => string;
+}) {
+  if (preferredSessionId) {
+    void loadFeedbackSessionDetail(preferredSessionId, bust);
+  }
+  const sessions = use(loadFeedbackSessions(shellType, shellId, bust));
+  const sessionId = resolveFeedbackViewerSessionId(preferredSessionId, sessions);
+
+  if (!sessionId) {
+    return (
+      <>
+        <FeedbackViewerHeader
+          onBack={onBack}
+          reviewerName="Reviewer"
+          submittedAt={null}
+          sessions={sessions}
+          currentSessionId={null}
+          onSessionChange={onSessionChange}
+        />
+        <div className="text-center py-12">
+          <p className="text-sm text-muted-foreground">No comments found</p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <FeedbackViewerSession
+      sessionId={sessionId}
+      sessions={sessions}
+      bust={bust}
+      onBack={onBack}
+      onSessionChange={onSessionChange}
+      onApplySuggestion={onApplySuggestion}
+      getCurrentText={getCurrentText}
+    />
+  );
+}
+
+function FeedbackViewerHeader({
+  onBack,
+  reviewerName,
+  submittedAt,
+  sessions,
+  currentSessionId,
+  onSessionChange,
+}: {
+  onBack?: () => void;
+  reviewerName: string;
+  submittedAt: string | null;
+  sessions: Array<{ id: string; reviewer_name: string }>;
+  currentSessionId: string | null;
+  onSessionChange: (sessionId: string) => void;
+}) {
+  return (
+    <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
+      <div className="flex items-center gap-3">
+        {onBack && (
+          <Button variant="ghost" size="icon" onClick={onBack} aria-label="Back to feedback list">
+            <ArrowLeft className="size-4" />
+          </Button>
+        )}
+        <div className="flex-1">
+          <DialogTitle className="flex items-center gap-2">
+            <MessageSquare className="size-5" />
+            Feedback from {reviewerName}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Review comments and suggested edits from {reviewerName}
+          </DialogDescription>
+          {submittedAt && (
+            <p className="text-sm text-muted-foreground mt-1">
+              {formatShortDateWithYear(submittedAt)}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {sessions.length > 1 && (
+        <div className="mt-3">
+          <Select
+            value={currentSessionId || ""}
+            onValueChange={onSessionChange}
+          >
+            <SelectTrigger className="w-full" aria-label="Select feedback session">
+              <SelectValue placeholder="Select feedback session" />
+            </SelectTrigger>
+            <SelectContent>
+              {sessions.map((session) => (
+                <SelectItem key={session.id} value={session.id}>
+                  {session.reviewer_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </DialogHeader>
+  );
+}
+
+function FeedbackViewerSession({
+  sessionId,
+  sessions,
+  bust,
+  onBack,
+  onSessionChange,
+  onApplySuggestion,
+  getCurrentText,
+}: {
+  sessionId: string;
+  sessions: Array<{
+    id: string;
+    reviewer_name: string;
+    submitted_at: string;
+  }>;
+  bust: number;
+  onBack?: () => void;
+  onSessionChange: (sessionId: string) => void;
+  onApplySuggestion?: (sectionKey: string, newText: string) => void;
+  getCurrentText?: (sectionKey: string) => string;
+}) {
+  const detail = use(loadFeedbackSessionDetail(sessionId, bust));
+  const [comments, setComments] = useState<FeedbackComment[]>(detail.comments);
+  const [prevDetail, setPrevDetail] = useState(detail);
   const [isUpdating, setIsUpdating] = useState<string | null>(null);
-  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
-  
-  // Review confirmation state - when AI makes changes beyond what was expected
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(
+    () => new Set(detail.comments.map((c) => c.section_key))
+  );
   const [reviewConfirmation, setReviewConfirmation] = useState<{
     show: boolean;
     currentText: string;
@@ -199,90 +337,43 @@ export function FeedbackViewerDialog({
     commentId: string;
   } | null>(null);
 
-  const loadSessionsList = useCallback(async () => {
-    try {
-      const response = await fetch(
-        `/api/feedback?shellType=${shellType}&shellId=${shellId}`
-      );
-      const data = await response.json();
+  if (detail !== prevDetail) {
+    setPrevDetail(detail);
+    setComments(detail.comments);
+    setExpandedSections(new Set(detail.comments.map((c) => c.section_key)));
+  }
 
-      if (response.ok && data.sessions) {
-        setSessions(data.sessions);
-        return data.sessions as FeedbackSession[];
+  const currentSession = sessions.find((s) => s.id === sessionId);
+  const contentSnapshot = detail.contentSnapshot;
+
+  const commentsBySection = useMemo(() => {
+    const grouped: Record<string, FeedbackComment[]> = {};
+    comments.forEach((comment) => {
+      const key = comment.section_key;
+      if (!grouped[key]) {
+        grouped[key] = [];
       }
-    } catch (error) {
-      console.error("Load sessions error:", error);
+      grouped[key].push(comment);
+    });
+    return grouped;
+  }, [comments]);
+
+  const getSectionText = (sectionKey: string): string => {
+    if (!contentSnapshot) return "";
+    let text = "";
+    if (sectionKey === "duty_description") {
+      text = contentSnapshot.duty_description || "";
+    } else {
+      const section = contentSnapshot.sections?.find((s) => s.mpa === sectionKey);
+      text = section?.statement_text || "";
     }
-    return [];
-  }, [shellType, shellId]);
+    return normalizeText(text);
+  };
 
-  const loadCommentsForSession = useCallback(async (sessionIdToLoad: string) => {
-    setIsLoading(true);
-    try {
-      const response = await fetch(`/api/feedback/${sessionIdToLoad}`);
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to load comments");
-      }
-
-      setComments(data.comments || []);
-      setContentSnapshot(data.contentSnapshot || null);
-
-      const allSections = new Set<string>();
-      (data.comments || []).forEach((c: FeedbackComment) => {
-        allSections.add(c.section_key);
-      });
-      setExpandedSections(allSections);
-    } catch (error) {
-      console.error("Load comments error:", error);
-      toast.error("Failed to load comments");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      onOpenChange(nextOpen);
-      if (!nextOpen) return;
-
-      void (async () => {
-        const loadedSessions = await loadSessionsList();
-        const initialSessionId =
-          sessionId ?? currentSessionId ?? loadedSessions[0]?.id ?? null;
-        if (initialSessionId) {
-          setCurrentSessionId(initialSessionId);
-          await loadCommentsForSession(initialSessionId);
-        }
-      })();
-    },
-    [
-      onOpenChange,
-      loadSessionsList,
-      loadCommentsForSession,
-      sessionId,
-      currentSessionId,
-    ]
-  );
-
-  const handleSessionChange = useCallback(
-    (nextSessionId: string) => {
-      setCurrentSessionId(nextSessionId);
-      void loadCommentsForSession(nextSessionId);
-    },
-    [loadCommentsForSession]
-  );
-
-  // Sync session id from props without fetching
-  useEffect(() => {
-    if (sessionId) {
-      setCurrentSessionId(sessionId);
-    }
-  }, [sessionId]);
-
-  // Handle accept/dismiss
-  const handleUpdateStatus = useCallback(async (commentId: string, status: "accepted" | "dismissed") => {
+  const handleUpdateStatus = async (
+    commentId: string,
+    status: "accepted" | "dismissed"
+  ) => {
     setIsUpdating(commentId);
     try {
       const response = await fetch(`/api/feedback/${commentId}`, {
@@ -296,9 +387,7 @@ export function FeedbackViewerDialog({
       }
 
       setComments((prev) =>
-        prev.map((c) =>
-          c.id === commentId ? { ...c, status } : c
-        )
+        prev.map((c) => (c.id === commentId ? { ...c, status } : c))
       );
     } catch (error) {
       console.error("Update error:", error);
@@ -306,75 +395,10 @@ export function FeedbackViewerDialog({
     } finally {
       setIsUpdating(null);
     }
-  }, []);
-
-  // Get section text from snapshot (normalized to fix PDF line breaks)
-  const getSectionText = useCallback((sectionKey: string): string => {
-    if (!contentSnapshot) return "";
-    
-    let text = "";
-    if (sectionKey === "duty_description") {
-      text = contentSnapshot.duty_description || "";
-    } else {
-      const section = contentSnapshot.sections?.find(s => s.mpa === sectionKey);
-      text = section?.statement_text || "";
-    }
-    
-    return normalizeText(text);
-  }, [contentSnapshot]);
-
-  // Render text with highlight
-  const renderTextWithHighlight = useCallback((
-    text: string, 
-    highlightStart?: number, 
-    highlightEnd?: number,
-    suggestionType?: string
-  ) => {
-    if (!text) {
-      return <span className="text-muted-foreground italic">No content available</span>;
-    }
-
-    if (highlightStart === undefined || highlightEnd === undefined) {
-      return <span className="whitespace-pre-wrap">{text}</span>;
-    }
-
-    const before = text.slice(0, highlightStart);
-    const highlighted = text.slice(highlightStart, highlightEnd);
-    const after = text.slice(highlightEnd);
-
-    return (
-      <span className="whitespace-pre-wrap">
-        {before}
-        <mark className={cn(
-          "px-0.5 rounded",
-          suggestionType === "delete" 
-            ? "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300" 
-            : "bg-amber-200 dark:bg-amber-900/50"
-        )}>
-          {highlighted}
-        </mark>
-        {after}
-      </span>
-    );
-  }, []);
-
-  const currentSession = sessions.find((s) => s.id === currentSessionId);
-
-  // Group comments by section
-  const commentsBySection = useMemo(() => {
-    const grouped: Record<string, FeedbackComment[]> = {};
-    comments.forEach((comment) => {
-      const key = comment.section_key;
-      if (!grouped[key]) {
-        grouped[key] = [];
-      }
-      grouped[key].push(comment);
-    });
-    return grouped;
-  }, [comments]);
+  };
 
   const toggleSection = (sectionKey: string) => {
-    setExpandedSections(prev => {
+    setExpandedSections((prev) => {
       const next = new Set(prev);
       if (next.has(sectionKey)) {
         next.delete(sectionKey);
@@ -386,74 +410,53 @@ export function FeedbackViewerDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="!max-w-5xl w-[90vw] h-[85vh] flex flex-col p-0 overflow-hidden">
-        {/* Header */}
-        <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
-          <div className="flex items-center gap-3">
-            {onBack && (
-              <Button variant="ghost" size="icon" onClick={onBack}>
-                <ArrowLeft className="size-4" />
-              </Button>
-            )}
-            <div className="flex-1">
-              <DialogTitle className="flex items-center gap-2">
-                <MessageSquare className="size-5" />
-                Feedback from {currentSession?.reviewer_name || "Reviewer"}
-              </DialogTitle>
-              {currentSession && (
-                <p className="text-sm text-muted-foreground mt-1">
-                  {formatShortDateWithYear(currentSession.submitted_at)}
-                </p>
-              )}
-            </div>
-          </div>
+    <>
+      <FeedbackViewerHeader
+        onBack={onBack}
+        reviewerName={currentSession?.reviewer_name || "Reviewer"}
+        submittedAt={currentSession?.submitted_at ?? null}
+        sessions={sessions}
+        currentSessionId={sessionId}
+        onSessionChange={onSessionChange}
+      />
 
-          {/* Session switcher */}
-          {sessions.length > 1 && (
-            <div className="mt-3">
-              <Select
-                value={currentSessionId || ""}
-                onValueChange={handleSessionChange}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Select feedback session" />
-                </SelectTrigger>
-                <SelectContent>
-                  {sessions.map((session) => (
-                    <SelectItem key={session.id} value={session.id}>
-                      {session.reviewer_name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+      <ScrollArea className="flex-1 min-h-0">
+        <div className={cn("px-6 py-4", motionEnterFade, motionEnterDurNormal)}>
+          {detail.error ? (
+            <div className="text-center py-12">
+              <p className="text-sm text-muted-foreground">{detail.error}</p>
             </div>
-          )}
-        </DialogHeader>
-
-        {/* Content */}
-        <ScrollArea className="flex-1 min-h-0">
-          <div className="px-6 py-4">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="size-6 animate-spin text-muted-foreground" />
-              </div>
-            ) : comments.length === 0 ? (
-              <div className="text-center py-12">
-                <p className="text-sm text-muted-foreground">No comments found</p>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                {Object.entries(commentsBySection).map(([sectionKey, sectionComments]) => {
+          ) : comments.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-sm text-muted-foreground">No comments found</p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {Object.entries(commentsBySection).map(
+                ([sectionKey, sectionComments], sectionIndex) => {
                   const sectionText = getSectionText(sectionKey);
                   const isExpanded = expandedSections.has(sectionKey);
 
                   return (
-                    <div key={sectionKey} className="border rounded-lg overflow-hidden">
-                      {/* Section header */}
-                      <button type="button"
+                    <div
+                      key={sectionKey}
+                      className={cn(
+                        "border rounded-lg overflow-hidden",
+                        motionEnter,
+                        motionEnterDurList
+                      )}
+                      style={motionListEnterStagger(sectionIndex)}
+                    >
+                      <button
+                        type="button"
                         onClick={() => toggleSection(sectionKey)}
-                        className="w-full px-4 py-3 flex items-center justify-between bg-muted/50 hover:bg-muted/70 transition-colors text-left"
+                        className={cn(
+                          motionPressable,
+                          motionTransitionColors,
+                          "w-full px-4 py-3 flex items-center justify-between bg-muted/50 hover:bg-muted/70 text-left"
+                        )}
+                        aria-expanded={isExpanded}
+                        aria-controls={`feedback-section-${sectionKey}`}
                       >
                         <span className="font-medium">
                           {MPA_LABELS[sectionKey] || sectionKey}
@@ -465,81 +468,126 @@ export function FeedbackViewerDialog({
                         )}
                       </button>
 
-                      {/* Expanded content */}
-                      {isExpanded && (
-                        <div className="p-4 space-y-4">
-                          {sectionComments.map((comment, idx) => (
-                            <div key={comment.id}>
-                              {idx > 0 && <Separator className="my-4" />}
-                              
-                              <FeedbackCommentCard
-                                comment={comment}
-                                sectionText={sectionText}
-                                currentText={getCurrentText ? getCurrentText(sectionKey) : sectionText}
-                                isUpdating={isUpdating === comment.id}
-                                onMarkRead={() => handleUpdateStatus(comment.id, "accepted")}
-                                onIgnore={() => handleUpdateStatus(comment.id, "dismissed")}
-                                onApply={onApplySuggestion ? async () => {
-                                  const currentTextVal = getCurrentText ? getCurrentText(sectionKey) : sectionText;
-                                  setIsUpdating(comment.id);
-                                  
-                                  try {
-                                    const result = await applySuggestionWithLLM(sectionText, currentTextVal, comment);
-                                    
-                                    if (result.success) {
-                                      // Check if the AI made changes that need user review
-                                      if (result.needsReview) {
-                                        setReviewConfirmation({
-                                          show: true,
-                                          currentText: currentTextVal,
-                                          proposedText: result.newText,
-                                          reviewReason: result.reviewReason || "The AI made changes that may differ from what was expected.",
-                                          sectionKey,
-                                          commentId: comment.id,
-                                        });
-                                      } else {
-                                        onApplySuggestion(sectionKey, result.newText);
-                                        await handleUpdateStatus(comment.id, "accepted");
-                                        toast.success("Suggestion applied successfully");
-                                      }
-                                    } else if (result.aborted) {
-                                      toast.error(result.reason || "Could not apply suggestion");
-                                    }
-                                  } catch (error) {
-                                    console.error("Error applying suggestion:", error);
-                                    toast.error("Failed to apply suggestion");
-                                  } finally {
-                                    setIsUpdating(null);
+                      <div
+                        id={`feedback-section-${sectionKey}`}
+                        className={motionCollapseGrid}
+                        data-open={isExpanded ? "true" : "false"}
+                      >
+                        <div>
+                          <div className="p-4 space-y-4">
+                            {sectionComments.map((comment, idx) => (
+                              <div key={comment.id}>
+                                {idx > 0 && <Separator className="my-4" />}
+                                <FeedbackCommentCard
+                                  comment={comment}
+                                  sectionText={sectionText}
+                                  currentText={
+                                    getCurrentText
+                                      ? getCurrentText(sectionKey)
+                                      : sectionText
                                   }
-                                } : undefined}
-                                renderTextWithHighlight={renderTextWithHighlight}
-                              />
-                            </div>
-                          ))}
+                                  isUpdating={isUpdating === comment.id}
+                                  onMarkRead={() =>
+                                    handleUpdateStatus(comment.id, "accepted")
+                                  }
+                                  onIgnore={() =>
+                                    handleUpdateStatus(comment.id, "dismissed")
+                                  }
+                                  onApply={
+                                    onApplySuggestion
+                                      ? async () => {
+                                          const currentTextVal = getCurrentText
+                                            ? getCurrentText(sectionKey)
+                                            : sectionText;
+                                          setIsUpdating(comment.id);
+
+                                          try {
+                                            const result =
+                                              await applySuggestionWithLLM(
+                                                sectionText,
+                                                currentTextVal,
+                                                comment
+                                              );
+
+                                            if (result.success) {
+                                              if (result.needsReview) {
+                                                setReviewConfirmation({
+                                                  show: true,
+                                                  currentText: currentTextVal,
+                                                  proposedText: result.newText,
+                                                  reviewReason:
+                                                    result.reviewReason ||
+                                                    "The AI made changes that may differ from what was expected.",
+                                                  sectionKey,
+                                                  commentId: comment.id,
+                                                });
+                                              } else {
+                                                onApplySuggestion(
+                                                  sectionKey,
+                                                  result.newText
+                                                );
+                                                await handleUpdateStatus(
+                                                  comment.id,
+                                                  "accepted"
+                                                );
+                                                toast.success(
+                                                  "Suggestion applied successfully"
+                                                );
+                                              }
+                                            } else if (result.aborted) {
+                                              toast.error(
+                                                result.reason ||
+                                                  "Could not apply suggestion"
+                                              );
+                                            }
+                                          } catch (error) {
+                                            console.error(
+                                              "Error applying suggestion:",
+                                              error
+                                            );
+                                            toast.error(
+                                              "Failed to apply suggestion"
+                                            );
+                                          } finally {
+                                            setIsUpdating(null);
+                                          }
+                                        }
+                                      : undefined
+                                  }
+                                />
+                              </div>
+                            ))}
+                          </div>
                         </div>
-                      )}
+                      </div>
                     </div>
                   );
-                })}
-              </div>
-            )}
-          </div>
-        </ScrollArea>
-      </DialogContent>
+                }
+              )}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
 
-      {/* Review Confirmation Dialog - shows when AI makes changes that need user approval */}
       {reviewConfirmation?.show && (
-        <Dialog open={reviewConfirmation.show} onOpenChange={(open) => {
-          if (!open) setReviewConfirmation(null);
-        }}>
+        <Dialog
+          open={reviewConfirmation.show}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setReviewConfirmation(null);
+          }}
+        >
           <DialogContent className="!max-w-5xl w-[90vw] max-h-[85vh] flex flex-col p-0 overflow-hidden">
             <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
               <DialogTitle className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
                 <AlertTriangle className="size-5" />
                 Review AI Changes
               </DialogTitle>
+              <DialogDescription>
+                The AI made changes that may differ from what was expected.
+                Review them before applying.
+              </DialogDescription>
             </DialogHeader>
-            
+
             <div className="flex-1 overflow-auto px-6 py-4 space-y-4">
               <div className="p-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg text-sm">
                 <p className="font-medium text-amber-800 dark:text-amber-200">
@@ -549,23 +597,27 @@ export function FeedbackViewerDialog({
                   {reviewConfirmation.reviewReason}
                 </p>
               </div>
-              
+
               <div className="space-y-4">
                 <div>
-                  <p className="text-xs font-medium text-muted-foreground mb-2">Current Text</p>
+                  <p className="text-xs font-medium text-muted-foreground mb-2">
+                    Current Text
+                  </p>
                   <div className="text-sm bg-muted/50 p-4 rounded-lg border min-h-[100px] max-h-[200px] overflow-auto whitespace-pre-wrap">
                     {reviewConfirmation.currentText}
                   </div>
                 </div>
                 <div>
-                  <p className="text-xs font-medium text-muted-foreground mb-2">Proposed Changes</p>
+                  <p className="text-xs font-medium text-muted-foreground mb-2">
+                    Proposed Changes
+                  </p>
                   <div className="text-sm bg-blue-50 dark:bg-blue-950/30 p-4 rounded-lg border border-blue-200 dark:border-blue-800 min-h-[100px] max-h-[200px] overflow-auto whitespace-pre-wrap">
                     {reviewConfirmation.proposedText}
                   </div>
                 </div>
               </div>
             </div>
-            
+
             <div className="flex justify-end gap-2 px-6 py-4 border-t shrink-0 bg-background">
               <Button
                 variant="outline"
@@ -576,8 +628,14 @@ export function FeedbackViewerDialog({
               <Button
                 onClick={async () => {
                   if (onApplySuggestion && reviewConfirmation) {
-                    onApplySuggestion(reviewConfirmation.sectionKey, reviewConfirmation.proposedText);
-                    await handleUpdateStatus(reviewConfirmation.commentId, "accepted");
+                    onApplySuggestion(
+                      reviewConfirmation.sectionKey,
+                      reviewConfirmation.proposedText
+                    );
+                    await handleUpdateStatus(
+                      reviewConfirmation.commentId,
+                      "accepted"
+                    );
                     toast.success("Changes applied");
                     setReviewConfirmation(null);
                   }
@@ -590,212 +648,61 @@ export function FeedbackViewerDialog({
           </DialogContent>
         </Dialog>
       )}
+    </>
+  );
+}
+
+export function FeedbackViewerDialog({
+  open,
+  onOpenChange,
+  sessionId,
+  shellType,
+  shellId,
+  onBack,
+  onApplySuggestion,
+  getCurrentText,
+}: FeedbackViewerDialogProps) {
+  const [bust, setBust] = useState(0);
+  const [wasOpen, setWasOpen] = useState(open);
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(
+    sessionId
+  );
+  const [prevPropSessionId, setPrevPropSessionId] = useState(sessionId);
+
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      invalidateFeedbackSessionsCache(shellType, shellId);
+      invalidateFeedbackSessionDetailCache();
+      setBust((n) => n + 1);
+      setCurrentSessionId(sessionId);
+    }
+  }
+
+  if (sessionId !== prevPropSessionId) {
+    setPrevPropSessionId(sessionId);
+    setCurrentSessionId(sessionId);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="!max-w-5xl w-[90vw] h-[85vh] flex flex-col p-0 overflow-hidden">
+        {open ? (
+          <Suspense fallback={<FeedbackViewerFallback onBack={onBack} />}>
+            <FeedbackViewerBody
+              key={`${shellType}-${shellId}-${currentSessionId ?? "auto"}-${bust}`}
+              shellType={shellType}
+              shellId={shellId}
+              preferredSessionId={currentSessionId}
+              bust={bust}
+              onBack={onBack}
+              onSessionChange={setCurrentSessionId}
+              onApplySuggestion={onApplySuggestion}
+              getCurrentText={getCurrentText}
+            />
+          </Suspense>
+        ) : null}
+      </DialogContent>
     </Dialog>
-  );
-}
-
-// Collapsible statement wrapper
-function CollapsibleStatement({ 
-  children, 
-  defaultOpen = true 
-}: { 
-  children: React.ReactNode; 
-  defaultOpen?: boolean;
-}) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-
-  return (
-    <div>
-      <button type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mb-2"
-      >
-        {isOpen ? (
-          <ChevronUp className="size-3" />
-        ) : (
-          <ChevronDown className="size-3" />
-        )}
-        <Eye className="size-3" />
-        {isOpen ? "Hide statement" : "Show statement"}
-      </button>
-      {isOpen && children}
-    </div>
-  );
-}
-
-// Individual comment card component
-function FeedbackCommentCard({
-  comment,
-  sectionText,
-  currentText,
-  isUpdating,
-  onMarkRead,
-  onIgnore,
-  onApply,
-  renderTextWithHighlight,
-}: {
-  comment: FeedbackComment;
-  sectionText: string;
-  currentText: string;
-  isUpdating: boolean;
-  onMarkRead: () => void;
-  onIgnore: () => void;
-  onApply?: () => void | Promise<void>;
-  renderTextWithHighlight: (
-    text: string, 
-    start?: number, 
-    end?: number, 
-    type?: string
-  ) => React.ReactNode;
-}) {
-  const isActionable = comment.suggestion_type === "replace" || 
-                       comment.suggestion_type === "delete" || 
-                       comment.is_full_rewrite;
-  const isPending = comment.status === "pending";
-  
-  // Text has changed indicator
-  const textHasChanged = currentText !== sectionText;
-
-  return (
-    <div className={cn("space-y-4", !isPending && "opacity-60")}>
-      {/* Status indicator for already-handled comments */}
-      {!isPending && (
-        <div className="flex items-center gap-1 text-xs text-muted-foreground">
-          <Check className="size-3" />
-          {comment.status === "accepted" ? "Reviewed" : "Ignored"}
-        </div>
-      )}
-
-      {/* Info notice if text has changed - LLM will attempt to apply intelligently */}
-      {isPending && isActionable && textHasChanged && (
-        <div className="flex items-start gap-2 p-2 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg text-xs text-blue-700 dark:text-blue-300">
-          <MessageSquare className="size-4 shrink-0 mt-0.5" />
-          <div>
-            <p className="font-medium">Text has been edited since review</p>
-            <p className="text-blue-600 dark:text-blue-400">AI will attempt to apply this change intelligently. If the text cannot be found, you&apos;ll be notified.</p>
-          </div>
-        </div>
-      )}
-
-      {/* Suggestion type indicator */}
-      {isActionable && (
-        <div className="flex items-center gap-1 text-xs text-muted-foreground">
-          {comment.is_full_rewrite ? (
-            <><FileEdit className="size-3" /> Suggested rewrite</>
-          ) : comment.suggestion_type === "delete" ? (
-            <><Trash2 className="size-3" /> Suggested deletion</>
-          ) : (
-            <><ArrowRightLeft className="size-3" /> Suggested replacement</>
-          )}
-        </div>
-      )}
-
-      {/* Full section rewrite - side by side */}
-      {comment.is_full_rewrite && comment.rewrite_text ? (
-        <CollapsibleStatement defaultOpen={isPending}>
-          <div className="grid md:grid-cols-2 gap-4">
-            <div>
-              <p className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1">
-                <Eye className="size-3" /> Original Statement
-              </p>
-              <div className="text-sm bg-muted/50 p-3 rounded-lg border max-h-60 overflow-auto whitespace-pre-wrap">
-                {sectionText || comment.original_text || "No content"}
-              </div>
-            </div>
-            <div>
-              <p className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1">
-                <FileEdit className="size-3" /> Suggested Rewrite
-              </p>
-              <div className="text-sm bg-blue-50 dark:bg-blue-950/30 p-3 rounded-lg border max-h-60 overflow-auto whitespace-pre-wrap">
-                {comment.rewrite_text}
-              </div>
-            </div>
-          </div>
-        </CollapsibleStatement>
-      ) : (
-        /* Show the full statement with highlight - collapsible for reviewed comments */
-        <CollapsibleStatement defaultOpen={isPending}>
-          <div className="text-sm bg-muted/50 p-3 rounded-lg border max-h-48 overflow-auto">
-            {renderTextWithHighlight(
-              sectionText || comment.original_text || "",
-              comment.highlight_start,
-              comment.highlight_end,
-              comment.suggestion_type
-            )}
-          </div>
-        </CollapsibleStatement>
-      )}
-
-      {/* Replacement text for replace suggestions */}
-      {comment.suggestion_type === "replace" && comment.replacement_text && (
-        <div className="flex items-start gap-2 pl-2">
-          <ArrowRight className="size-4 text-blue-500 mt-0.5 shrink-0" />
-          <div className="flex-1">
-            <p className="text-xs font-medium text-muted-foreground mb-1">
-              Replace with:
-            </p>
-            <div className="text-sm bg-blue-50 dark:bg-blue-950/30 p-2 rounded border">
-              {comment.replacement_text}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Reviewer's comment */}
-      {comment.comment_text && (
-        <div className="bg-card border rounded-lg p-3">
-          <p className="text-xs font-medium text-muted-foreground mb-1">
-            Reviewer&apos;s Comment:
-          </p>
-          <p className="text-sm">{comment.comment_text}</p>
-        </div>
-      )}
-
-      {/* Action buttons - only show for pending */}
-      {isPending && (
-        <div className="flex gap-2 pt-2">
-          {isActionable ? (
-            <>
-              <Button
-                size="sm"
-                onClick={onApply || onMarkRead}
-                disabled={isUpdating}
-                className="gap-1"
-              >
-                {isUpdating ? (
-                  <Loader2 className="size-3 animate-spin" />
-                ) : (
-                  <Check className="size-3" />
-                )}
-                Accept
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onIgnore}
-                disabled={isUpdating}
-              >
-                Ignore
-              </Button>
-            </>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onMarkRead}
-              disabled={isUpdating}
-              className="gap-1"
-            >
-              {isUpdating ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Check className="size-3" />
-              )}
-              Mark as Read
-            </Button>
-          )}
-        </div>
-      )}
-    </div>
   );
 }

--- a/src/lib/__tests__/feedback-sessions.test.ts
+++ b/src/lib/__tests__/feedback-sessions.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  invalidateFeedbackSessionDetailCache,
+  invalidateFeedbackSessionsCache,
+  loadFeedbackSessionDetail,
+  loadFeedbackSessions,
+  resolveFeedbackViewerSessionId,
+} from "../feedback-sessions";
+
+afterEach(() => {
+  invalidateFeedbackSessionDetailCache();
+  invalidateFeedbackSessionsCache();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("resolveFeedbackViewerSessionId", () => {
+  const sessions = [
+    { id: "s1", reviewer_name: "Alex" },
+    { id: "s2", reviewer_name: "Jordan" },
+  ] as never;
+
+  it("prefers the selected session id", () => {
+    expect(resolveFeedbackViewerSessionId("s2", sessions)).toBe("s2");
+  });
+
+  it("falls back to the first session when none is selected", () => {
+    expect(resolveFeedbackViewerSessionId(null, sessions)).toBe("s1");
+  });
+
+  it("returns null when there is nothing to show", () => {
+    expect(resolveFeedbackViewerSessionId(null, [])).toBeNull();
+  });
+});
+
+describe("loadFeedbackSessionDetail", () => {
+  it("fetches comments for the session and caches the promise", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        comments: [
+          {
+            id: "c1",
+            section_key: "executing_mission",
+            comment_text: "Tighten the verb",
+            status: "pending",
+            created_at: "2026-08-01T00:00:00.000Z",
+          },
+        ],
+        contentSnapshot: { duty_description: "NCOIC" },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = loadFeedbackSessionDetail("session-1", 0);
+    const second = loadFeedbackSessionDetail("session-1", 0);
+    expect(first).toBe(second);
+
+    const detail = await first;
+    expect(detail.error).toBeUndefined();
+    expect(detail.comments).toHaveLength(1);
+    expect(detail.contentSnapshot?.duty_description).toBe("NCOIC");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("/api/feedback/session-1");
+  });
+
+  it("refetches after cache invalidation", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ comments: [], contentSnapshot: null }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          comments: [{ id: "c2", section_key: "general", comment_text: "New", status: "pending", created_at: "" }],
+          contentSnapshot: null,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await loadFeedbackSessionDetail("session-2", 1);
+    invalidateFeedbackSessionDetailCache("session-2");
+    const detail = await loadFeedbackSessionDetail("session-2", 1);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(detail.comments[0]?.id).toBe("c2");
+  });
+
+  it("returns an error payload instead of hanging the viewer", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: "Session not found" }),
+      })
+    );
+
+    const detail = await loadFeedbackSessionDetail("missing", 0);
+    expect(detail.comments).toEqual([]);
+    expect(detail.error).toBe("Session not found");
+  });
+});
+
+describe("loadFeedbackSessions", () => {
+  it("shares one request per shell + bust key", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sessions: [{ id: "s1", reviewer_name: "Alex", comment_count: 1 }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const a = loadFeedbackSessions("epb", "shell-1", 3);
+    const b = loadFeedbackSessions("epb", "shell-1", 3);
+    expect(a).toBe(b);
+    await a;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/feedback-sessions.ts
+++ b/src/lib/feedback-sessions.ts
@@ -60,3 +60,98 @@ export function loadFeedbackSessions(
   sessionsCache.set(key, promise);
   return promise;
 }
+
+export interface FeedbackComment {
+  id: string;
+  section_key: string;
+  original_text?: string;
+  highlight_start?: number;
+  highlight_end?: number;
+  highlighted_text?: string;
+  comment_text: string;
+  suggestion?: string;
+  status: "pending" | "accepted" | "dismissed";
+  created_at: string;
+  suggestion_type?: "comment" | "replace" | "delete";
+  replacement_text?: string;
+  is_full_rewrite?: boolean;
+  rewrite_text?: string;
+}
+
+export interface FeedbackContentSnapshot {
+  duty_description?: string;
+  cycle_year?: string;
+  sections?: Array<{
+    mpa: string;
+    statement_text: string;
+  }>;
+}
+
+export interface FeedbackSessionDetail {
+  comments: FeedbackComment[];
+  contentSnapshot: FeedbackContentSnapshot | null;
+  error?: string;
+}
+
+const detailCache = new Map<string, Promise<FeedbackSessionDetail>>();
+
+function detailCacheKey(sessionId: string, bust: number): string {
+  return `${sessionId}:${bust}`;
+}
+
+export function invalidateFeedbackSessionDetailCache(sessionId?: string): void {
+  if (!sessionId) {
+    detailCache.clear();
+    return;
+  }
+  const prefix = `${sessionId}:`;
+  for (const key of detailCache.keys()) {
+    if (key.startsWith(prefix)) detailCache.delete(key);
+  }
+}
+
+export function loadFeedbackSessionDetail(
+  sessionId: string,
+  bust = 0
+): Promise<FeedbackSessionDetail> {
+  const key = detailCacheKey(sessionId, bust);
+  const cached = detailCache.get(key);
+  if (cached) return cached;
+
+  const promise = (async (): Promise<FeedbackSessionDetail> => {
+    try {
+      const response = await fetch(
+        `/api/feedback/${encodeURIComponent(sessionId)}`
+      );
+      const data = await response.json();
+      if (!response.ok) {
+        return {
+          comments: [],
+          contentSnapshot: null,
+          error: data.error || "Failed to load comments",
+        };
+      }
+      return {
+        comments: (data.comments || []) as FeedbackComment[],
+        contentSnapshot: (data.contentSnapshot ||
+          null) as FeedbackContentSnapshot | null,
+      };
+    } catch {
+      return {
+        comments: [],
+        contentSnapshot: null,
+        error: "Failed to load comments",
+      };
+    }
+  })();
+
+  detailCache.set(key, promise);
+  return promise;
+}
+
+export function resolveFeedbackViewerSessionId(
+  preferredSessionId: string | null,
+  sessions: FeedbackSessionSummary[]
+): string | null {
+  return preferredSessionId ?? sessions[0]?.id ?? null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `/epb` reviewer feedback viewer stayed on a spinner under **Feedback from Reviewer** because comments only loaded in Radix `onOpenChange(true)`. Opening the dialog from parent state (after picking a session) never fires that callback.

This loads session list + comments when the controlled `open` prop becomes true, using the same Suspense/`use()` cache pattern as the feedback list dialog.

## Ship checks
- `npx vitest run src/lib/__tests__/feedback-sessions.test.ts` — 7 passed
- `npx eslint` on changed files — clean
- `npm run motion:check` — OK on migrated surfaces
- React Doctor `--scope changed --base origin/acceptance` — **100 / 100**, 0 issues (4 files)
- React Doctor `--scope full` — 69 / 100, 59 pre-existing issues; none in this diff

## Branch audit (no follow-up plans)
No introduced high-confidence bugs. Pre-existing PATCH ownership on `/api/feedback/[id]` is out of scope for this spinner fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68c6bc77-5ca2-43be-9eca-223edbb44afd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68c6bc77-5ca2-43be-9eca-223edbb44afd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

