### PR TITLE
Restore highlight-word thesaurus on EPB, award, and decoration

### DIFF
--- a/src/app/api/dictionary-synonyms/route.ts
+++ b/src/app/api/dictionary-synonyms/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { fetchDictionarySynonyms } from "@/lib/datamuse-synonyms";
+import { isSingleSelectableWord, sanitizeThesaurusWord } from "@/lib/word-thesaurus";
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const word = sanitizeThesaurusWord(
+      new URL(request.url).searchParams.get("word") ?? "",
+    );
+    if (!isSingleSelectableWord(word)) {
+      return NextResponse.json(
+        { error: "Select a single word to look up synonyms" },
+        { status: 400 },
+      );
+    }
+
+    const synonyms = await fetchDictionarySynonyms(word);
+    return NextResponse.json({ synonyms });
+  } catch (error) {
+    console.error("GET /api/dictionary-synonyms", error);
+    return NextResponse.json(
+      { error: "Failed to load dictionary synonyms" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/synonyms/route.ts
+++ b/src/app/api/synonyms/route.ts
@@ -16,6 +16,11 @@ import { resolveRequestedModel } from "@/app/actions/ai-models";
 import { checkAndTrackUsage } from "@/lib/usage-tracker";
 import { appendUserRulesToPrompt } from "@/lib/prompt-rules/server";
 import type { PromptRuleContext } from "@/types/database";
+import {
+  isSingleSelectableWord,
+  sanitizeThesaurusWord,
+  WORD_THESAURUS_MAX_WORD_LENGTH,
+} from "@/lib/word-thesaurus";
 
 // Allow up to 60s for LLM calls
 export const maxDuration = 60;
@@ -23,6 +28,7 @@ export const maxDuration = 60;
 interface SynonymRequest {
   word: string;
   fullStatement: string;
+  sentence?: string;
   model: string;
   context?: "epb" | "decoration" | "award"; // Type of document for better suggestions
 }
@@ -42,10 +48,21 @@ export async function POST(request: Request) {
     }
 
     const body: SynonymRequest = await request.json();
-    const { word, fullStatement, model, context = "epb" } = body;
+    const { model, context = "epb" } = body;
+    const word = sanitizeThesaurusWord(body.word ?? "");
+    const fullStatement =
+      typeof body.fullStatement === "string" ? body.fullStatement.slice(0, 8000) : "";
+    const sentence =
+      typeof body.sentence === "string" ? body.sentence.slice(0, 800) : "";
     if (!word || !fullStatement) {
       return NextResponse.json(
         { error: "Word and full statement are required" },
+        { status: 400 }
+      );
+    }
+    if (!isSingleSelectableWord(word) || word.length > WORD_THESAURUS_MAX_WORD_LENGTH) {
+      return NextResponse.json(
+        { error: "Select a single word to find replacements" },
         { status: 400 }
       );
     }
@@ -102,41 +119,34 @@ export async function POST(request: Request) {
           ? "decoration"
           : "epb";
     const systemPrompt = await appendUserRulesToPrompt(
-      `You are an expert military writing assistant specializing in Air Force performance and recognition documents. Your task is to suggest context-appropriate synonyms for a specific word within a ${docType.name}.
+      `You are an expert military writing assistant specializing in Air Force performance and recognition documents. Suggest replacement words for one highlighted word inside a ${docType.name}.
 
 GUIDELINES:
-1. **ANALYZE THE FULL CONTEXT** - Read the entire statement to understand how the word is used
-2. ${docType.guidance}
-3. Prioritize words that:
-   - Fit grammatically in the exact same position
-   - Maintain or enhance the professional, action-oriented tone
-   - Are commonly used in Air Force writing
-4. Include a mix of:
-   - Direct synonyms that fit the context perfectly
-   - Stronger/more impactful alternatives
-   - Military-appropriate terminology
-5. Each suggestion MUST be grammatically correct when substituted directly
-6. Keep suggestions concise (preferably single words, short phrases only if needed)
-7. Order suggestions from MOST relevant/impactful to least
+1. **SENTENCE FIRST** — The containing sentence is the primary context. Suggest replacements that fit THAT sentence's meaning, grammar, and tense — not a generic thesaurus dump.
+2. Use the full statement only to confirm tone and nearby facts.
+3. ${docType.guidance}
+4. Each suggestion MUST drop in as a direct substitute (same part of speech, same tense/number).
+5. Prefer single words. Short phrases only when the original is a compound idea.
+6. Order from MOST context-fit / impactful to least.
+7. Do NOT include the original word.
 
-IMPORTANT: Return ONLY a JSON array of 10-15 synonyms/alternatives.`,
+IMPORTANT: Return ONLY a JSON array of 6-8 replacements.`,
       user.id,
       rulesContext,
     );
 
-    const userPrompt = `Find synonyms for the word "${word}" in this ${docType.name}:
+    const userPrompt = `Replace the word "${word}" in this ${docType.name}.
 
+CONTAINING SENTENCE (primary context):
+"${sentence || fullStatement}"
+
+FULL STATEMENT (secondary context):
 "${fullStatement}"
 
-The word "${word}" appears in the context above. Consider:
-- What part of speech is this word? (verb, noun, adjective, etc.)
-- What tone and formality level fits this document?
-- What synonyms would a senior Air Force leader use?
-
-Provide 10-15 context-appropriate alternatives, ordered from most to least impactful.
+Suggest 6-8 replacements a senior Air Force leader would actually use in this sentence.
 
 Return ONLY a JSON array of strings:
-["synonym1", "synonym2", "synonym3", ...]`;
+["replacement1", "replacement2", ...]`;
 
     const { text } = await generateText({
       model: modelProvider,
@@ -150,7 +160,8 @@ Return ONLY a JSON array of strings:
     try {
       const jsonMatch = text.match(/\[[\s\S]*\]/);
       if (jsonMatch) {
-        synonyms = JSON.parse(jsonMatch[0]);
+        const parsed = JSON.parse(jsonMatch[0]);
+        synonyms = Array.isArray(parsed) ? parsed : [];
       }
     } catch {
       // Fallback: try to extract words from text
@@ -160,12 +171,25 @@ Return ONLY a JSON array of strings:
         .filter((s) => s.length > 0 && s.length < 50);
     }
 
-    // Clean up and deduplicate
-    synonyms = [...new Set(synonyms.map((s) => s.toLowerCase().trim()))]
-      .filter((s) => s.length > 0 && s !== word.toLowerCase())
-      .slice(0, 15);
+    // Deduplicate case-insensitively while preserving the model's casing
+    const seen = new Set<string>();
+    const originalKey = word.toLowerCase();
+    synonyms = synonyms
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter((item) => {
+        if (!item || item.length > 50) return false;
+        const key = item.toLowerCase();
+        if (key === originalKey || seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .slice(0, 8);
 
-    return cacheBillableJson(billableCtx, { synonyms }, usageCheck);
+    return cacheBillableJson(
+      billableCtx,
+      { suggestions: synonyms, synonyms },
+      usageCheck,
+    );
   } catch (error) {
     if (billableCtx) {
       return handleBillableLLMError(

--- a/src/components/award/award-category-section.tsx
+++ b/src/components/award/award-category-section.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef, useCallback, useEffect, useMemo, useLayoutEffect } from "react";
 import { Badge } from "@/components/ui/badge";
-import { fetchWithRetry } from "@/lib/fetch-with-retry";
 import { Button } from "@/components/ui/button";
 import { TokenCostBadge } from "@/components/billing/token-cost-badge";
 import {
@@ -36,9 +35,6 @@ import {
   Trash2,
   Zap,
   FileText,
-  Maximize2,
-  Minimize2,
-  RefreshCw,
   X,
   CalendarDays,
   MessageSquareText,
@@ -53,6 +49,8 @@ import { useClarifyingQuestionsStore } from "@/stores/clarifying-questions-store
 import { ClarifyingQuestionsIndicator, ClarifyingQuestionsModal } from "@/components/generate/clarifying-questions-modal";
 import { compressText, normalizeSpaces, getVisualLineSegments, AF1206_LINE_WIDTH_PX, toDisplayText, fromDisplayText } from "@/lib/bullet-fitting";
 import { formatShortDateWithYear } from "@/lib/format";
+import { useWordThesaurus } from "@/hooks/use-word-thesaurus";
+import { WordThesaurusPopup } from "@/components/word-thesaurus/word-thesaurus-popup";
 
 // ============================================================================
 // Types
@@ -249,14 +247,7 @@ function StatementSlotCard({
   const [showAiPanel, setShowAiPanel] = useState(false);
   const [showActionSelector, setShowActionSelector] = useState(false);
   const [generatedSuggestion, setGeneratedSuggestion] = useState<string | null>(null);
-  
-  // Selection popup state
-  const [showSelectionPopup, setShowSelectionPopup] = useState(false);
-  const [selectedText, setSelectedText] = useState("");
-  const [selectionStart, setSelectionStart] = useState(0);
-  const [selectionEnd, setSelectionEnd] = useState(0);
-  const [isRevising, setIsRevising] = useState(false);
-  const [revisionResults, setRevisionResults] = useState<string[]>([]);
+  const thesaurus = useWordThesaurus({ model, documentContext: "award" });
   
   // Clarifying questions for this slot
   const slotMpaKey = `award:${categoryKey}:${slotIndex}`;
@@ -390,78 +381,9 @@ function StatementSlotCard({
     : customContext.trim().length > 0;
   const canGenerate = hasContent || hasAdditionalContext;
 
-  // Handle text selection for synonym/revision popup
-  const handleTextSelect = () => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-    
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const text = draftText.substring(start, end);
-    
-    if (text.trim().length > 0 && start !== end) {
-      setSelectedText(text);
-      setSelectionStart(start);
-      setSelectionEnd(end);
-      setShowSelectionPopup(true);
-      setRevisionResults([]);
-    } else {
-      setShowSelectionPopup(false);
-    }
+  const applyThesaurusText = (nextDisplayText: string) => {
+    onUpdate({ draftText: fromDisplayText(nextDisplayText), isDirty: true });
   };
-
-  // Close selection popup
-  const closeSelectionPopup = () => {
-    setShowSelectionPopup(false);
-    setSelectedText("");
-    setRevisionResults([]);
-  };
-
-  // Revise selected text (expand, compress, or general)
-  const handleReviseSelection = async (mode: "expand" | "compress" | "general") => {
-    if (!selectedText.trim()) return;
-    
-    setIsRevising(true);
-    setRevisionResults([]);
-    
-    try {
-      const response = await fetchWithRetry("/api/revise-selection", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          fullStatement: draftText,
-          selectedText,
-          selectionStart,
-          selectionEnd,
-          model,
-          mode,
-        }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        if (handleUsageLimitResponse(errorData)) return;
-        throw new Error(errorData.error || "Revision failed");
-      }
-
-      const data = await response.json();
-      setRevisionResults(data.revisions || []);
-    } catch (error) {
-      console.error("Revision error:", error);
-      toast.error(error instanceof Error ? error.message : "Failed to revise selection");
-    } finally {
-      setIsRevising(false);
-    }
-  };
-
-  // Apply a revision to the text
-  const applyRevision = (revision: string) => {
-    const newText = draftText.substring(0, selectionStart) + revision + draftText.substring(selectionEnd);
-    onUpdate({ draftText: newText, isDirty: true });
-    closeSelectionPopup();
-    toast.success("Applied revision");
-  };
-
 
   return (
     <div className="border rounded-lg bg-card/50 overflow-hidden">
@@ -557,18 +479,23 @@ function StatementSlotCard({
                       e.clipboardData.setData('text/plain', fromDisplayText(selection));
                     }
                   }}
-                  onMouseUp={handleTextSelect}
+                  onMouseUp={() =>
+                    thesaurus.handleTextSelect(textareaRef.current, {
+                      text: toDisplayText(draftText),
+                      onChange: applyThesaurusText,
+                    })
+                  }
                   onKeyUp={(e) => {
-                    // Handle shift+arrow key selection
-                    if (e.shiftKey) handleTextSelect();
+                    if (e.shiftKey || e.key.startsWith("Arrow")) {
+                      thesaurus.handleTextSelect(textareaRef.current, {
+                        text: toDisplayText(draftText),
+                        onChange: applyThesaurusText,
+                      });
+                    }
                   }}
+                  onKeyDown={thesaurus.handleKeyDown}
                   onBlur={() => {
-                    // Delay closing popup to allow clicking on it
-                    setTimeout(() => {
-                      if (!document.activeElement?.closest('.selection-popup')) {
-                        closeSelectionPopup();
-                      }
-                    }, 200);
+                    thesaurus.handleBlur();
                   }}
                   placeholder="Enter your statement here..."
                   className="bg-transparent focus:outline-none resize-none"
@@ -647,75 +574,7 @@ function StatementSlotCard({
           </div>
         </div>
         
-        {/* Selection Popup - appears when text is selected */}
-        {showSelectionPopup && (
-          <div 
-            className="selection-popup p-3 rounded-lg bg-card border shadow-lg animate-in fade-in-0 zoom-in-95 duration-200"
-          >
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <p className="text-xs text-muted-foreground">
-                  Selected: <span className="font-medium text-foreground">&ldquo;{selectedText.slice(0, 30)}{selectedText.length > 30 ? "..." : ""}&rdquo;</span>
-                  <span className="ml-1">({selectedText.length} chars)</span>
-                </p>
-                <button type="button"
-                  onClick={closeSelectionPopup}
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  aria-label="Close selection popup"
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-              
-              {/* Revision mode buttons */}
-              <div className="flex items-center gap-2">
-                <button type="button"
-                  onClick={() => handleReviseSelection("expand")}
-                  disabled={isRevising}
-                  className="flex-1 h-8 px-3 rounded-md text-xs border border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-1.5 transition-colors disabled:opacity-50"
-                >
-                  {isRevising ? <Loader2 className="size-3 animate-spin" /> : <Maximize2 className="size-3" />}
-                  Expand
-                </button>
-                <button type="button"
-                  onClick={() => handleReviseSelection("compress")}
-                  disabled={isRevising}
-                  className="flex-1 h-8 px-3 rounded-md text-xs border border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-1.5 transition-colors disabled:opacity-50"
-                >
-                  {isRevising ? <Loader2 className="size-3 animate-spin" /> : <Minimize2 className="size-3" />}
-                  Compress
-                </button>
-                <button type="button"
-                  onClick={() => handleReviseSelection("general")}
-                  disabled={isRevising}
-                  className="flex-1 h-8 px-3 rounded-md text-xs border border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-1.5 transition-colors disabled:opacity-50"
-                >
-                  {isRevising ? <Loader2 className="size-3 animate-spin" /> : <RefreshCw className="size-3" />}
-                  Rephrase
-                </button>
-              </div>
-              
-              {/* Revision results */}
-              {revisionResults.length > 0 && (
-                <div className="space-y-2 pt-2 border-t">
-                  <p className="text-xs text-muted-foreground font-medium">Alternatives:</p>
-                  {revisionResults.map((revision) => (
-                    <button type="button"
-                      key={`alt-${revision.slice(0, 48)}-${revision.length}`}
-                      onClick={() => applyRevision(revision)}
-                      className="w-full text-left p-2 rounded-md text-sm border hover:bg-accent hover:border-primary/50 transition-colors"
-                    >
-                      <p className="whitespace-pre-wrap">{revision}</p>
-                      <span className="text-[10px] text-muted-foreground mt-1">
-                        {revision.length} chars ({revision.length > selectedText.length ? "+" : ""}{revision.length - selectedText.length})
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
+        <WordThesaurusPopup thesaurus={thesaurus} />
       </div>
 
       {/* AI Options Bar - below workspace */}

--- a/src/components/decoration/decoration-citation-editor.tsx
+++ b/src/components/decoration/decoration-citation-editor.tsx
@@ -8,12 +8,10 @@ import {
   type HighlightColorId,
 } from "@/stores/decoration-shell-store";
 import { useUserStore } from "@/stores/user-store";
-import { handleUsageLimitResponse } from "@/stores/usage-limit-store";
 import { createClient } from "@/lib/supabase/client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { fetchWithRetry } from "@/lib/fetch-with-retry";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
@@ -21,6 +19,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { toast } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
 import { DECORATION_TYPES } from "@/features/decorations/constants";
+import { useWordThesaurus } from "@/hooks/use-word-thesaurus";
+import { WordThesaurusPopup } from "@/components/word-thesaurus/word-thesaurus-popup";
 import {
   Copy,
   Check,
@@ -29,11 +29,6 @@ import {
   Camera,
   History,
   X,
-  Loader2,
-  Maximize2,
-  Minimize2,
-  RefreshCw,
-  BookA,
   Palette,
 } from "lucide-react";
 import {
@@ -95,23 +90,10 @@ export function DecorationCitationEditor({
   } = useDecorationShellStore();
 
   const [copied, setCopied] = useState(false);
-
-  // Text selection state for highlight-to-revise
-  const [showSelectionPopup, setShowSelectionPopup] = useState(false);
-  const [selectedText, setSelectedText] = useState("");
-  const [selectionStart, setSelectionStart] = useState(0);
-  const [selectionEnd, setSelectionEnd] = useState(0);
-  const [revisionResults, setRevisionResults] = useState<string[]>([]);
-  const [isRevisingSelection, setIsRevisingSelection] = useState(false);
-  
-  // Synonym state (for single-word selection)
-  const [synonyms, setSynonyms] = useState<string[]>([]);
-  const [isLoadingSynonyms, setIsLoadingSynonyms] = useState(false);
-  
-  // Staged synonym state - for preview/toggle before applying
-  const [stagedSynonym, setStagedSynonym] = useState<string | null>(null);
-  const [originalWord, setOriginalWord] = useState<string>(""); // The original highlighted word
-  const [synonymsLocked, setSynonymsLocked] = useState(false); // When true, popup stays open
+  const thesaurus = useWordThesaurus({
+    model: selectedModel,
+    documentContext: "decoration",
+  });
 
   // Color overlay state — overlay is visible when not hovering/focused/editing
   const [isHoveringCitation, setIsHoveringCitation] = useState(false);
@@ -454,15 +436,6 @@ export function DecorationCitationEditor({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [citationText]); // Only trigger on citation text changes
   
-  // Check if selection is a single word (no spaces, reasonable length)
-  const isSingleWord = useMemo(() => {
-    const trimmed = selectedText.trim();
-    return trimmed.length > 0 && 
-           trimmed.length <= 30 && 
-           !trimmed.includes(" ") &&
-           /^[a-zA-Z-]+$/.test(trimmed);
-  }, [selectedText]);
-
   // Get decoration config
   const decorationConfig = useMemo(() => {
     return DECORATION_TYPES.find((d) => d.key === awardType);
@@ -547,147 +520,6 @@ export function DecorationCitationEditor({
   );
 
 
-  // Handle text selection for popup (highlight text to get expand/compress/rephrase options)
-  const handleTextSelect = useCallback(() => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const text = citationText.substring(start, end);
-
-    if (text.trim().length > 0 && start !== end) {
-      // If selecting a different word, reset synonym state to allow fresh search
-      if (text.trim() !== selectedText.trim()) {
-        setSynonyms([]);
-        setStagedSynonym(null);
-        setOriginalWord("");
-        setSynonymsLocked(false);
-        setRevisionResults([]);
-      }
-      
-      setSelectedText(text);
-      setSelectionStart(start);
-      setSelectionEnd(end);
-      setShowSelectionPopup(true);
-    } else {
-      // Clicking away without selection - close and reset everything
-      if (showSelectionPopup) {
-        // If we have a staged synonym, keep it (don't revert) but close the popup
-        setShowSelectionPopup(false);
-        setSelectedText("");
-        setRevisionResults([]);
-        setSynonyms([]);
-        setStagedSynonym(null);
-        setOriginalWord("");
-        setSynonymsLocked(false);
-      }
-    }
-  }, [citationText, selectedText, showSelectionPopup]);
-
-  // Close selection popup and reset all synonym state (keeps current text as-is)
-  const closeSelectionPopup = useCallback(() => {
-    setShowSelectionPopup(false);
-    setSelectedText("");
-    setRevisionResults([]);
-    setSynonyms([]);
-    setStagedSynonym(null);
-    setOriginalWord("");
-    setSynonymsLocked(false);
-  }, []);
-  
-  // Fetch synonyms for a single word
-  const handleFetchSynonyms = useCallback(async () => {
-    if (!selectedText.trim() || !isSingleWord) return;
-    
-    setIsLoadingSynonyms(true);
-    setSynonyms([]);
-    
-    // Store the original word when fetching synonyms
-    setOriginalWord(selectedText.trim());
-    
-    try {
-      const response = await fetch("/api/synonyms", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          word: selectedText.trim(),
-          fullStatement: citationText,
-          model: selectedModel,
-          context: "decoration", // Decoration-specific synonym suggestions
-        }),
-      });
-      
-      if (!response.ok) throw new Error("Failed to fetch synonyms");
-      
-      const data = await response.json();
-      setSynonyms(data.synonyms || []);
-      setSynonymsLocked(true); // Lock the popup open only after success
-    } catch (error) {
-      console.error("Synonym error:", error);
-      toast.error("Failed to get synonyms");
-      setOriginalWord(""); // Reset on error
-    } finally {
-      setIsLoadingSynonyms(false);
-    }
-  }, [selectedText, isSingleWord, citationText, selectedModel]);
-  
-  // Stage a synonym (toggle preview without final apply)
-  const stageSynonym = useCallback(
-    (synonym: string) => {
-      // Get current word in the text (could be original or previously staged)
-      const currentWord = stagedSynonym || originalWord;
-      
-      if (synonym === currentWord) {
-        // Clicking the same word - unstage it (revert to original)
-        if (stagedSynonym) {
-          const newText = citationText.substring(0, selectionStart) + originalWord + citationText.substring(selectionStart + stagedSynonym.length);
-          setCitationText(newText);
-          setStagedSynonym(null);
-        }
-        return;
-      }
-      
-      // Replace current word with new synonym
-      const newText = citationText.substring(0, selectionStart) + synonym + citationText.substring(selectionStart + currentWord.length);
-      setCitationText(newText);
-      setStagedSynonym(synonym);
-    },
-    [citationText, selectionStart, stagedSynonym, originalWord, setCitationText]
-  );
-  
-  // Apply the staged synonym (finalize and close)
-  const applyStaged = useCallback(() => {
-    if (stagedSynonym) {
-      toast.success(`Replaced "${originalWord}" with "${stagedSynonym}"`);
-    }
-    // Clear state without reverting
-    setShowSelectionPopup(false);
-    setSelectedText("");
-    setRevisionResults([]);
-    setSynonyms([]);
-    setStagedSynonym(null);
-    setOriginalWord("");
-    setSynonymsLocked(false);
-  }, [stagedSynonym, originalWord]);
-  
-  // Cancel and revert to original word
-  const cancelSynonym = useCallback(() => {
-    if (stagedSynonym && originalWord) {
-      // Revert to original
-      const newText = citationText.substring(0, selectionStart) + originalWord + citationText.substring(selectionStart + stagedSynonym.length);
-      setCitationText(newText);
-    }
-    // Clear state
-    setShowSelectionPopup(false);
-    setSelectedText("");
-    setRevisionResults([]);
-    setSynonyms([]);
-    setStagedSynonym(null);
-    setOriginalWord("");
-    setSynonymsLocked(false);
-  }, [citationText, selectionStart, stagedSynonym, originalWord, setCitationText]);
-  
   // Render citation text with highlights
   const renderHighlightedText = useMemo(() => {
     if (citationHighlights.length === 0) return null;
@@ -727,30 +559,6 @@ export function DecorationCitationEditor({
     return segments;
   }, [citationText, citationHighlights]);
 
-  // Handle textarea blur - delay closing to allow button clicks
-  const handleTextareaBlur = useCallback(() => {
-    setTimeout(() => {
-      // Don't close if focus is inside the popup
-      if (document.activeElement?.closest(".selection-popup")) {
-        return;
-      }
-      // Check the current revising/loading state via data attribute to avoid stale closure
-      const loadingElement = document.querySelector('[data-loading="true"]');
-      if (loadingElement) {
-        return;
-      }
-      // When blurring, just close the popup without reverting
-      // Keep whatever word is currently staged in the text
-      setShowSelectionPopup(false);
-      setSelectedText("");
-      setRevisionResults([]);
-      setSynonyms([]);
-      setStagedSynonym(null);
-      setOriginalWord("");
-      setSynonymsLocked(false);
-    }, 300);
-  }, []);
-
   // Sync overlay scroll position with textarea
   const handleCitationScroll = useCallback(() => {
     if (textareaRef.current && overlayRef.current) {
@@ -765,70 +573,8 @@ export function DecorationCitationEditor({
     renderHighlightedText.length > 0 &&
     !isHoveringCitation &&
     !isCitationFocused &&
-    !showSelectionPopup &&
+    !thesaurus.open &&
     !isGenerating
-  );
-
-  // Revise selected text
-  const handleReviseSelection = useCallback(
-    async (mode: "expand" | "compress" | "general") => {
-      // Capture values at call time to avoid stale closures
-      const textToRevise = selectedText.trim();
-      const fullText = citationText;
-      const start = selectionStart;
-      const end = selectionEnd;
-      const model = selectedModel;
-      
-      if (!textToRevise) {
-        console.warn("No text selected for revision");
-        return;
-      }
-
-      setIsRevisingSelection(true);
-      setRevisionResults([]);
-
-      try {
-        const response = await fetchWithRetry("/api/revise-selection", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            fullStatement: fullText,
-            selectedText: textToRevise,
-            selectionStart: start,
-            selectionEnd: end,
-            model: model,
-            mode,
-          }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
-          if (handleUsageLimitResponse(errorData)) return;
-          throw new Error(errorData.error || "Revision failed");
-        }
-
-        const data = await response.json();
-        setRevisionResults(data.revisions || []);
-      } catch (error) {
-        console.error("Revision error:", error);
-        toast.error(error instanceof Error ? error.message : "Failed to revise selection");
-      } finally {
-        setIsRevisingSelection(false);
-      }
-    },
-    [selectedText, citationText, selectionStart, selectionEnd, selectedModel]
-  );
-
-  // Apply a revision to the text
-  const applyRevision = useCallback(
-    (revision: string) => {
-      const newText =
-        citationText.substring(0, selectionStart) + revision + citationText.substring(selectionEnd);
-      setCitationText(newText);
-      closeSelectionPopup();
-      toast.success("Applied revision");
-    },
-    [citationText, selectionStart, selectionEnd, setCitationText, closeSelectionPopup]
   );
 
   // Copy to clipboard
@@ -1029,12 +775,25 @@ export function DecorationCitationEditor({
               ref={textareaRef}
               value={citationText}
               onChange={(e) => setCitationText(e.target.value)}
-              onMouseUp={handleTextSelect}
-              onKeyUp={handleTextSelect}
+              onMouseUp={() =>
+                thesaurus.handleTextSelect(textareaRef.current, {
+                  text: citationText,
+                  onChange: setCitationText,
+                })
+              }
+              onKeyUp={(event) => {
+                if (event.shiftKey || event.key.startsWith("Arrow")) {
+                  thesaurus.handleTextSelect(textareaRef.current, {
+                    text: citationText,
+                    onChange: setCitationText,
+                  });
+                }
+              }}
+              onKeyDown={thesaurus.handleKeyDown}
               onFocus={() => setIsCitationFocused(true)}
               onBlur={() => {
                 setIsCitationFocused(false);
-                handleTextareaBlur();
+                thesaurus.handleBlur();
               }}
               onScroll={handleCitationScroll}
               placeholder={
@@ -1096,226 +855,7 @@ export function DecorationCitationEditor({
             )}
           </div>
 
-          {/* Text Selection Popup - with smooth transition */}
-          <div
-            className={cn(
-              "selection-popup grid transition-all duration-200 ease-in-out",
-              showSelectionPopup ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0 pointer-events-none"
-            )}
-            data-loading={(isRevisingSelection || isLoadingSynonyms) ? "true" : "false"}
-          >
-            <div className="overflow-hidden">
-              <div className="p-3 rounded-lg bg-card border shadow-lg">
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs text-muted-foreground">
-                      Selected:{" "}
-                      <span className="font-medium text-foreground">
-                        &ldquo;{selectedText.slice(0, 50)}
-                        {selectedText.length > 50 ? "..." : ""}&rdquo;
-                      </span>
-                      <span className="ml-1">({selectedText.length} chars)</span>
-                      {isSingleWord && (
-                        <span className="ml-1.5 text-[10px] text-primary">(word)</span>
-                      )}
-                    </p>
-                    <button
-                      type="button"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={synonymsLocked ? cancelSynonym : closeSelectionPopup}
-                      className="text-muted-foreground hover:text-foreground transition-colors"
-                      aria-label="Close synonym suggestions"
-                    >
-                      <X className="size-4" />
-                    </button>
-                  </div>
-
-                  {/* Single word: Show synonym button */}
-                  {isSingleWord && (
-                    <div className="space-y-2">
-                      {/* Only show Find Synonyms button if synonyms haven't been fetched yet */}
-                      {!synonymsLocked && (
-                        <button
-                          type="button"
-                          onMouseDown={(e) => e.preventDefault()}
-                          onClick={handleFetchSynonyms}
-                          disabled={isLoadingSynonyms}
-                          className="w-full h-8 px-3 rounded-md text-xs border border-primary/30 bg-primary/5 hover:bg-primary/10 text-primary inline-flex items-center justify-center gap-1.5 transition-colors disabled:opacity-50"
-                        >
-                          {isLoadingSynonyms ? (
-                            <Loader2 className="size-3 animate-spin" />
-                          ) : (
-                            <BookA className="size-3" />
-                          )}
-                          {isLoadingSynonyms ? "Finding synonyms..." : "Find Synonyms"}
-                        </button>
-                      )}
-                      
-                      {/* Synonyms results - toggle buttons */}
-                      {synonyms.length > 0 && (
-                        <div className="space-y-3 pt-2 border-t">
-                          {/* Current word indicator */}
-                          <div className="flex items-center justify-between text-xs">
-                            <span className="text-muted-foreground">
-                              Original: <span className="font-medium text-foreground">&ldquo;{originalWord}&rdquo;</span>
-                            </span>
-                            {stagedSynonym && (
-                              <span className="text-primary font-medium">
-                                → &ldquo;{stagedSynonym}&rdquo;
-                              </span>
-                            )}
-                          </div>
-                          
-                          {/* Synonym toggle buttons */}
-                          <div className="flex flex-wrap gap-1.5">
-                            {/* Original word button */}
-                            <button
-                              type="button"
-                              onMouseDown={(e) => e.preventDefault()}
-                              onClick={() => {
-                                if (stagedSynonym) {
-                                  stageSynonym(originalWord);
-                                }
-                              }}
-                              className={cn(
-                                "px-2 py-1 rounded text-xs border transition-colors",
-                                !stagedSynonym
-                                  ? "bg-primary text-primary-foreground border-primary"
-                                  : "bg-background hover:bg-accent hover:border-primary/50"
-                              )}
-                            >
-                              {originalWord}
-                            </button>
-                            
-                            {/* Synonym buttons */}
-                            {synonyms.map((synonym) => (
-                              <button
-                                key={synonym}
-                                type="button"
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={() => stageSynonym(synonym)}
-                                className={cn(
-                                  "px-2 py-1 rounded text-xs border transition-colors",
-                                  stagedSynonym === synonym
-                                    ? "bg-primary text-primary-foreground border-primary"
-                                    : "bg-background hover:bg-accent hover:border-primary/50"
-                                )}
-                              >
-                                {synonym}
-                              </button>
-                            ))}
-                          </div>
-                          
-                          {/* Apply/Cancel buttons */}
-                          <div className="flex items-center gap-2 pt-2 border-t">
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              onMouseDown={(e) => e.preventDefault()}
-                              onClick={cancelSynonym}
-                              className="h-7 text-xs flex-1"
-                            >
-                              Cancel
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="default"
-                              size="sm"
-                              onMouseDown={(e) => e.preventDefault()}
-                              onClick={applyStaged}
-                              className="h-7 text-xs flex-1"
-                            >
-                              {stagedSynonym ? `Apply "${stagedSynonym}"` : "Keep Original"}
-                            </Button>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  {/* Multi-word/phrase: Show revision buttons */}
-                  {!isSingleWord && (
-                    <div className="flex items-center gap-2">
-                      <button
-                        type="button"
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => handleReviseSelection("expand")}
-                        disabled={isRevisingSelection}
-                        className="flex-1 h-8 px-3 rounded-md text-xs border border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-1.5 transition-colors disabled:opacity-50"
-                      >
-                        {isRevisingSelection ? (
-                          <Loader2 className="size-3 animate-spin" />
-                        ) : (
-                          <Maximize2 className="size-3" />
-                        )}
-                        Expand
-                      </button>
-                      <button
-                        type="button"
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => handleReviseSelection("compress")}
-                        disabled={isRevisingSelection}
-                        className="flex-1 h-8 px-3 rounded-md text-xs border border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-1.5 transition-colors disabled:opacity-50"
-                      >
-                        {isRevisingSelection ? (
-                          <Loader2 className="size-3 animate-spin" />
-                        ) : (
-                          <Minimize2 className="size-3" />
-                        )}
-                        Compress
-                      </button>
-                      <button
-                        type="button"
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => handleReviseSelection("general")}
-                        disabled={isRevisingSelection}
-                        className="flex-1 h-8 px-3 rounded-md text-xs border border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-1.5 transition-colors disabled:opacity-50"
-                      >
-                        {isRevisingSelection ? (
-                          <Loader2 className="size-3 animate-spin" />
-                        ) : (
-                          <RefreshCw className="size-3" />
-                        )}
-                        Rephrase
-                      </button>
-                    </div>
-                  )}
-
-                  {/* Revision results - with smooth transition (only for multi-word) */}
-                  <div
-                    className={cn(
-                      "grid transition-all duration-200 ease-in-out",
-                      revisionResults.length > 0 && !isSingleWord ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
-                    )}
-                  >
-                    <div className="overflow-hidden">
-                      <div className="space-y-2 pt-2 border-t">
-                        <p className="text-xs text-muted-foreground font-medium">Alternatives:</p>
-                        {revisionResults.map((revision) => (
-                          <button
-                            key={`alt-${revision.slice(0, 48)}-${revision.length}`}
-                            type="button"
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => applyRevision(revision)}
-                            className="w-full text-left p-2 rounded-md text-sm border hover:bg-accent hover:border-primary/50 transition-colors"
-                          >
-                            <p className="whitespace-pre-wrap">{revision}</p>
-                            <span className="text-[10px] text-muted-foreground mt-1">
-                              {revision.length} chars (
-                              {revision.length > selectedText.length ? "+" : ""}
-                              {revision.length - selectedText.length})
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-            </div>
-          </div>
+          <WordThesaurusPopup thesaurus={thesaurus} />
 
           {/* TODO: Future work - Revise Panel (needs proper citation structure parsing)
           {citationText.trim() && (

--- a/src/components/epb/duty-description-card.tsx
+++ b/src/components/epb/duty-description-card.tsx
@@ -61,6 +61,8 @@ import {
 } from "./epb-animated-collapse";
 import { animateEpbShellResize } from "./epb-resize-transition";
 import { WordReplacementSlider } from "./word-replacement-slider";
+import { useWordThesaurus } from "@/hooks/use-word-thesaurus";
+import { WordThesaurusPopup } from "@/components/word-thesaurus/word-thesaurus-popup";
 import { formatDateTime } from "@/lib/format";
 
 /** A single generated batch of revisions kept in short-term session history. */
@@ -76,6 +78,8 @@ const MAX_REVISION_HISTORY = MAX_GENERATED_STATEMENT_SETS;
 
 interface DutyDescriptionCardProps {
   currentDutyDescription: string;
+  /** Selected LLM for highlight-to-replace suggestions */
+  model: string;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
   onSave: (text: string) => Promise<void>;
@@ -119,6 +123,7 @@ interface DutyDescriptionCardProps {
 
 export function DutyDescriptionCard({
   currentDutyDescription,
+  model,
   isCollapsed,
   onToggleCollapse,
   onSave,
@@ -179,6 +184,7 @@ export function DutyDescriptionCard({
   const [isRevisePanelClosing, setIsRevisePanelClosing] = useState(false);
   const [isRevisionsResultsClosing, setIsRevisionsResultsClosing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const thesaurus = useWordThesaurus({ model, documentContext: "epb" });
   const cardBodyShellRef = useRef<HTMLDivElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
   const lastSavedRef = useRef<string>(currentDutyDescription);
@@ -707,7 +713,25 @@ export function DutyDescriptionCard({
               value={localText}
               onChange={(e) => handleTextChange(e.target.value)}
               onFocus={handleTextFocus}
-              onBlur={handleTextBlur}
+              onBlur={() => {
+                thesaurus.handleBlur();
+                void handleTextBlur();
+              }}
+              onMouseUp={() =>
+                thesaurus.handleTextSelect(textareaRef.current, {
+                  text: localText,
+                  onChange: handleTextChange,
+                })
+              }
+              onKeyUp={(event) => {
+                if (event.shiftKey || event.key.startsWith("Arrow")) {
+                  thesaurus.handleTextSelect(textareaRef.current, {
+                    text: localText,
+                    onChange: handleTextChange,
+                  });
+                }
+              }}
+              onKeyDown={thesaurus.handleKeyDown}
               placeholder='e.g., "Leads 36 Amn & 12 total force members directing 24/7 O&M of 730 enterprise domain controllers by administering & securing enterprise Directory Services on a $14B cyber weapon system..."'
               rows={5}
               className={cn(
@@ -715,6 +739,7 @@ export function DutyDescriptionCard({
                 isOverLimit && "border-destructive focus-visible:ring-destructive"
               )}
             />
+            <WordThesaurusPopup thesaurus={thesaurus} />
 
             {/* Action bar */}
             <div className="flex items-center justify-between gap-2">

--- a/src/components/epb/epb-shell-form.tsx
+++ b/src/components/epb/epb-shell-form.tsx
@@ -2287,6 +2287,7 @@ export function EPBShellForm({
         {/* Duty Description Card - Placed at the top above MPAs */}
         <DutyDescriptionCard
           key={`duty-desc-${loadVersion}-${selectedRatee?.id || 'new'}`}
+          model={model}
           currentDutyDescription={currentShell?.duty_description || ""}
           isCollapsed={isDutyDescriptionCollapsed}
           onToggleCollapse={() => setIsDutyDescriptionCollapsed(!isDutyDescriptionCollapsed)}
@@ -2325,6 +2326,7 @@ export function EPBShellForm({
             <div key={`${loadVersion}-${mpa.key}`} data-mpa-key={mpa.key}>
               <MPASectionCard
                 section={section}
+                model={model}
                 rateeId={selectedRatee?.id}
                 isCollapsed={collapsedSections[mpa.key] ?? false}
                 onToggleCollapse={() => toggleSectionCollapsed(mpa.key)}

--- a/src/components/epb/mpa-section-card.tsx
+++ b/src/components/epb/mpa-section-card.tsx
@@ -71,6 +71,8 @@ import { useStyleFeedback, getMpaCategory } from "@/hooks/use-style-feedback";
 import { PromptSettingsModal } from "./prompt-settings-modal";
 import { ImpactBoosterPanel } from "./impact-booster-panel";
 import { WordReplacementSlider } from "./word-replacement-slider";
+import { useWordThesaurus } from "@/hooks/use-word-thesaurus";
+import { WordThesaurusPopup } from "@/components/word-thesaurus/word-thesaurus-popup";
 import {
   DEFAULT_IMPACT_BOOSTER_PROMPTS,
   buildImpactBoosterContext,
@@ -100,6 +102,8 @@ import type {
 import { FormattingViolationNote } from "@/components/generate/formatting-violation-note";
 interface MPASectionCardProps {
   section: EPBShellSection;
+  /** Selected LLM for highlight-to-replace suggestions */
+  model: string;
   /** Ratee ID for clarifying questions feature */
   rateeId?: string;
   isCollapsed: boolean;
@@ -335,6 +339,7 @@ const MAX_REVISION_HISTORY = MAX_GENERATED_STATEMENT_SETS;
 
 export function MPASectionCard({
   section,
+  model,
   rateeId: _rateeId,
   isCollapsed,
   onToggleCollapse,
@@ -411,6 +416,7 @@ export function MPASectionCard({
   const mpaCardBodyShellRef = useRef<HTMLDivElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
   const lastSavedRef = useRef<string>(section.statement_text);
+  const thesaurus = useWordThesaurus({ model, documentContext: "epb" });
   
   // Revise panel state — always request 3 alternatives (1 credit)
   const [showRevisePanel, setShowRevisePanel] = useState(false);
@@ -1558,6 +1564,7 @@ export function MPASectionCard({
                     isClosing={isSplitViewClosing}
                     onFocus={handleTextFocus}
                     onBlur={handleTextBlur}
+                    model={model}
                   />
                 ) : (
                   <div className="relative">
@@ -1566,7 +1573,25 @@ export function MPASectionCard({
                       value={localText}
                       onChange={(e) => handleTextChange(e.target.value)}
                       onFocus={handleTextFocus}
-                      onBlur={handleTextBlur}
+                      onBlur={() => {
+                        thesaurus.handleBlur();
+                        void handleTextBlur();
+                      }}
+                      onMouseUp={() =>
+                        thesaurus.handleTextSelect(textareaRef.current, {
+                          text: localText,
+                          onChange: handleTextChange,
+                        })
+                      }
+                      onKeyUp={(event) => {
+                        if (event.shiftKey || event.key.startsWith("Arrow")) {
+                          thesaurus.handleTextSelect(textareaRef.current, {
+                            text: localText,
+                            onChange: handleTextChange,
+                          });
+                        }
+                      }}
+                      onKeyDown={thesaurus.handleKeyDown}
                       placeholder={`Enter your ${mpa?.label || "statement"} here...`}
                       rows={5}
                       className={cn(
@@ -1574,6 +1599,8 @@ export function MPASectionCard({
                         isOverLimit && "border-destructive focus-visible:ring-destructive"
                       )}
                     />
+
+                    <WordThesaurusPopup thesaurus={thesaurus} />
 
                     {/* Drop overlay - shows when dragging a sentence from another MPA */}
                     {!isHLR && !isLockedByOther && (

--- a/src/components/epb/split-view-editor.tsx
+++ b/src/components/epb/split-view-editor.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils";
 import { parseStatement, combineSentences, type ParsedSentence } from "@/lib/sentence-utils";
 import { getCharacterCountColor } from "@/lib/utils";
 import { GripVertical } from "lucide-react";
+import { useWordThesaurus } from "@/hooks/use-word-thesaurus";
+import { WordThesaurusPopup } from "@/components/word-thesaurus/word-thesaurus-popup";
 
 // Re-export compatible type for drag-drop
 export interface DraggedSentence {
@@ -29,6 +31,8 @@ interface SplitViewEditorProps {
   isClosing?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
+  /** Selected LLM for highlight-to-replace suggestions */
+  model?: string;
 }
 
 // Strip ALL periods from text (periods are added automatically when combining)
@@ -56,6 +60,7 @@ export function SplitViewEditor({
   isClosing = false,
   onFocus,
   onBlur,
+  model,
 }: SplitViewEditorProps) {
   // Local state for each sentence (stored WITHOUT trailing periods)
   const [sentence1, setSentence1] = useState("");
@@ -70,6 +75,12 @@ export function SplitViewEditor({
   
   // Track if we're in the middle of a local edit
   const isLocalEditRef = useRef(false);
+  const sentence1Ref = useRef<HTMLTextAreaElement>(null);
+  const sentence2Ref = useRef<HTMLTextAreaElement>(null);
+  const thesaurus = useWordThesaurus({
+    model: model ?? "",
+    documentContext: "epb",
+  });
   
   // Initialize from external text when it changes from external source
   useEffect(() => {
@@ -290,10 +301,31 @@ export function SplitViewEditor({
           )}
           <div className="relative flex-1">
             <textarea
+              ref={sentence1Ref}
               value={sentence1}
               onChange={(e) => handleS1Change(e.target.value)}
               onFocus={onFocus}
-              onBlur={onBlur}
+              onBlur={() => {
+                thesaurus.handleBlur();
+                onBlur?.();
+              }}
+              onMouseUp={() => {
+                if (disabled || !model) return;
+                thesaurus.handleTextSelect(sentence1Ref.current, {
+                  text: sentence1,
+                  onChange: handleS1Change,
+                });
+              }}
+              onKeyUp={(event) => {
+                if (disabled || !model) return;
+                if (event.shiftKey || event.key.startsWith("Arrow")) {
+                  thesaurus.handleTextSelect(sentence1Ref.current, {
+                    text: sentence1,
+                    onChange: handleS1Change,
+                  });
+                }
+              }}
+              onKeyDown={thesaurus.handleKeyDown}
               disabled={disabled}
               placeholder={placeholder}
               rows={3}
@@ -364,10 +396,31 @@ export function SplitViewEditor({
           )}
           <div className="relative flex-1">
             <textarea
+              ref={sentence2Ref}
               value={sentence2}
               onChange={(e) => handleS2Change(e.target.value)}
               onFocus={onFocus}
-              onBlur={onBlur}
+              onBlur={() => {
+                thesaurus.handleBlur();
+                onBlur?.();
+              }}
+              onMouseUp={() => {
+                if (disabled || !model) return;
+                thesaurus.handleTextSelect(sentence2Ref.current, {
+                  text: sentence2,
+                  onChange: handleS2Change,
+                });
+              }}
+              onKeyUp={(event) => {
+                if (disabled || !model) return;
+                if (event.shiftKey || event.key.startsWith("Arrow")) {
+                  thesaurus.handleTextSelect(sentence2Ref.current, {
+                    text: sentence2,
+                    onChange: handleS2Change,
+                  });
+                }
+              }}
+              onKeyDown={thesaurus.handleKeyDown}
               disabled={disabled}
               placeholder="Second sentence (optional)..."
               rows={3}
@@ -397,6 +450,8 @@ export function SplitViewEditor({
           {totalLength}/{maxChars}
         </span>
       </div>
+
+      {model && <WordThesaurusPopup thesaurus={thesaurus} />}
       
       {isOverLimit && (
         <p className="text-xs text-destructive">

--- a/src/components/word-thesaurus/word-thesaurus-popup.tsx
+++ b/src/components/word-thesaurus/word-thesaurus-popup.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { BookA, Loader2, Maximize2, Minimize2, RefreshCw, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  motionChip,
+  motionCollapseGrid,
+  motionEnter,
+  motionEnterDurFast,
+  motionPressable,
+  motionSurfaceElevated,
+  motionTransitionColors,
+} from "@/lib/motion/classes";
+import type { WordThesaurusApi } from "@/hooks/use-word-thesaurus";
+
+interface WordThesaurusPopupProps {
+  thesaurus: WordThesaurusApi;
+}
+
+function ReplacementChip({
+  label,
+  onSelect,
+}: {
+  label: string;
+  onSelect: (value: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => onSelect(label)}
+      className={cn(
+        "px-2 py-1 rounded-md text-xs border border-border/80 bg-background",
+        "hover:bg-accent hover:border-primary/40",
+        motionChip,
+      )}
+      aria-label={`Replace with ${label}`}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function WordThesaurusPopup({ thesaurus }: WordThesaurusPopupProps) {
+  const {
+    open,
+    selectedText,
+    isSingleWord,
+    suggested,
+    allSynonyms,
+    showAllSynonyms,
+    isLoadingSuggestions,
+    isLoadingAll,
+    revisionResults,
+    isRevising,
+    enablePhraseRevise,
+    applyReplacement,
+    applyRevision,
+    showAll,
+    hideAll,
+    reviseSelection,
+    close,
+  } = thesaurus;
+
+  const loading = isLoadingSuggestions || isLoadingAll || isRevising;
+  const preview =
+    selectedText.length > 48 ? `${selectedText.slice(0, 48)}…` : selectedText;
+
+  return (
+    <div
+      className={cn("selection-popup", motionCollapseGrid)}
+      data-open={open ? "true" : "false"}
+      data-loading={loading ? "true" : "false"}
+    >
+      <div className="overflow-hidden">
+        <div
+          role={open ? "dialog" : undefined}
+          aria-hidden={!open}
+          aria-label={
+            isSingleWord
+              ? `Replacement suggestions for ${selectedText}`
+              : `Revise selected text`
+          }
+          className={cn(
+            "mt-2 p-3 rounded-lg bg-card",
+            motionSurfaceElevated,
+            motionEnter,
+            motionEnterDurFast,
+          )}
+        >
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-xs text-muted-foreground min-w-0">
+                Selected:{" "}
+                <span className="font-medium text-foreground">
+                  &ldquo;{preview}&rdquo;
+                </span>
+                <span className="ml-1 tabular-nums">({selectedText.length} chars)</span>
+                {isSingleWord && (
+                  <span className="ml-1.5 text-[10px] text-primary">word</span>
+                )}
+              </p>
+              <button
+                type="button"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={close}
+                className={cn(
+                  "text-muted-foreground hover:text-foreground shrink-0",
+                  motionPressable,
+                  motionTransitionColors,
+                )}
+                aria-label="Close replacement suggestions"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+
+            {isSingleWord && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                  <BookA className="size-3.5 text-primary" />
+                  Suggested replacements
+                </div>
+                <p className="text-[11px] text-muted-foreground">
+                  Matched to this sentence, not a raw synonym dump.
+                </p>
+
+                {isLoadingSuggestions ? (
+                  <div
+                    className="flex items-center gap-2 text-xs text-muted-foreground"
+                    aria-live="polite"
+                  >
+                    <Loader2 className="size-3 animate-spin" />
+                    Finding replacements from this sentence…
+                  </div>
+                ) : suggested.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {suggested.map((word) => (
+                      <ReplacementChip
+                        key={`suggested-${word}`}
+                        label={word}
+                        onSelect={applyReplacement}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    No context-aware replacements yet. Open all synonyms for dictionary matches.
+                  </p>
+                )}
+
+                <div>
+                  <button
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={showAllSynonyms ? hideAll : () => void showAll()}
+                    className={cn(
+                      "h-7 px-2.5 rounded-md text-xs border border-input bg-background",
+                      "hover:bg-accent hover:text-accent-foreground inline-flex items-center gap-1.5",
+                      motionChip,
+                    )}
+                    aria-expanded={showAllSynonyms}
+                  >
+                    {showAllSynonyms ? "Hide all synonyms" : "See all synonyms"}
+                  </button>
+                </div>
+
+                <div
+                  className={motionCollapseGrid}
+                  data-open={showAllSynonyms ? "true" : "false"}
+                >
+                  <div className="overflow-hidden">
+                    <div className="pt-2 space-y-2 border-t border-border/60">
+                      <p className="text-[11px] text-muted-foreground">
+                        Dictionary synonyms — may not fit this sentence.
+                      </p>
+                      {isLoadingAll ? (
+                        <div
+                          className="flex items-center gap-2 text-xs text-muted-foreground"
+                          aria-live="polite"
+                        >
+                          <Loader2 className="size-3 animate-spin" />
+                          Loading all synonyms…
+                        </div>
+                      ) : allSynonyms.length > 0 ? (
+                        <div className="flex flex-wrap gap-1.5 max-h-36 overflow-y-auto">
+                          {allSynonyms.map((word) => (
+                            <ReplacementChip
+                              key={`all-${word}`}
+                              label={word}
+                              onSelect={applyReplacement}
+                            />
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          No additional synonyms found.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {!isSingleWord && enablePhraseRevise && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <PhraseButton
+                    label="Expand"
+                    icon={Maximize2}
+                    disabled={isRevising}
+                    onClick={() => void reviseSelection("expand")}
+                  />
+                  <PhraseButton
+                    label="Compress"
+                    icon={Minimize2}
+                    disabled={isRevising}
+                    onClick={() => void reviseSelection("compress")}
+                  />
+                  <PhraseButton
+                    label="Rephrase"
+                    icon={RefreshCw}
+                    disabled={isRevising}
+                    onClick={() => void reviseSelection("general")}
+                  />
+                </div>
+                {isRevising && (
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Loader2 className="size-3 animate-spin" />
+                    Revising selection…
+                  </div>
+                )}
+                {revisionResults.length > 0 && (
+                  <div className="space-y-2 pt-1">
+                    <p className="text-xs font-medium text-muted-foreground">Alternatives</p>
+                    {revisionResults.map((revision) => (
+                      <button
+                        type="button"
+                        key={`rev-${revision.slice(0, 48)}-${revision.length}`}
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => applyRevision(revision)}
+                        className={cn(
+                          "w-full text-left p-2 rounded-md text-sm border border-border/80",
+                          "hover:bg-accent hover:border-primary/40",
+                          motionChip,
+                        )}
+                      >
+                        <p className="whitespace-pre-wrap">{revision}</p>
+                        <span className="text-[10px] text-muted-foreground tabular-nums">
+                          {revision.length} chars (
+                          {revision.length > selectedText.length ? "+" : ""}
+                          {revision.length - selectedText.length})
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PhraseButton({
+  label,
+  icon: Icon,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  icon: typeof Maximize2;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "flex-1 h-8 px-3 rounded-md text-xs border border-input bg-background",
+        "hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center gap-1.5",
+        "disabled:opacity-50",
+        motionChip,
+      )}
+      aria-label={`${label} selected text`}
+    >
+      {disabled ? <Loader2 className="size-3 animate-spin" /> : <Icon className="size-3" />}
+      {label}
+    </button>
+  );
+}

--- a/src/hooks/use-word-thesaurus.ts
+++ b/src/hooks/use-word-thesaurus.ts
@@ -1,0 +1,340 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { toast } from "@/components/ui/sonner";
+import { fetchWithRetry } from "@/lib/fetch-with-retry";
+import { fetchDictionarySynonyms } from "@/lib/datamuse-synonyms";
+import { handleUsageLimitResponse } from "@/stores/usage-limit-store";
+import {
+  applyRangeReplacement,
+  isSingleSelectableWord,
+  preserveReplacementCase,
+  sentenceContainingRange,
+  shouldAutoFetchSuggestions,
+  splitSuggestedAndRest,
+  trimSelection,
+  type PhraseReviseMode,
+  type WordThesaurusDocumentContext,
+} from "@/lib/word-thesaurus";
+
+const SUGGEST_DEBOUNCE_MS = 280;
+
+export interface ThesaurusTextSource {
+  text: string;
+  onChange: (next: string) => void;
+}
+
+export interface UseWordThesaurusOptions {
+  model: string;
+  documentContext: WordThesaurusDocumentContext;
+  enablePhraseRevise?: boolean;
+}
+
+export function useWordThesaurus({
+  model,
+  documentContext,
+  enablePhraseRevise = true,
+}: UseWordThesaurusOptions) {
+  const [open, setOpen] = useState(false);
+  const [selectedText, setSelectedText] = useState("");
+  const [selectionStart, setSelectionStart] = useState(0);
+  const [selectionEnd, setSelectionEnd] = useState(0);
+  const [suggested, setSuggested] = useState<string[]>([]);
+  const [allSynonyms, setAllSynonyms] = useState<string[]>([]);
+  const [showAllSynonyms, setShowAllSynonyms] = useState(false);
+  const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
+  const [isLoadingAll, setIsLoadingAll] = useState(false);
+  const [revisionResults, setRevisionResults] = useState<string[]>([]);
+  const [isRevising, setIsRevising] = useState(false);
+
+  const sourceRef = useRef<ThesaurusTextSource | null>(null);
+  const rangeRef = useRef({ start: 0, end: 0 });
+  const selectedRef = useRef("");
+  const suggestAbortRef = useRef<AbortController | null>(null);
+  const allAbortRef = useRef<AbortController | null>(null);
+  const debounceRef = useRef<number | null>(null);
+  const suggestionKeyRef = useRef("");
+
+  const isSingleWord = isSingleSelectableWord(selectedText);
+
+  const abortPending = useCallback(() => {
+    if (debounceRef.current != null) {
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    suggestAbortRef.current?.abort();
+    suggestAbortRef.current = null;
+    allAbortRef.current?.abort();
+    allAbortRef.current = null;
+  }, []);
+
+  const resetLists = useCallback(() => {
+    setSuggested([]);
+    setAllSynonyms([]);
+    setShowAllSynonyms(false);
+    setRevisionResults([]);
+    setIsLoadingSuggestions(false);
+    setIsLoadingAll(false);
+    setIsRevising(false);
+    suggestionKeyRef.current = "";
+  }, []);
+
+  const close = useCallback(() => {
+    abortPending();
+    setOpen(false);
+    setSelectedText("");
+    resetLists();
+    sourceRef.current = null;
+  }, [abortPending, resetLists]);
+
+  const fetchSuggestions = useCallback(
+    async (word: string, fullStatement: string, sentence: string) => {
+      const key = `${word.toLowerCase()}::${sentence}`;
+      if (suggestionKeyRef.current === key) return;
+
+      suggestAbortRef.current?.abort();
+      const controller = new AbortController();
+      suggestAbortRef.current = controller;
+      suggestionKeyRef.current = key;
+      setIsLoadingSuggestions(true);
+      setSuggested([]);
+
+      try {
+        const response = await fetchWithRetry(
+          "/api/synonyms",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              word,
+              fullStatement,
+              sentence,
+              model,
+              context: documentContext,
+            }),
+            signal: controller.signal,
+          },
+          { timeout: 45000 },
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          if (handleUsageLimitResponse(errorData)) return;
+          throw new Error(errorData.error || "Failed to fetch replacements");
+        }
+
+        const data = await response.json();
+        const raw: string[] = Array.isArray(data.suggestions)
+          ? data.suggestions
+          : Array.isArray(data.synonyms)
+            ? data.synonyms
+            : [];
+        const { suggested: nextSuggested } = splitSuggestedAndRest(raw);
+        setSuggested(nextSuggested);
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        suggestionKeyRef.current = "";
+        console.error("Thesaurus suggestion error:", error);
+        toast.error(error instanceof Error ? error.message : "Failed to get replacements");
+        setSuggested([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoadingSuggestions(false);
+        }
+      }
+    },
+    [documentContext, model],
+  );
+
+  const handleTextSelect = useCallback(
+    (textarea: HTMLTextAreaElement | null, source: ThesaurusTextSource) => {
+      if (!textarea) return;
+
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      const raw = source.text.slice(start, end);
+      const trimmed = trimSelection(raw);
+
+      if (!trimmed || start === end) {
+        if (open) close();
+        return;
+      }
+
+      sourceRef.current = source;
+      rangeRef.current = { start, end };
+      selectedRef.current = trimmed;
+      setSelectionStart(start);
+      setSelectionEnd(end);
+      setSelectedText(trimmed);
+      setOpen(true);
+
+      const single = isSingleSelectableWord(trimmed);
+      if (!single) {
+        abortPending();
+        setSuggested([]);
+        setAllSynonyms([]);
+        setShowAllSynonyms(false);
+        setIsLoadingSuggestions(false);
+        return;
+      }
+
+      if (!shouldAutoFetchSuggestions(trimmed)) {
+        abortPending();
+        setSuggested([]);
+        setIsLoadingSuggestions(false);
+        return;
+      }
+
+      const sentence = sentenceContainingRange(source.text, start, end);
+      if (debounceRef.current != null) window.clearTimeout(debounceRef.current);
+      debounceRef.current = window.setTimeout(() => {
+        debounceRef.current = null;
+        void fetchSuggestions(trimmed, source.text, sentence);
+      }, SUGGEST_DEBOUNCE_MS);
+    },
+    [abortPending, close, fetchSuggestions, open],
+  );
+
+  const applyReplacement = useCallback(
+    (replacement: string) => {
+      const source = sourceRef.current;
+      if (!source) return;
+      const original = selectedRef.current;
+      const cased = preserveReplacementCase(original, replacement);
+      const { start, end } = rangeRef.current;
+      const next = applyRangeReplacement(source.text, start, end, cased);
+      source.onChange(next);
+      toast.success(`Replaced "${original}" with "${cased}"`);
+      close();
+    },
+    [close],
+  );
+
+  const applyRevision = useCallback(
+    (revision: string) => {
+      const source = sourceRef.current;
+      if (!source) return;
+      const { start, end } = rangeRef.current;
+      source.onChange(applyRangeReplacement(source.text, start, end, revision));
+      toast.success("Selection replaced");
+      close();
+    },
+    [close],
+  );
+
+  const showAll = useCallback(async () => {
+    const word = selectedRef.current;
+    if (!isSingleSelectableWord(word)) return;
+
+    setShowAllSynonyms(true);
+    if (allSynonyms.length > 0 || isLoadingAll) return;
+
+    allAbortRef.current?.abort();
+    const controller = new AbortController();
+    allAbortRef.current = controller;
+    setIsLoadingAll(true);
+
+    try {
+      const dictionary = await fetchDictionarySynonyms(word, controller.signal);
+      const already = new Set(suggested.map((item) => item.toLowerCase()));
+      already.add(word.toLowerCase());
+      setAllSynonyms(dictionary.filter((item) => !already.has(item.toLowerCase())));
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      console.error("Dictionary synonym error:", error);
+      toast.error("Failed to load all synonyms");
+      setAllSynonyms([]);
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoadingAll(false);
+      }
+    }
+  }, [allSynonyms.length, isLoadingAll, suggested]);
+
+  const hideAll = useCallback(() => {
+    setShowAllSynonyms(false);
+  }, []);
+
+  const reviseSelection = useCallback(
+    async (mode: PhraseReviseMode) => {
+      const source = sourceRef.current;
+      const selected = selectedRef.current;
+      if (!source || !selected) return;
+
+      setIsRevising(true);
+      setRevisionResults([]);
+
+      try {
+        const response = await fetchWithRetry("/api/revise-selection", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            fullStatement: source.text,
+            selectedText: selected,
+            selectionStart: rangeRef.current.start,
+            selectionEnd: rangeRef.current.end,
+            model,
+            mode,
+          }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          if (handleUsageLimitResponse(errorData)) return;
+          throw new Error(errorData.error || "Revision failed");
+        }
+
+        const data = await response.json();
+        setRevisionResults(Array.isArray(data.revisions) ? data.revisions : []);
+      } catch (error) {
+        console.error("Selection revise error:", error);
+        toast.error(error instanceof Error ? error.message : "Failed to revise selection");
+      } finally {
+        setIsRevising(false);
+      }
+    },
+    [model],
+  );
+
+  const handleBlur = useCallback(() => {
+    window.setTimeout(() => {
+      if (document.activeElement?.closest(".selection-popup")) return;
+      if (document.querySelector(".selection-popup[data-loading='true']")) return;
+      close();
+    }, 200);
+  }, [close]);
+
+  const handleKeyDown = useCallback(
+    (event: { key: string }) => {
+      if (event.key === "Escape" && open) close();
+    },
+    [close, open],
+  );
+
+  return {
+    open,
+    selectedText,
+    selectionStart,
+    selectionEnd,
+    isSingleWord,
+    suggested,
+    allSynonyms,
+    showAllSynonyms,
+    isLoadingSuggestions,
+    isLoadingAll,
+    revisionResults,
+    isRevising,
+    enablePhraseRevise,
+    handleTextSelect,
+    handleBlur,
+    handleKeyDown,
+    applyReplacement,
+    applyRevision,
+    showAll,
+    hideAll,
+    reviseSelection,
+    close,
+  };
+}
+
+export type WordThesaurusApi = ReturnType<typeof useWordThesaurus>;

--- a/src/hooks/use-word-thesaurus.ts
+++ b/src/hooks/use-word-thesaurus.ts
@@ -3,7 +3,6 @@
 import { useCallback, useRef, useState } from "react";
 import { toast } from "@/components/ui/sonner";
 import { fetchWithRetry } from "@/lib/fetch-with-retry";
-import { fetchDictionarySynonyms } from "@/lib/datamuse-synonyms";
 import { handleUsageLimitResponse } from "@/stores/usage-limit-store";
 import {
   applyRangeReplacement,
@@ -138,9 +137,7 @@ export function useWordThesaurus({
         toast.error(error instanceof Error ? error.message : "Failed to get replacements");
         setSuggested([]);
       } finally {
-        if (!controller.signal.aborted) {
-          setIsLoadingSuggestions(false);
-        }
+        setIsLoadingSuggestions(false);
       }
     },
     [documentContext, model],
@@ -235,7 +232,15 @@ export function useWordThesaurus({
     setIsLoadingAll(true);
 
     try {
-      const dictionary = await fetchDictionarySynonyms(word, controller.signal);
+      const response = await fetch(
+        `/api/dictionary-synonyms?word=${encodeURIComponent(word)}`,
+        { signal: controller.signal },
+      );
+      if (!response.ok) {
+        throw new Error("Failed to fetch dictionary synonyms");
+      }
+      const data = await response.json();
+      const dictionary: string[] = Array.isArray(data.synonyms) ? data.synonyms : [];
       const already = new Set(suggested.map((item) => item.toLowerCase()));
       already.add(word.toLowerCase());
       setAllSynonyms(dictionary.filter((item) => !already.has(item.toLowerCase())));
@@ -245,9 +250,7 @@ export function useWordThesaurus({
       toast.error("Failed to load all synonyms");
       setAllSynonyms([]);
     } finally {
-      if (!controller.signal.aborted) {
-        setIsLoadingAll(false);
-      }
+      setIsLoadingAll(false);
     }
   }, [allSynonyms.length, isLoadingAll, suggested]);
 

--- a/src/lib/__tests__/datamuse-synonyms.test.ts
+++ b/src/lib/__tests__/datamuse-synonyms.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchDictionarySynonyms } from "@/lib/datamuse-synonyms";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchDictionarySynonyms", () => {
+  it("merges strict synonyms ahead of means-like words and drops the original", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL) => {
+        const url = String(input);
+        if (url.includes("rel_syn")) {
+          return {
+            ok: true,
+            json: async () => [{ word: "drove" }, { word: "led" }, { word: "headed" }],
+          };
+        }
+        return {
+          ok: true,
+          json: async () => [{ word: "headed" }, { word: "commanded" }, { word: "led the charge" }],
+        };
+      }),
+    );
+
+    const words = await fetchDictionarySynonyms("Led");
+    expect(words).toEqual(["drove", "headed", "commanded"]);
+  });
+
+  it("returns an empty list for a blank word without fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await fetchDictionarySynonyms("   ")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/word-thesaurus.test.ts
+++ b/src/lib/__tests__/word-thesaurus.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyRangeReplacement,
+  isSingleSelectableWord,
+  preserveReplacementCase,
+  sanitizeThesaurusWord,
+  sentenceContainingRange,
+  shouldAutoFetchSuggestions,
+  splitSuggestedAndRest,
+} from "@/lib/word-thesaurus";
+
+describe("isSingleSelectableWord", () => {
+  it("accepts a simple action verb", () => {
+    expect(isSingleSelectableWord("Led")).toBe(true);
+    expect(isSingleSelectableWord("  drove  ")).toBe(true);
+  });
+
+  it("accepts hyphenated and possessive forms", () => {
+    expect(isSingleSelectableWord("mission-ready")).toBe(true);
+    expect(isSingleSelectableWord("Airman's")).toBe(true);
+  });
+
+  it("rejects phrases and numbers", () => {
+    expect(isSingleSelectableWord("Led team")).toBe(false);
+    expect(isSingleSelectableWord("90%")).toBe(false);
+    expect(isSingleSelectableWord("")).toBe(false);
+  });
+});
+
+describe("shouldAutoFetchSuggestions", () => {
+  it("skips tiny and function words to avoid wasting an LLM call", () => {
+    expect(shouldAutoFetchSuggestions("to")).toBe(false);
+    expect(shouldAutoFetchSuggestions("the")).toBe(false);
+    expect(shouldAutoFetchSuggestions("a")).toBe(false);
+  });
+
+  it("runs for impact verbs", () => {
+    expect(shouldAutoFetchSuggestions("Led")).toBe(true);
+    expect(shouldAutoFetchSuggestions("orchestrated")).toBe(true);
+  });
+});
+
+describe("sentenceContainingRange", () => {
+  it("returns the sentence that owns the highlighted word", () => {
+    const text =
+      "Led 12 Amn through a $2M upgrade. Directed cyber ops across 10 sites.";
+    const start = text.indexOf("Directed");
+    expect(sentenceContainingRange(text, start, start + "Directed".length)).toBe(
+      "Directed cyber ops across 10 sites.",
+    );
+  });
+
+  it("returns the first sentence when the selection is in it", () => {
+    const text = "Led 12 Amn through a $2M upgrade. Directed cyber ops.";
+    const start = text.indexOf("Led");
+    expect(sentenceContainingRange(text, start, start + 3)).toBe(
+      "Led 12 Amn through a $2M upgrade.",
+    );
+  });
+
+  it("falls back to the full text when there are no sentence breaks", () => {
+    const text = "Led 12 Amn through a $2M upgrade";
+    expect(sentenceContainingRange(text, 0, 3)).toBe(text);
+  });
+});
+
+describe("preserveReplacementCase", () => {
+  it("keeps title case when the original was capitalized", () => {
+    expect(preserveReplacementCase("Led", "drove")).toBe("Drove");
+  });
+
+  it("keeps all-caps replacements for acronyms", () => {
+    expect(preserveReplacementCase("NCOIC", "superintendent")).toBe("SUPERINTENDENT");
+  });
+
+  it("lowercases a title-case replacement when the original was lowercase", () => {
+    expect(preserveReplacementCase("led", "Drove")).toBe("drove");
+  });
+
+  it("keeps short acronyms even when the original was lowercase", () => {
+    expect(preserveReplacementCase("ncoic", "NCOIC")).toBe("NCOIC");
+  });
+});
+
+describe("applyRangeReplacement", () => {
+  it("replaces only the selected span", () => {
+    expect(applyRangeReplacement("Led 12 Amn. Directed ops.", 0, 3, "Drove")).toBe(
+      "Drove 12 Amn. Directed ops.",
+    );
+  });
+});
+
+describe("splitSuggestedAndRest", () => {
+  it("dedupes case-insensitively and splits the suggested list", () => {
+    const { suggested, rest } = splitSuggestedAndRest(
+      ["Drove", "drove", "Directed", "Managed", "Led", "Ran", "Oversaw", "Guided"],
+      3,
+    );
+    expect(suggested).toEqual(["Drove", "Directed", "Managed"]);
+    expect(rest).toEqual(["Led", "Ran", "Oversaw", "Guided"]);
+  });
+});
+
+describe("sanitizeThesaurusWord", () => {
+  it("trims and caps length", () => {
+    expect(sanitizeThesaurusWord("  Led  ")).toBe("Led");
+    expect(sanitizeThesaurusWord("x".repeat(80)).length).toBe(40);
+  });
+});

--- a/src/lib/datamuse-synonyms.ts
+++ b/src/lib/datamuse-synonyms.ts
@@ -1,0 +1,58 @@
+import { sanitizeThesaurusWord } from "@/lib/word-thesaurus";
+
+interface DatamuseWord {
+  word?: unknown;
+}
+
+function asWordList(payload: unknown): string[] {
+  if (!Array.isArray(payload)) return [];
+  return payload
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (item && typeof item === "object" && "word" in item) {
+        const word = (item as DatamuseWord).word;
+        return typeof word === "string" ? word : "";
+      }
+      return "";
+    })
+    .map((word) => word.trim())
+    .filter((word) => word.length > 0 && !word.includes(" "));
+}
+
+/**
+ * Dictionary synonyms via Datamuse (no API key). Used for "see all synonyms"
+ * after context-aware LLM suggestions are shown.
+ */
+export async function fetchDictionarySynonyms(
+  word: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const sanitized = sanitizeThesaurusWord(word);
+  if (!sanitized) return [];
+
+  const encoded = encodeURIComponent(sanitized.toLowerCase());
+  const [synResponse, meansLikeResponse] = await Promise.all([
+    fetch(`https://api.datamuse.com/words?rel_syn=${encoded}&max=40`, { signal }),
+    fetch(`https://api.datamuse.com/words?ml=${encoded}&max=50`, { signal }),
+  ]);
+
+  if (!synResponse.ok && !meansLikeResponse.ok) {
+    throw new Error("Failed to fetch dictionary synonyms");
+  }
+
+  const [synData, meansLikeData] = await Promise.all([
+    synResponse.ok ? synResponse.json() : [],
+    meansLikeResponse.ok ? meansLikeResponse.json() : [],
+  ]);
+
+  const seen = new Set<string>([sanitized.toLowerCase()]);
+  const merged: string[] = [];
+  for (const candidate of [...asWordList(synData), ...asWordList(meansLikeData)]) {
+    const key = candidate.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(candidate);
+    if (merged.length >= 50) break;
+  }
+  return merged;
+}

--- a/src/lib/word-thesaurus.ts
+++ b/src/lib/word-thesaurus.ts
@@ -1,0 +1,156 @@
+/** Shared helpers for highlight-to-replace (context suggestions + full synonyms). */
+
+export const WORD_THESAURUS_SUGGESTED_COUNT = 6;
+export const WORD_THESAURUS_MAX_WORD_LENGTH = 40;
+
+const SINGLE_WORD_RE = /^[A-Za-z][A-Za-z'-]{0,39}$/;
+
+/** Function words that should not auto-spend an LLM call. */
+const SKIP_LLM_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "or",
+  "but",
+  "nor",
+  "for",
+  "of",
+  "to",
+  "in",
+  "on",
+  "at",
+  "by",
+  "as",
+  "is",
+  "was",
+  "are",
+  "were",
+  "be",
+  "been",
+  "being",
+  "it",
+  "its",
+  "this",
+  "that",
+  "these",
+  "those",
+  "with",
+  "from",
+]);
+
+export type PhraseReviseMode = "expand" | "compress" | "general";
+
+export type WordThesaurusDocumentContext = "epb" | "award" | "decoration";
+
+export function trimSelection(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function isSingleSelectableWord(text: string): boolean {
+  const trimmed = trimSelection(text);
+  return trimmed.length > 0 && SINGLE_WORD_RE.test(trimmed) && !trimmed.includes(" ");
+}
+
+export function shouldAutoFetchSuggestions(word: string): boolean {
+  const trimmed = trimSelection(word);
+  if (!isSingleSelectableWord(trimmed)) return false;
+  if (trimmed.length < 3) return false;
+  return !SKIP_LLM_WORDS.has(trimmed.toLowerCase());
+}
+
+/**
+ * Sentence that contains [start, end) in the original string.
+ * Uses the live editor text (not whitespace-normalized) so indices stay valid.
+ */
+export function sentenceContainingRange(
+  text: string,
+  start: number,
+  end: number,
+): string {
+  if (!text) return "";
+  const clampedStart = Math.max(0, Math.min(start, text.length));
+  const clampedEnd = Math.max(clampedStart, Math.min(end, text.length));
+
+  let from = clampedStart;
+  while (from > 0) {
+    const prev = text[from - 1];
+    if (prev === "." || prev === "!" || prev === "?") break;
+    from -= 1;
+  }
+  while (from < clampedStart && /\s/.test(text[from] ?? "")) from += 1;
+
+  let to = clampedEnd;
+  while (to < text.length) {
+    const ch = text[to];
+    to += 1;
+    if (ch === "." || ch === "!" || ch === "?") break;
+  }
+
+  const sentence = text.slice(from, to).trim();
+  return sentence || text.trim();
+}
+
+export function preserveReplacementCase(
+  original: string,
+  replacement: string,
+): string {
+  const trimmedOriginal = original.trim();
+  const trimmedReplacement = replacement.trim();
+  if (!trimmedOriginal || !trimmedReplacement) return trimmedReplacement;
+
+  if (trimmedOriginal === trimmedOriginal.toUpperCase() && /[A-Z]/.test(trimmedOriginal)) {
+    return trimmedReplacement.toUpperCase();
+  }
+
+  const originalFirst = trimmedOriginal[0];
+  if (
+    originalFirst &&
+    originalFirst === originalFirst.toUpperCase() &&
+    originalFirst !== originalFirst.toLowerCase()
+  ) {
+    return trimmedReplacement.charAt(0).toUpperCase() + trimmedReplacement.slice(1);
+  }
+
+  const isAcronym =
+    trimmedReplacement === trimmedReplacement.toUpperCase() &&
+    /[A-Z]/.test(trimmedReplacement) &&
+    trimmedReplacement.length <= 6;
+  if (isAcronym) return trimmedReplacement;
+
+  return trimmedReplacement.charAt(0).toLowerCase() + trimmedReplacement.slice(1);
+}
+
+export function applyRangeReplacement(
+  text: string,
+  start: number,
+  end: number,
+  replacement: string,
+): string {
+  const clampedStart = Math.max(0, Math.min(start, text.length));
+  const clampedEnd = Math.max(clampedStart, Math.min(end, text.length));
+  return text.slice(0, clampedStart) + replacement + text.slice(clampedEnd);
+}
+
+export function sanitizeThesaurusWord(word: string): string {
+  return trimSelection(word).slice(0, WORD_THESAURUS_MAX_WORD_LENGTH);
+}
+
+export function splitSuggestedAndRest(items: string[], suggestedCount = WORD_THESAURUS_SUGGESTED_COUNT): {
+  suggested: string[];
+  rest: string[];
+} {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const item of items) {
+    const trimmed = item.trim();
+    const key = trimmed.toLowerCase();
+    if (!trimmed || seen.has(key)) continue;
+    seen.add(key);
+    unique.push(trimmed);
+  }
+  return {
+    suggested: unique.slice(0, suggestedCount),
+    rest: unique.slice(suggestedCount),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Highlighting a word in EPB / award / decoration no longer opened the context-aware replacement menu. EPB had no selection popup, award only offered expand/compress/rephrase, and decoration required a separate “Find Synonyms” click that dumped generic synonyms.

## What changed
- Shared highlight-to-replace menu on EPB (MPA, split view, duty description), award statements, and decoration citations.
- Highlighting a **word** auto-loads **sentence-aware LLM replacements** first (not a raw thesaurus dump).
- **See all synonyms** expands a dictionary list via an authenticated `/api/dictionary-synonyms` proxy (Datamuse is blocked by CSP from the browser).
- Highlighting a **phrase** still offers Expand / Compress / Rephrase.
- `/api/synonyms` now takes the containing sentence as primary context and returns a short suggested list.

## How to try it
1. Open `/epb`, an award workspace, or a decoration citation.
2. Highlight a single action verb in a statement.
3. Confirm the menu lists suggested replacements, then open **See all synonyms**.
4. Click a chip to replace the word in place.

[Suggested replacements for exceeding](https://cursor.com/agents/bc-f76045ce-777b-427c-95c9-f4c7c6d57f77/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fepb_suggested_replacements.webp)
[See all dictionary synonyms expanded](https://cursor.com/agents/bc-f76045ce-777b-427c-95c9-f4c7c6d57f77/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fepb_see_all_synonyms.webp)
[Replaced exceeding with surpassing](https://cursor.com/agents/bc-f76045ce-777b-427c-95c9-f4c7c6d57f77/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fepb_word_replaced_toast.webp)
[epb_thesaurus_suggested_and_all_synonyms.mp4](https://cursor.com/agents/bc-f76045ce-777b-427c-95c9-f4c7c6d57f77/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fepb_thesaurus_suggested_and_all_synonyms.mp4)

## Testing
- Unit tests: `word-thesaurus` and `datamuse-synonyms` (17 passing).
- `tsc --noEmit` clean.
- React Doctor `--scope changed`: 0 issues (score 83, no new findings).
- Manual EPB: highlight → suggested chips → see all synonyms → replace word → phrase expand/compress/rephrase.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f76045ce-777b-427c-95c9-f4c7c6d57f77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f76045ce-777b-427c-95c9-f4c7c6d57f77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

