### PR TITLE
Stop charging credits for synonym replacement suggestions

### DIFF
--- a/src/app/api/revise-selection/route.ts
+++ b/src/app/api/revise-selection/route.ts
@@ -3,6 +3,7 @@ import { generateText } from "ai";
 import { NextResponse } from "next/server";
 import { getDecryptedApiKeys } from "@/app/actions/api-keys";
 import { getModelProvider } from "@/lib/llm-provider";
+import { reviseTrackingAction, withTrackingAction } from "@/lib/revise-tracking";
 import {
   cacheBillableJson,
   createBillableRequestContext,
@@ -505,7 +506,11 @@ ${noReuseRule}`;
     // Cost reduction: force cheapest model for default-key users
     const effectiveModel = usageCheck.effectiveModel;
     requestModelId = effectiveModel;
-    const modelProvider = getModelProvider(effectiveModel, userKeys, usageCheck.tracking);
+    const modelProvider = getModelProvider(
+      effectiveModel,
+      userKeys,
+      withTrackingAction(usageCheck.tracking, reviseTrackingAction(mode)),
+    );
 
     const beforeSelection = fullStatement.substring(0, selectionStart);
     const afterSelection = fullStatement.substring(selectionEnd);

--- a/src/app/api/synonyms/route.ts
+++ b/src/app/api/synonyms/route.ts
@@ -7,13 +7,12 @@ import {
   cacheBillableJson,
   createBillableRequestContext,
   getReplayedBillableResponse,
-  handleBillableLLMError,
   type BillableRequestContext,
 } from "@/lib/billing/billable-request";
 import { handleLLMError } from "@/lib/llm-error-handler";
 import { enforceUsageGate } from "@/lib/usage-gate";
 import { resolveRequestedModel } from "@/app/actions/ai-models";
-import { checkAndTrackUsage } from "@/lib/usage-tracker";
+import { allowUnbilledLlmUsage } from "@/lib/usage-tracker";
 import { appendUserRulesToPrompt } from "@/lib/prompt-rules/server";
 import type { PromptRuleContext } from "@/types/database";
 import {
@@ -78,13 +77,12 @@ export async function POST(request: Request) {
     const replayed = await getReplayedBillableResponse(billableCtx);
     if (replayed) return replayed;
 
-    // Usage tracking — enforce weekly limit for default-key users
-    const usageCheck = await checkAndTrackUsage(
+    // Free for default-key users — suggestions never consume a prepaid credit.
+    const usageCheck = await allowUnbilledLlmUsage(
       user.id,
       "synonyms",
       modelId,
       userKeys,
-      billableCtx.idempotencyKey,
     );
     billableCtx.usageCheck = usageCheck;
     if (!usageCheck.allowed) {
@@ -191,14 +189,6 @@ Return ONLY a JSON array of strings:
       usageCheck,
     );
   } catch (error) {
-    if (billableCtx) {
-      return handleBillableLLMError(
-        error,
-        "POST /api/synonyms",
-        modelId,
-        billableCtx,
-      );
-    }
     return handleLLMError(error, "POST /api/synonyms", modelId);
   }
 }

--- a/src/components/admin/admin-usage-dashboard.tsx
+++ b/src/components/admin/admin-usage-dashboard.tsx
@@ -12,9 +12,12 @@ import {
   DailyBurnCostChart,
   ByokModelsChart,
   WeeklyActiveUsersChart,
+  ActionCostChart,
 } from "@/components/admin/usage-charts";
+import { WritingAssistCostGrid } from "@/components/admin/writing-assist-cost-grid";
 import type { AdminUsagePageData } from "@/components/admin/admin-usage-types";
 import {
+  buildActionCostSeries,
   buildByokModelSeries,
   buildDailyBurnSeries,
   buildWeeklyBurnSeries,
@@ -75,6 +78,10 @@ export function AdminUsageDashboard({ data }: { data: AdminUsagePageData }) {
       );
   const weeklySeries = buildWeeklyUsersSeries(credits.trial_burn.by_week);
   const byokSeries = buildByokModelSeries(credits.byok_models.by_model);
+  const actionSeries = buildActionCostSeries(defaultKey.by_action ?? []);
+  const writingAssistCost = actionSeries
+    .filter((row) => row.featured)
+    .reduce((sum, row) => sum + row.cost, 0);
 
   const totalByokCalls = credits.byok_models.by_model.reduce(
     (sum, row) => sum + row.calls,
@@ -131,6 +138,34 @@ export function AdminUsageDashboard({ data }: { data: AdminUsagePageData }) {
         </CardHeader>
         <CardContent className="min-w-0">
           <DailyBurnCostChart data={burnSeries} weekly={weeklyBurn} />
+        </CardContent>
+      </Card>
+
+      <Card className="min-w-0 overflow-hidden">
+        <CardHeader className="pb-2">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <CardTitle>Writing assists</CardTitle>
+              <CardDescription>
+                Highlighted synonym suggestions plus Expand, Compress, and Rephrase.
+                Estimated app-key spend — suggestions are free to members.
+              </CardDescription>
+            </div>
+            <div className="text-sm tabular-nums sm:text-right">
+              <p className="text-muted-foreground">Assist cost</p>
+              <p className="text-lg font-semibold">{formatCost(writingAssistCost)}</p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="min-w-0 space-y-6">
+          <WritingAssistCostGrid points={actionSeries} />
+          <div>
+            <p className="mb-2 text-sm font-medium">Estimated cost by feature</p>
+            <p className="mb-3 text-xs text-muted-foreground">
+              Writing assists in green; other app-key features in blue.
+            </p>
+            <ActionCostChart data={actionSeries} />
+          </div>
         </CardContent>
       </Card>
 

--- a/src/components/admin/usage-charts.tsx
+++ b/src/components/admin/usage-charts.tsx
@@ -3,6 +3,7 @@
 import {
   Bar,
   CartesianGrid,
+  Cell,
   ComposedChart,
   Line,
   BarChart as RechartsBarChart,
@@ -12,6 +13,7 @@ import {
   YAxis,
 } from "recharts";
 import type {
+  ActionCostPoint,
   ByokModelPoint,
   DailyBurnPoint,
   WeeklyUsersPoint,
@@ -276,6 +278,82 @@ export function ByokModelsChart({ data }: { data: ByokModelPoint[] }) {
           maxBarSize={20}
         />
       </RechartsBarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export function ActionCostChart({ data }: { data: ActionCostPoint[] }) {
+  const hasCost = data.some((row) => row.cost > 0);
+  const chartHeight = Math.max(220, data.length * 34);
+
+  if (data.length === 0) {
+    return (
+      <p className="flex h-[220px] items-center justify-center text-sm text-muted-foreground">
+        No feature usage in this period yet.
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="w-full min-w-0 max-w-full"
+      style={{ height: chartHeight }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsBarChart
+          data={data}
+          layout="vertical"
+          margin={{ top: 4, right: 16, left: 4, bottom: 4 }}
+        >
+          <CartesianGrid
+            stroke="var(--border)"
+            strokeDasharray="3 3"
+            horizontal={false}
+          />
+          <XAxis
+            type="number"
+            tick={{ fill: MUTED, fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={formatCostAxis}
+          />
+          <YAxis
+            type="category"
+            dataKey="label"
+            tick={{ fill: MUTED, fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            width={132}
+          />
+          <Tooltip
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              const row = payload[0]?.payload as ActionCostPoint | undefined;
+              return (
+                <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
+                  <p className="font-medium">{label}</p>
+                  <p className="tabular-nums text-muted-foreground">
+                    {formatInt(row?.calls ?? 0)} calls · {formatCost(row?.cost ?? 0)}
+                  </p>
+                </div>
+              );
+            }}
+          />
+          <Bar
+            dataKey="cost"
+            name="Cost"
+            radius={[0, 4, 4, 0]}
+            maxBarSize={18}
+          >
+            {data.map((row) => (
+              <Cell
+                key={row.action}
+                fill={row.featured ? CHART_1 : hasCost ? CHART_2 : CHART_1}
+              />
+            ))}
+          </Bar>
+        </RechartsBarChart>
       </ResponsiveContainer>
     </div>
   );

--- a/src/components/admin/writing-assist-cost-grid.tsx
+++ b/src/components/admin/writing-assist-cost-grid.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { motionProgressIndicator } from "@/lib/motion/classes";
+import type { ActionCostPoint } from "@/lib/admin/usage-chart-data";
+import { formatCost, formatInt } from "@/lib/admin/usage-formatters";
+
+export function WritingAssistCostGrid({
+  points,
+}: {
+  points: ActionCostPoint[];
+}) {
+  const featured = points.filter((row) => row.featured);
+  const maxCost = Math.max(...featured.map((row) => row.cost), 0);
+
+  return (
+    <ul
+      className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"
+      aria-label="Writing assist estimated cost"
+    >
+      {featured.map((row) => {
+        const share = maxCost > 0 ? row.cost / maxCost : 0;
+        return (
+          <li
+            key={row.action}
+            className="rounded-lg border border-border/80 bg-muted/20 p-3"
+          >
+            <p className="text-sm font-medium">{row.label}</p>
+            <p className="mt-1 text-lg font-semibold tabular-nums tracking-tight">
+              {formatCost(row.cost)}
+            </p>
+            <p className="text-xs text-muted-foreground tabular-nums">
+              {formatInt(row.calls)} {row.calls === 1 ? "call" : "calls"}
+            </p>
+            <div
+              className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted"
+              aria-hidden="true"
+            >
+              <div
+                className={cn(
+                  "h-full w-full origin-left rounded-full bg-chart-1",
+                  motionProgressIndicator,
+                )}
+                style={{ transform: `scaleX(${share})` }}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/generate/custom-context-workspace.tsx
+++ b/src/components/generate/custom-context-workspace.tsx
@@ -1060,7 +1060,7 @@ export function CustomContextWorkspace({
   // Synonym lookup - needs word, full statement context, and model
   const synonymLookup = async (word: string, fullStatement: string): Promise<string[]> => {
     try {
-      const response = await billableFetch("/api/synonyms", {
+      const response = await fetchWithRetry("/api/synonyms", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ word, fullStatement, model }),

--- a/src/components/word-thesaurus/word-thesaurus-popup.tsx
+++ b/src/components/word-thesaurus/word-thesaurus-popup.tsx
@@ -2,6 +2,7 @@
 
 import { BookA, Loader2, Maximize2, Minimize2, RefreshCw, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TokenCostBadge } from "@/components/billing/token-cost-badge";
 import {
   motionChip,
   motionCollapseGrid,
@@ -292,6 +293,7 @@ function PhraseButton({
     >
       {disabled ? <Loader2 className="size-3 animate-spin" /> : <Icon className="size-3" />}
       {label}
+      <TokenCostBadge compact className="ml-0.5" />
     </button>
   );
 }

--- a/src/lib/__tests__/billable-api.test.ts
+++ b/src/lib/__tests__/billable-api.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BILLABLE_API_PATHS,
+  isBillableApiRequest,
+  maybeOptimisticConsume,
+} from "../billable-api";
+
+const { applyOptimisticConsume } = vi.hoisted(() => ({
+  applyOptimisticConsume: vi.fn(),
+}));
+
+vi.mock("@/stores/credits-store", () => ({
+  useCreditsStore: {
+    getState: () => ({
+      applyOptimisticConsume,
+      fetchCredits: vi.fn(),
+    }),
+  },
+}));
+
+describe("billable API paths", () => {
+  it("does not treat synonym suggestions as a credit charge", () => {
+    expect(BILLABLE_API_PATHS).not.toContain("/api/synonyms");
+    expect(isBillableApiRequest("/api/synonyms", "POST")).toBe(false);
+    expect(isBillableApiRequest("/api/dictionary-synonyms", "GET")).toBe(false);
+  });
+
+  it("still charges expand / compress / rephrase via revise-selection", () => {
+    expect(BILLABLE_API_PATHS).toContain("/api/revise-selection");
+    expect(isBillableApiRequest("/api/revise-selection", "POST")).toBe(true);
+    expect(isBillableApiRequest("/api/revise-selection", "GET")).toBe(false);
+  });
+
+  it("does not optimistic-consume on synonym POSTs", () => {
+    applyOptimisticConsume.mockClear();
+    maybeOptimisticConsume("/api/synonyms", "POST");
+    expect(applyOptimisticConsume).not.toHaveBeenCalled();
+
+    maybeOptimisticConsume("/api/revise-selection", "POST");
+    expect(applyOptimisticConsume).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/__tests__/revise-tracking.test.ts
+++ b/src/lib/__tests__/revise-tracking.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { reviseTrackingAction, withTrackingAction } from "../revise-tracking";
+
+describe("reviseTrackingAction", () => {
+  it("maps expand / compress / rephrase without changing credit action names", () => {
+    expect(reviseTrackingAction("expand")).toBe("revise_expand");
+    expect(reviseTrackingAction("compress")).toBe("revise_compress");
+    expect(reviseTrackingAction("general")).toBe("revise_rephrase");
+    expect(reviseTrackingAction(undefined)).toBe("revise_rephrase");
+  });
+});
+
+describe("withTrackingAction", () => {
+  it("overrides the telemetry action while keeping the rest of the context", () => {
+    const next = withTrackingAction(
+      { subjectId: "user-1", action: "revise_selection", usingDefaultKey: true },
+      "revise_expand",
+    );
+    expect(next).toEqual({
+      subjectId: "user-1",
+      action: "revise_expand",
+      usingDefaultKey: true,
+    });
+  });
+
+  it("passes through missing tracking", () => {
+    expect(withTrackingAction(undefined, "revise_expand")).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/synonyms-billing-contract.test.ts
+++ b/src/lib/__tests__/synonyms-billing-contract.test.ts
@@ -33,5 +33,7 @@ describe("synonym vs phrase-revise billing contract", () => {
     expect(consumeCalls).toHaveLength(REVISE_SELECTION_USAGE_CHECKS_PER_REQUEST);
     expect(src).toContain("revise_selection");
     expect(src).toContain("handleBillableLLMError");
+    expect(src).toContain("reviseTrackingAction");
+    expect(src).toContain("withTrackingAction");
   });
 });

--- a/src/lib/__tests__/synonyms-billing-contract.test.ts
+++ b/src/lib/__tests__/synonyms-billing-contract.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  REVISE_SELECTION_USAGE_CHECKS_PER_REQUEST,
+  SYNONYMS_CONSUME_CREDIT,
+} from "../synonyms-billing-contract";
+
+describe("synonym vs phrase-revise billing contract", () => {
+  it("marks synonym suggestions as unbilled", () => {
+    expect(SYNONYMS_CONSUME_CREDIT).toBe(false);
+  });
+
+  it("keeps the synonyms route off consume_credit", () => {
+    const src = readFileSync(
+      resolve(process.cwd(), "src/app/api/synonyms/route.ts"),
+      "utf8",
+    );
+
+    expect(src).toContain("allowUnbilledLlmUsage");
+    expect(src).not.toContain("checkAndTrackUsage");
+    expect(src).not.toContain("handleBillableLLMError");
+    expect(src).not.toContain("consume_credit");
+  });
+
+  it("keeps expand / compress / rephrase on a single credit consume", () => {
+    const src = readFileSync(
+      resolve(process.cwd(), "src/app/api/revise-selection/route.ts"),
+      "utf8",
+    );
+
+    const consumeCalls = src.match(/checkAndTrackUsage\(/g) ?? [];
+    expect(consumeCalls).toHaveLength(REVISE_SELECTION_USAGE_CHECKS_PER_REQUEST);
+    expect(src).toContain("revise_selection");
+    expect(src).toContain("handleBillableLLMError");
+  });
+});

--- a/src/lib/__tests__/usage-chart-data.test.ts
+++ b/src/lib/__tests__/usage-chart-data.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildActionCostSeries } from "../admin/usage-chart-data";
+
+describe("buildActionCostSeries", () => {
+  it("always includes synonym and phrase-revise rows even at zero", () => {
+    const series = buildActionCostSeries([
+      { action_type: "generate", calls: 10, estimated_cost_usd: 1.25 },
+    ]);
+
+    expect(series.map((row) => row.action)).toEqual([
+      "synonyms",
+      "revise_expand",
+      "revise_compress",
+      "revise_rephrase",
+      "generate",
+    ]);
+    expect(series[0]).toMatchObject({
+      label: "Synonym suggestions",
+      calls: 0,
+      cost: 0,
+      featured: true,
+    });
+    expect(series.at(-1)).toMatchObject({
+      action: "generate",
+      cost: 1.25,
+      featured: false,
+    });
+  });
+
+  it("uses recorded synonym and expand costs", () => {
+    const series = buildActionCostSeries([
+      { action_type: "synonyms", calls: 8, estimated_cost_usd: 0.012 },
+      { action_type: "revise_expand", calls: 2, estimated_cost_usd: 0.04 },
+      { action_type: "revise_selection", calls: 3, estimated_cost_usd: 0.09 },
+    ]);
+
+    const byAction = Object.fromEntries(series.map((row) => [row.action, row]));
+    expect(byAction.synonyms).toMatchObject({ calls: 8, cost: 0.012, featured: true });
+    expect(byAction.revise_expand).toMatchObject({ calls: 2, cost: 0.04, featured: true });
+    expect(byAction.revise_selection).toMatchObject({
+      label: "Phrase revise",
+      calls: 3,
+      cost: 0.09,
+      featured: false,
+    });
+  });
+});

--- a/src/lib/__tests__/usage-formatters.test.ts
+++ b/src/lib/__tests__/usage-formatters.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatUsageActionLabel,
+  isWritingAssistAction,
+  WRITING_ASSIST_ACTIONS,
+} from "../admin/usage-formatters";
+
+describe("formatUsageActionLabel", () => {
+  it("labels synonym and phrase-revise tracking actions", () => {
+    expect(formatUsageActionLabel("synonyms")).toBe("Synonym suggestions");
+    expect(formatUsageActionLabel("revise_expand")).toBe("Expand");
+    expect(formatUsageActionLabel("revise_compress")).toBe("Compress");
+    expect(formatUsageActionLabel("revise_rephrase")).toBe("Rephrase");
+    expect(formatUsageActionLabel("revise_selection")).toBe("Phrase revise");
+  });
+
+  it("title-cases unknown actions", () => {
+    expect(formatUsageActionLabel("custom_widget")).toBe("Custom Widget");
+  });
+});
+
+describe("writing assist actions", () => {
+  it("pins synonym plus expand / compress / rephrase", () => {
+    expect([...WRITING_ASSIST_ACTIONS]).toEqual([
+      "synonyms",
+      "revise_expand",
+      "revise_compress",
+      "revise_rephrase",
+    ]);
+    expect(isWritingAssistAction("synonyms")).toBe(true);
+    expect(isWritingAssistAction("generate")).toBe(false);
+  });
+});

--- a/src/lib/__tests__/usage-tracker.test.ts
+++ b/src/lib/__tests__/usage-tracker.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { checkAndTrackUsage } from "../usage-tracker";
+import { allowUnbilledLlmUsage, checkAndTrackUsage } from "../usage-tracker";
 
 const mockRpc = vi.fn();
 
@@ -74,7 +74,7 @@ describe("checkAndTrackUsage", () => {
 
     const result = await checkAndTrackUsage(
       "user-1",
-      "synonyms",
+      "generate",
       "gemini-2.5-flash-lite",
       null,
     );
@@ -106,6 +106,60 @@ describe("checkAndTrackUsage", () => {
         p_user_id: "user-1",
         p_action_type: "generate",
       }),
+    );
+  });
+});
+
+describe("allowUnbilledLlmUsage", () => {
+  beforeEach(() => {
+    mockRpc.mockReset();
+  });
+
+  it("does not consume a credit for default-key users", async () => {
+    const result = await allowUnbilledLlmUsage(
+      "user-1",
+      "synonyms",
+      "gemini-2.5-flash-lite",
+      null,
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.usingDefaultKey).toBe(true);
+    expect(result.insufficientCredits).toBeFalsy();
+    expect(result.creditsRemaining).toBeUndefined();
+    expect(result.tracking).toEqual({
+      subjectId: "user-1",
+      action: "synonyms",
+      usingDefaultKey: true,
+    });
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("still burst-limits BYOK users without consuming credits", async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: 1,
+      error: null,
+    });
+
+    const result = await allowUnbilledLlmUsage(
+      "user-1",
+      "synonyms",
+      "gpt-4o",
+      { openai_key: "sk-test" },
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.usingDefaultKey).toBe(false);
+    expect(mockRpc).toHaveBeenCalledWith(
+      "check_and_record_usage",
+      expect.objectContaining({
+        p_user_id: "user-1",
+        p_action_type: "synonyms",
+      }),
+    );
+    expect(mockRpc).not.toHaveBeenCalledWith(
+      "consume_credit",
+      expect.anything(),
     );
   });
 });

--- a/src/lib/admin/usage-chart-data.ts
+++ b/src/lib/admin/usage-chart-data.ts
@@ -1,3 +1,8 @@
+import {
+  formatUsageActionLabel,
+  WRITING_ASSIST_ACTIONS,
+} from "@/lib/admin/usage-formatters";
+
 export interface DayCostRow {
   day: string;
   calls: number;
@@ -22,6 +27,14 @@ export interface ByokModelPoint {
   model: string;
   calls: number;
   users: number;
+}
+
+export interface ActionCostPoint {
+  action: string;
+  label: string;
+  calls: number;
+  cost: number;
+  featured: boolean;
 }
 
 function formatDayLabel(day: string): string {
@@ -150,4 +163,51 @@ export function buildByokModelSeries(
       calls: row.calls,
       users: row.unique_users,
     }));
+}
+
+function toActionPoint(
+  action: string,
+  calls: number,
+  cost: number,
+  featured: boolean,
+): ActionCostPoint {
+  return {
+    action,
+    label: formatUsageActionLabel(action),
+    calls,
+    cost,
+    featured,
+  };
+}
+
+/**
+ * Cost series for the admin usage page.
+ * Writing-assist actions (synonyms, expand, compress, rephrase) always appear,
+ * even at zero, so ops can see those features in the estimated-cost visual.
+ */
+export function buildActionCostSeries(
+  byAction: { action_type: string; calls: number; estimated_cost_usd: number }[],
+): ActionCostPoint[] {
+  const totals = new Map<string, { calls: number; cost: number }>();
+  for (const row of byAction) {
+    const action = row.action_type || "unknown";
+    const previous = totals.get(action) ?? { calls: 0, cost: 0 };
+    totals.set(action, {
+      calls: previous.calls + Number(row.calls ?? 0),
+      cost: previous.cost + Number(row.estimated_cost_usd ?? 0),
+    });
+  }
+
+  const featured = WRITING_ASSIST_ACTIONS.map((action) => {
+    const row = totals.get(action);
+    totals.delete(action);
+    return toActionPoint(action, row?.calls ?? 0, row?.cost ?? 0, true);
+  });
+
+  const rest = [...totals.entries()]
+    .filter(([, row]) => row.calls > 0 || row.cost > 0)
+    .sort((a, b) => b[1].cost - a[1].cost || b[1].calls - a[1].calls)
+    .map(([action, row]) => toActionPoint(action, row.calls, row.cost, false));
+
+  return [...featured, ...rest];
 }

--- a/src/lib/admin/usage-formatters.ts
+++ b/src/lib/admin/usage-formatters.ts
@@ -22,6 +22,57 @@ export function formatCost(value: number): string {
   }).format(amount);
 }
 
+const ACTION_LABELS: Record<string, string> = {
+  synonyms: "Synonym suggestions",
+  revise_expand: "Expand",
+  revise_compress: "Compress",
+  revise_rephrase: "Rephrase",
+  revise_selection: "Phrase revise",
+  generate: "Generate statements",
+  plan_epb: "Plan EPB",
+  generate_war: "Generate WAR",
+  generate_award: "Generate award",
+  generate_decoration: "Generate decoration",
+  generate_slot_statement: "Slot statement",
+  assess_epb: "Assess EPB",
+  assess_accomplishment: "Assess accomplishment",
+  assess_accomplishment_preview: "Accomplishment preview",
+  generate_feedback_talking_points: "Feedback talking points",
+  generate_feedback_session_guide: "Session guide",
+  revise_feedback_session_guide: "Revise session guide",
+  parse_bulk_statements: "Parse bulk statements",
+  extract_accomplishments: "Extract accomplishments",
+  adapt_sentence: "Adapt sentence",
+  combine: "Combine",
+  combine_statements: "Combine statements",
+  convert_sentences: "Convert sentences",
+  feedback_apply: "Apply feedback",
+};
+
+/** Always-visible writing-assist rows on /admin/usage (even at zero). */
+export const WRITING_ASSIST_ACTIONS = [
+  "synonyms",
+  "revise_expand",
+  "revise_compress",
+  "revise_rephrase",
+] as const;
+
+export type WritingAssistAction = (typeof WRITING_ASSIST_ACTIONS)[number];
+
+export function formatUsageActionLabel(actionType: string): string {
+  const known = ACTION_LABELS[actionType];
+  if (known) return known;
+  return actionType
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function isWritingAssistAction(actionType: string): boolean {
+  return (WRITING_ASSIST_ACTIONS as readonly string[]).includes(actionType);
+}
+
 export function projectedMonthlyCost(
   costInWindow: number,
   days: number,

--- a/src/lib/billable-api.ts
+++ b/src/lib/billable-api.ts
@@ -1,6 +1,7 @@
 import { useCreditsStore } from "@/stores/credits-store";
 
 /** POST endpoints that consume a prepaid AI call (default-key users). */
+/** `/api/synonyms` is intentionally omitted — word replacement suggestions are free. */
 export const BILLABLE_API_PATHS = [
   "/api/generate",
   "/api/plan-epb",
@@ -17,7 +18,6 @@ export const BILLABLE_API_PATHS = [
   "/api/parse-bulk-statements",
   "/api/extract-accomplishments",
   "/api/adapt-sentence",
-  "/api/synonyms",
   "/api/combine",
   "/api/combine-statements",
   "/api/convert-sentences",

--- a/src/lib/revise-tracking.ts
+++ b/src/lib/revise-tracking.ts
@@ -1,0 +1,24 @@
+import type { TokenTrackingContext } from "@/lib/ai-models/token-usage";
+import type { PhraseReviseMode } from "@/lib/word-thesaurus";
+
+/** Token-usage action for expand / compress / rephrase (credits still use revise_selection). */
+export type ReviseTrackingAction =
+  | "revise_expand"
+  | "revise_compress"
+  | "revise_rephrase";
+
+export function reviseTrackingAction(
+  mode: PhraseReviseMode | string | undefined,
+): ReviseTrackingAction {
+  if (mode === "expand") return "revise_expand";
+  if (mode === "compress") return "revise_compress";
+  return "revise_rephrase";
+}
+
+export function withTrackingAction(
+  tracking: TokenTrackingContext | undefined,
+  action: string,
+): TokenTrackingContext | undefined {
+  if (!tracking) return tracking;
+  return { ...tracking, action };
+}

--- a/src/lib/synonyms-billing-contract.ts
+++ b/src/lib/synonyms-billing-contract.ts
@@ -1,0 +1,11 @@
+/**
+ * Product billing contract for highlight-word replacement suggestions:
+ * POST /api/synonyms is a free LLM assist. Expand / compress / rephrase
+ * still consume one prepaid credit each via POST /api/revise-selection.
+ */
+
+/** Synonym suggestions must never call consume_credit. */
+export const SYNONYMS_CONSUME_CREDIT = false as const;
+
+/** Phrase expand / compress / rephrase still consume one credit per successful click. */
+export const REVISE_SELECTION_USAGE_CHECKS_PER_REQUEST = 1 as const;

--- a/src/lib/usage-tracker.ts
+++ b/src/lib/usage-tracker.ts
@@ -80,41 +80,7 @@ export async function checkAndTrackUsage(
   };
 
   if (!usingDefault) {
-    const { data: countAfter, error } = await (supabase.rpc as Function)(
-      "check_and_record_usage",
-      {
-        p_user_id: userId,
-        p_action_type: action,
-        p_model_id: effectiveModel,
-        p_provider: provider,
-      },
-    ) as { data: number | null; error: { message: string } | null };
-
-    if (error) {
-      console.error("[usage-tracker] BYOK RPC error:", error.message);
-      return {
-        allowed: false,
-        usingDefaultKey: false,
-        effectiveModel,
-        serviceError: true,
-      };
-    }
-
-    if (countAfter === -1) {
-      return {
-        allowed: false,
-        usingDefaultKey: false,
-        effectiveModel,
-        rateLimited: true,
-      };
-    }
-
-    return {
-      allowed: true,
-      usingDefaultKey: false,
-      effectiveModel,
-      tracking,
-    };
+    return recordByokUsage(supabase, userId, action, effectiveModel, provider, tracking);
   }
 
   const { data: balanceAfter, error } = await (supabase.rpc as Function)(
@@ -165,6 +131,86 @@ export async function checkAndTrackUsage(
     effectiveModel,
     creditsRemaining: result,
     creditsBalance: result,
+    tracking,
+  };
+}
+
+/**
+ * Allow an authenticated LLM call without consuming a prepaid credit.
+ *
+ * Default-key users skip `consume_credit` (and therefore never get 402).
+ * BYOK users still hit the burst limiter via `check_and_record_usage`.
+ * Token-usage telemetry is recorded either way.
+ */
+export async function allowUnbilledLlmUsage(
+  userId: string,
+  action: BillableAction,
+  modelId: string,
+  userKeys: Partial<DecryptedApiKeys> | null,
+): Promise<UsageCheckResult> {
+  const usingDefault = isUsingDefaultKey(modelId, userKeys);
+  const effectiveModel = usingDefault ? DEFAULT_KEY_MODEL : modelId;
+  const provider = detectProvider(effectiveModel);
+  const tracking: TokenTrackingContext = {
+    subjectId: userId,
+    action,
+    usingDefaultKey: usingDefault,
+  };
+
+  if (!usingDefault) {
+    const supabase = await createClient();
+    return recordByokUsage(supabase, userId, action, effectiveModel, provider, tracking);
+  }
+
+  return {
+    allowed: true,
+    usingDefaultKey: true,
+    effectiveModel,
+    tracking,
+  };
+}
+
+async function recordByokUsage(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  action: BillableAction,
+  effectiveModel: string,
+  provider: ReturnType<typeof detectProvider>,
+  tracking: TokenTrackingContext,
+): Promise<UsageCheckResult> {
+  const { data: countAfter, error } = await (supabase.rpc as Function)(
+    "check_and_record_usage",
+    {
+      p_user_id: userId,
+      p_action_type: action,
+      p_model_id: effectiveModel,
+      p_provider: provider,
+    },
+  ) as { data: number | null; error: { message: string } | null };
+
+  if (error) {
+    console.error("[usage-tracker] BYOK RPC error:", error.message);
+    return {
+      allowed: false,
+      usingDefaultKey: false,
+      effectiveModel,
+      serviceError: true,
+    };
+  }
+
+  if (countAfter === -1) {
+    return {
+      allowed: false,
+      usingDefaultKey: false,
+      effectiveModel,
+      rateLimited: true,
+    };
+  }
+
+  return {
+    allowed: true,
+    usingDefaultKey: false,
+    effectiveModel,
     tracking,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Word-highlight replacement suggestions no longer consume a prepaid credit. Expand, compress, and rephrase still charge one credit per successful generation. `/admin/usage` now shows those writing-assist calls with estimated app-key cost.

## Billing
- `POST /api/synonyms` uses `allowUnbilledLlmUsage` instead of `consume_credit`
- Removed `/api/synonyms` from `BILLABLE_API_PATHS` so the sidebar no longer optimistic-decrements
- Expand / Compress / Rephrase still go through `POST /api/revise-selection` (1 credit)

## Admin usage
- Token telemetry for phrase revise is split into `revise_expand` / `revise_compress` / `revise_rephrase` (credits still consume `revise_selection`)
- `/admin/usage` always shows Synonym suggestions, Expand, Compress, and Rephrase with estimated USD cost, plus a by-feature cost chart

## Assumption
Phrase revise already charged on HTTP 200. Historical phrase-revise rows stay labeled “Phrase revise” until new mode-tagged calls land.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f76045ce-777b-427c-95c9-f4c7c6d57f77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f76045ce-777b-427c-95c9-f4c7c6d57f77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

