### PR TITLE
Allow email logo PNG in inboxes without a forced refresh

### DIFF
--- a/.preserve-app-build-id
+++ b/.preserve-app-build-id
@@ -1,0 +1,3 @@
+# Delete this file before the next deploy that should show "Update required".
+# Pins /api/version to the buildId already in production clients.
+79413510223b20bf

--- a/next.config.ts
+++ b/next.config.ts
@@ -105,6 +105,45 @@ const nextConfig: NextConfig = {
         source: "/:path*",
         headers: securityHeaders,
       },
+      // Email clients (Outlook, Apple Mail) and some image proxies load
+      // remote <img> as a cross-origin subresource. CORP: same-origin
+      // makes the PNG 200 in a browser tab and invisible in the inbox.
+      {
+        source: "/:path*.png",
+        headers: [
+          { key: "Cross-Origin-Resource-Policy", value: "cross-origin" },
+        ],
+      },
+      {
+        source: "/:path*.jpg",
+        headers: [
+          { key: "Cross-Origin-Resource-Policy", value: "cross-origin" },
+        ],
+      },
+      {
+        source: "/:path*.jpeg",
+        headers: [
+          { key: "Cross-Origin-Resource-Policy", value: "cross-origin" },
+        ],
+      },
+      {
+        source: "/:path*.gif",
+        headers: [
+          { key: "Cross-Origin-Resource-Policy", value: "cross-origin" },
+        ],
+      },
+      {
+        source: "/:path*.webp",
+        headers: [
+          { key: "Cross-Origin-Resource-Policy", value: "cross-origin" },
+        ],
+      },
+      {
+        source: "/:path*.ico",
+        headers: [
+          { key: "Cross-Origin-Resource-Policy", value: "cross-origin" },
+        ],
+      },
     ];
   },
 };

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -20,12 +20,30 @@ function getGitCommitHash() {
   }
 }
 
+function readPinnedBuildId() {
+  const fromEnv = (process.env.PIN_APP_BUILD_ID || "").trim();
+  if (/^[a-f0-9]{16}$/i.test(fromEnv)) return fromEnv.toLowerCase();
+
+  const pinFilePath = path.join(process.cwd(), ".preserve-app-build-id");
+  if (!fs.existsSync(pinFilePath)) return null;
+
+  const line = fs
+    .readFileSync(pinFilePath, "utf8")
+    .split("\n")
+    .map((entry) => entry.trim())
+    .find((entry) => entry && !entry.startsWith("#"));
+
+  if (line && /^[a-f0-9]{16}$/i.test(line)) return line.toLowerCase();
+  return null;
+}
+
 function generateVersion() {
   const packageJsonPath = path.join(process.cwd(), "package.json");
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
   
   const now = new Date();
-  const buildId = crypto.randomBytes(8).toString("hex");
+  const pinnedBuildId = readPinnedBuildId();
+  const buildId = pinnedBuildId || crypto.randomBytes(8).toString("hex");
   const commitHash = getGitCommitHash();
   
   const versionInfo = {
@@ -55,7 +73,9 @@ function generateVersion() {
   
   console.log("✓ Generated version.json:");
   console.log(`  Version: ${versionInfo.version}`);
-  console.log(`  Build ID: ${versionInfo.buildId}`);
+  console.log(
+    `  Build ID: ${versionInfo.buildId}${pinnedBuildId ? " (pinned)" : ""}`
+  );
   console.log(`  Build Time: ${versionInfo.buildTime}`);
   if (commitHash) {
     console.log(`  Commit: ${commitHash}`);

--- a/src/lib/app-build-id.ts
+++ b/src/lib/app-build-id.ts
@@ -1,2 +1,2 @@
 /** Generated at build time — do not edit. */
-export const APP_BUILD_ID = "f4d0baaaacd06bf8";
+export const APP_BUILD_ID = "79413510223b20bf";


### PR DESCRIPTION
## Summary
- Set `Cross-Origin-Resource-Policy: cross-origin` on static images so Gmail/Outlook can display `icon-email.png`.
- Pin `/api/version` to the live production `buildId` (`79413510223b20bf`) so this deploy does not show Update required.

## Test plan
- [ ] `https://www.myepbuddy.com/icon-email.png` response includes `cross-origin-resource-policy: cross-origin`
- [ ] `https://www.myepbuddy.com/api/version` still returns `"buildId":"79413510223b20bf"`
- [ ] Open app sessions do not get the blocking update dialog
- [ ] Resend test send shows the logo (use `?v=2` if Gmail cached the earlier 404)


Made with [Cursor](https://cursor.com)