### PR TITLE
Use a full-access Resend key for contact opt-out

### DIFF
--- a/env.example
+++ b/env.example
@@ -9,7 +9,11 @@ NEXT_PUBLIC_SITE_URL=https://myepbuddy.com
 
 # Transactional email (Resend) — review share links, mentor-feedback alerts, invites, admin replies
 # From address must be on a domain verified in Resend.
-RESEND_API_KEY=re_your_resend_api_key
+# Sending-access key is enough for POST /emails. Do not use it for Contacts.
+RESEND_API_KEY=re_your_resend_sending_api_key
+# Full-access key for Broadcast contact sync (Settings opt-out / onboarding).
+# Sending-access keys return 401 restricted_api_key on PATCH /contacts.
+RESEND_CONTACTS_API_KEY=re_your_resend_full_access_contacts_key
 EMAIL_FROM=MyEPBuddy <noreply@your-verified-domain.com>
 # Optional fallbacks / product-specific addresses:
 # FEEDBACK_FROM_EMAIL=MyEPBuddy <noreply@your-verified-domain.com>

--- a/src/lib/email/__tests__/resend-contacts.test.ts
+++ b/src/lib/email/__tests__/resend-contacts.test.ts
@@ -12,6 +12,7 @@ describe("isMilEmail", () => {
 
 describe("syncResendMarketingContact", () => {
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -20,7 +21,7 @@ describe("syncResendMarketingContact", () => {
     const result = await syncResendMarketingContact({
       email: "a@gmail.com",
       optedIn: false,
-      resendApiKey: null,
+      resendContactsApiKey: null,
     });
     expect(result).toEqual({ status: "skipped", reason: "no_key" });
   });
@@ -29,7 +30,7 @@ describe("syncResendMarketingContact", () => {
     const result = await syncResendMarketingContact({
       email: "a@us.af.mil",
       optedIn: true,
-      resendApiKey: "re_test",
+      resendContactsApiKey: "re_contacts_test",
     });
     expect(result).toEqual({ status: "skipped", reason: "mil" });
   });
@@ -45,7 +46,7 @@ describe("syncResendMarketingContact", () => {
     const result = await syncResendMarketingContact({
       email: "Airman@Gmail.com",
       optedIn: false,
-      resendApiKey: "re_test",
+      resendContactsApiKey: "re_contacts_test",
     });
 
     expect(result).toEqual({ status: "synced" });
@@ -53,6 +54,9 @@ describe("syncResendMarketingContact", () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://api.resend.com/contacts/airman%40gmail.com");
     expect(init.method).toBe("PATCH");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer re_contacts_test"
+    );
     expect(JSON.parse(String(init.body))).toEqual({ unsubscribed: true });
   });
 
@@ -74,7 +78,7 @@ describe("syncResendMarketingContact", () => {
     const result = await syncResendMarketingContact({
       email: "new@gmail.com",
       optedIn: true,
-      resendApiKey: "re_test",
+      resendContactsApiKey: "re_contacts_test",
     });
 
     expect(result).toEqual({ status: "synced" });
@@ -98,7 +102,41 @@ describe("syncResendMarketingContact", () => {
       syncResendMarketingContact({
         email: "a@gmail.com",
         optedIn: false,
-        resendApiKey: "re_test",
+        resendContactsApiKey: "re_contacts_test",
+      })
+    ).rejects.toBeInstanceOf(ResendSendError);
+  });
+
+  it("uses RESEND_CONTACTS_API_KEY instead of the sending key", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_sending_only");
+    vi.stubEnv("RESEND_CONTACTS_API_KEY", "re_full_contacts");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => "{}",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncResendMarketingContact({
+      email: "a@gmail.com",
+      optedIn: false,
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer re_full_contacts"
+    );
+  });
+
+  it("throws in production when the contacts key is missing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("RESEND_API_KEY", "re_sending_only");
+    vi.stubEnv("RESEND_CONTACTS_API_KEY", "");
+
+    await expect(
+      syncResendMarketingContact({
+        email: "a@gmail.com",
+        optedIn: false,
       })
     ).rejects.toBeInstanceOf(ResendSendError);
   });

--- a/src/lib/email/resend-contacts.ts
+++ b/src/lib/email/resend-contacts.ts
@@ -1,4 +1,8 @@
-import { getResendApiKey, ResendSendError } from "@/lib/email/resend";
+import {
+  getResendApiKey,
+  getResendContactsApiKey,
+  ResendSendError,
+} from "@/lib/email/resend";
 
 const CONTACTS_URL = "https://api.resend.com/contacts";
 
@@ -20,7 +24,7 @@ export type SyncResendMarketingContactResult =
 export async function syncResendMarketingContact(params: {
   email: string | null | undefined;
   optedIn: boolean;
-  resendApiKey?: string | null;
+  resendContactsApiKey?: string | null;
 }): Promise<SyncResendMarketingContactResult> {
   const email = params.email?.trim().toLowerCase() ?? "";
   if (!email || !email.includes("@")) {
@@ -30,8 +34,17 @@ export async function syncResendMarketingContact(params: {
     return { status: "skipped", reason: "mil" };
   }
 
-  const resendApiKey = params.resendApiKey ?? getResendApiKey();
+  const resendApiKey =
+    params.resendContactsApiKey !== undefined
+      ? params.resendContactsApiKey
+      : getResendContactsApiKey();
   if (!resendApiKey) {
+    if (process.env.NODE_ENV === "production" && getResendApiKey()) {
+      throw new ResendSendError(
+        401,
+        "RESEND_CONTACTS_API_KEY is required to update Broadcast contacts"
+      );
+    }
     return { status: "skipped", reason: "no_key" };
   }
 

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -80,3 +80,11 @@ export function getTransactionalFromEmail(): string | null {
 export function getResendApiKey(): string | null {
   return normalizeEnvSecret(process.env.RESEND_API_KEY);
 }
+
+/**
+ * Full-access key for Contacts (Broadcast unsub). Sending-access keys
+ * return 401 restricted_api_key on PATCH /contacts.
+ */
+export function getResendContactsApiKey(): string | null {
+  return normalizeEnvSecret(process.env.RESEND_CONTACTS_API_KEY);
+}


### PR DESCRIPTION
## Summary
- Settings and onboarding sync Broadcast contacts with `RESEND_CONTACTS_API_KEY` (full access).
- Sending-access `RESEND_API_KEY` is no longer used for PATCH /contacts (that 401ed as restricted_api_key).

## Test plan
- [ ] Toggle Email preferences in production after deploy — no 401 in Resend
- [ ] Invites/transactional mail still send with the sending key
- [ ] Matt opt-out and Maria opt-in are applied in profiles + Resend


Made with [Cursor](https://cursor.com)