### PR TITLE
Create Resend contacts first and sync list events via webhook

### DIFF
--- a/env.example
+++ b/env.example
@@ -12,8 +12,12 @@ NEXT_PUBLIC_SITE_URL=https://myepbuddy.com
 # Sending-access key is enough for POST /emails. Do not use it for Contacts.
 RESEND_API_KEY=re_your_resend_sending_api_key
 # Full-access key for Broadcast contact sync (Settings opt-out / onboarding).
-# Sending-access keys return 401 restricted_api_key on PATCH /contacts.
+# Sending-access keys return 401 restricted_api_key on POST/PATCH /contacts.
 RESEND_CONTACTS_API_KEY=re_your_resend_full_access_contacts_key
+# Svix signing secret from the webhook details page. Register:
+#   POST https://myepbuddy.com/api/webhooks/resend
+# Events: contact.updated, contact.created, email.bounced, email.complained
+RESEND_WEBHOOK_SECRET=whsec_your_resend_webhook_signing_secret
 EMAIL_FROM=MyEPBuddy <noreply@your-verified-domain.com>
 # Optional fallbacks / product-specific addresses:
 # FEEDBACK_FROM_EMAIL=MyEPBuddy <noreply@your-verified-domain.com>

--- a/env.example
+++ b/env.example
@@ -15,7 +15,8 @@ RESEND_API_KEY=re_your_resend_sending_api_key
 # Sending-access keys return 401 restricted_api_key on POST/PATCH /contacts.
 RESEND_CONTACTS_API_KEY=re_your_resend_full_access_contacts_key
 # Svix signing secret from the webhook details page. Register:
-#   POST https://myepbuddy.com/api/webhooks/resend
+#   POST https://www.myepbuddy.com/api/webhooks/resend
+#   (must be www — apex 307s to www and Resend will not deliver the POST)
 # Events: contact.updated, contact.created, email.bounced, email.complained
 RESEND_WEBHOOK_SECRET=whsec_your_resend_webhook_signing_secret
 EMAIL_FROM=MyEPBuddy <noreply@your-verified-domain.com>

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getResendWebhookSecret } from "@/lib/email/resend";
+import {
+  applyResendListAction,
+  interpretResendWebhookEvent,
+  parseResendWebhookEvent,
+  verifyResendWebhookSignature,
+} from "@/lib/email/resend-webhook";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Resend → MyEPBuddy list sync.
+ * Dashboard URL to register: https://myepbuddy.com/api/webhooks/resend
+ * Events: contact.updated, contact.created, email.bounced, email.complained
+ */
+export async function POST(request: NextRequest) {
+  const secret = getResendWebhookSecret();
+  if (!secret) {
+    console.error("[webhooks/resend] RESEND_WEBHOOK_SECRET is not configured");
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 503 });
+  }
+
+  const id = request.headers.get("svix-id");
+  const timestamp = request.headers.get("svix-timestamp");
+  const signature = request.headers.get("svix-signature");
+  if (!id || !timestamp || !signature) {
+    return NextResponse.json({ error: "Missing signature headers" }, { status: 400 });
+  }
+
+  const payload = await request.text();
+  try {
+    verifyResendWebhookSignature({
+      payload,
+      id,
+      timestamp,
+      signatureHeader: signature,
+      secret,
+    });
+  } catch (error) {
+    console.error("[webhooks/resend] Signature verification failed:", error);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  let event;
+  try {
+    event = parseResendWebhookEvent(payload);
+  } catch {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  try {
+    const action = interpretResendWebhookEvent(event);
+    const result = await applyResendListAction(action);
+    return NextResponse.json({ received: true, ...result });
+  } catch (error) {
+    console.error("[webhooks/resend] Failed to apply event:", error);
+    return NextResponse.json({ error: "Processing failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -12,7 +12,8 @@ export const dynamic = "force-dynamic";
 
 /**
  * Resend → MyEPBuddy list sync.
- * Dashboard URL to register: https://myepbuddy.com/api/webhooks/resend
+ * Dashboard URL to register: https://www.myepbuddy.com/api/webhooks/resend
+ * (apex myepbuddy.com 307s to www; Resend will not follow that POST).
  * Events: contact.updated, contact.created, email.bounced, email.complained
  */
 export async function POST(request: NextRequest) {

--- a/src/lib/email/__tests__/resend-contacts.test.ts
+++ b/src/lib/email/__tests__/resend-contacts.test.ts
@@ -35,7 +35,7 @@ describe("syncResendMarketingContact", () => {
     expect(result).toEqual({ status: "skipped", reason: "mil" });
   });
 
-  it("PATCHes unsubscribed true on opt-out", async () => {
+  it("POSTs a new contact with unsubscribed true on opt-out", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -52,21 +52,24 @@ describe("syncResendMarketingContact", () => {
     expect(result).toEqual({ status: "synced" });
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("https://api.resend.com/contacts/airman%40gmail.com");
-    expect(init.method).toBe("PATCH");
+    expect(url).toBe("https://api.resend.com/contacts");
+    expect(init.method).toBe("POST");
     expect((init.headers as Record<string, string>).Authorization).toBe(
       "Bearer re_contacts_test"
     );
-    expect(JSON.parse(String(init.body))).toEqual({ unsubscribed: true });
+    expect(JSON.parse(String(init.body))).toEqual({
+      email: "airman@gmail.com",
+      unsubscribed: true,
+    });
   });
 
-  it("creates the contact when PATCH returns 404", async () => {
+  it("PATCHes by email when POST reports the contact already exists", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
         ok: false,
-        status: 404,
-        text: async () => "missing",
+        status: 409,
+        text: async () => JSON.stringify({ name: "conflict", message: "already exists" }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -83,15 +86,41 @@ describe("syncResendMarketingContact", () => {
 
     expect(result).toEqual({ status: "synced" });
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    const createInit = fetchMock.mock.calls[1][1] as RequestInit;
-    expect(createInit.method).toBe("POST");
-    expect(JSON.parse(String(createInit.body))).toEqual({
-      email: "new@gmail.com",
-      unsubscribed: false,
-    });
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.resend.com/contacts");
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("POST");
+    const [patchUrl, patchInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(patchUrl).toBe("https://api.resend.com/contacts/new%40gmail.com");
+    expect(patchInit.method).toBe("PATCH");
+    expect(JSON.parse(String(patchInit.body))).toEqual({ unsubscribed: false });
   });
 
-  it("throws when Resend rejects the update", async () => {
+  it("PATCHes when POST returns 422 already exists", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: async () => JSON.stringify({ message: "Contact already exists" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => "{}",
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await syncResendMarketingContact({
+      email: "existing@gmail.com",
+      optedIn: false,
+      resendContactsApiKey: "re_contacts_test",
+    });
+
+    expect(result).toEqual({ status: "synced" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((fetchMock.mock.calls[1][1] as RequestInit).method).toBe("PATCH");
+  });
+
+  it("throws when POST is rejected for a reason other than an existing contact", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
       ok: false,
       status: 403,

--- a/src/lib/email/__tests__/resend-webhook.test.ts
+++ b/src/lib/email/__tests__/resend-webhook.test.ts
@@ -1,0 +1,212 @@
+import { createHmac } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyResendListAction,
+  interpretResendWebhookEvent,
+  parseResendWebhookEvent,
+  verifyResendWebhookSignature,
+} from "../resend-webhook";
+
+function sign(params: {
+  payload: string;
+  id: string;
+  timestamp: string;
+  secret: string;
+}): string {
+  const secretB64 = params.secret.startsWith("whsec_")
+    ? params.secret.slice(6)
+    : params.secret;
+  const key = Buffer.from(secretB64, "base64");
+  const digest = createHmac("sha256", key)
+    .update(`${params.id}.${params.timestamp}.${params.payload}`)
+    .digest("base64");
+  return `v1,${digest}`;
+}
+
+describe("verifyResendWebhookSignature", () => {
+  const secret = `whsec_${Buffer.from("test-secret").toString("base64")}`;
+  const payload = '{"type":"contact.updated"}';
+  const id = "msg_test";
+
+  it("accepts a valid Svix signature", () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    expect(() =>
+      verifyResendWebhookSignature({
+        payload,
+        id,
+        timestamp,
+        signatureHeader: sign({ payload, id, timestamp, secret }),
+        secret,
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects a tampered payload", () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signatureHeader = sign({ payload, id, timestamp, secret });
+    expect(() =>
+      verifyResendWebhookSignature({
+        payload: '{"type":"forged"}',
+        id,
+        timestamp,
+        signatureHeader,
+        secret,
+      })
+    ).toThrow(/Invalid webhook signature/);
+  });
+
+  it("rejects a stale timestamp", () => {
+    const timestamp = String(Math.floor(Date.now() / 1000) - 60 * 60);
+    expect(() =>
+      verifyResendWebhookSignature({
+        payload,
+        id,
+        timestamp,
+        signatureHeader: sign({ payload, id, timestamp, secret }),
+        secret,
+      })
+    ).toThrow(/too old/);
+  });
+});
+
+describe("interpretResendWebhookEvent", () => {
+  it("maps contact.updated unsubscribed to opt-out without re-PATCHing Resend", () => {
+    expect(
+      interpretResendWebhookEvent({
+        type: "contact.updated",
+        data: { email: "Airman@Gmail.com", unsubscribed: true },
+      })
+    ).toEqual({
+      kind: "preference",
+      email: "airman@gmail.com",
+      optedIn: false,
+      syncContact: false,
+    });
+  });
+
+  it("maps a hard bounce to opt-out and contact sync", () => {
+    expect(
+      interpretResendWebhookEvent({
+        type: "email.bounced",
+        data: {
+          to: ["gone@gmail.com"],
+          bounce: { type: "Permanent" },
+        },
+      })
+    ).toEqual({
+      kind: "preference",
+      email: "gone@gmail.com",
+      optedIn: false,
+      syncContact: true,
+    });
+  });
+
+  it("ignores soft bounces", () => {
+    expect(
+      interpretResendWebhookEvent({
+        type: "email.bounced",
+        data: {
+          to: ["temp@gmail.com"],
+          bounce: { type: "Temporary" },
+        },
+      })
+    ).toEqual({ kind: "ignore", reason: "soft_bounce" });
+  });
+
+  it("maps spam complaints to opt-out", () => {
+    expect(
+      interpretResendWebhookEvent({
+        type: "email.complained",
+        data: { to: ["spam@gmail.com"] },
+      })
+    ).toEqual({
+      kind: "preference",
+      email: "spam@gmail.com",
+      optedIn: false,
+      syncContact: true,
+    });
+  });
+
+  it("skips .mil recipients", () => {
+    expect(
+      interpretResendWebhookEvent({
+        type: "contact.updated",
+        data: { email: "a@us.af.mil", unsubscribed: true },
+      })
+    ).toEqual({ kind: "ignore", reason: "mil" });
+  });
+});
+
+describe("applyResendListAction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("no-ops when the stored preference already matches", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: "user-1", marketing_email_opt_in: false },
+      error: null,
+    });
+    const admin = {
+      from: () => ({
+        select: () => ({
+          ilike: () => ({ maybeSingle }),
+        }),
+        update: () => ({ eq: vi.fn() }),
+      }),
+    };
+
+    const result = await applyResendListAction(
+      {
+        kind: "preference",
+        email: "a@gmail.com",
+        optedIn: false,
+        syncContact: false,
+      },
+      { admin: admin as never }
+    );
+
+    expect(result).toEqual({ status: "unchanged" });
+  });
+
+  it("updates the profile when Resend unsubscribes a previously opted-in user", async () => {
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    const update = vi.fn().mockReturnValue({ eq });
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: "user-1", marketing_email_opt_in: true },
+      error: null,
+    });
+    const admin = {
+      from: () => ({
+        select: () => ({
+          ilike: () => ({ maybeSingle }),
+        }),
+        update,
+      }),
+    };
+
+    const result = await applyResendListAction(
+      {
+        kind: "preference",
+        email: "a@gmail.com",
+        optedIn: false,
+        syncContact: false,
+      },
+      { admin: admin as never }
+    );
+
+    expect(result).toEqual({ status: "updated" });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketing_email_opt_in: false,
+        marketing_email_opt_in_source: "resend",
+      })
+    );
+  });
+});
+
+describe("parseResendWebhookEvent", () => {
+  it("requires a type", () => {
+    expect(() => parseResendWebhookEvent("{}")).toThrow(/Invalid webhook payload/);
+  });
+});

--- a/src/lib/email/resend-contacts.ts
+++ b/src/lib/email/resend-contacts.ts
@@ -20,6 +20,10 @@ export type SyncResendMarketingContactResult =
  * cycle mail stops. Turning them on sets unsubscribed false.
  * Does not run for legacy NULL — those contacts stay on the campaign until
  * they opt out. Skips .mil. No-ops when the API key is unset (local/dev).
+ *
+ * Create first, then PATCH only when the email already exists. PATCH-by-email
+ * returns 404 for unknown addresses; probing with PATCH floods Resend's error
+ * log for every new opt-in.
  */
 export async function syncResendMarketingContact(params: {
   email: string | null | undefined;
@@ -49,29 +53,35 @@ export async function syncResendMarketingContact(params: {
   }
 
   const unsubscribed = !params.optedIn;
-  const patched = await resendContactRequest(
-    resendApiKey,
-    `${CONTACTS_URL}/${encodeURIComponent(email)}`,
-    "PATCH",
-    { unsubscribed }
-  );
+  const created = await resendContactRequest(resendApiKey, CONTACTS_URL, "POST", {
+    email,
+    unsubscribed,
+  });
 
-  if (patched.ok || patched.status === 200) {
+  if (created.ok) {
     return { status: "synced" };
   }
 
-  if (patched.status === 404) {
-    const created = await resendContactRequest(resendApiKey, CONTACTS_URL, "POST", {
-      email,
-      unsubscribed,
-    });
-    if (created.ok) {
+  if (isExistingContactConflict(created.status, created.detail)) {
+    const patched = await resendContactRequest(
+      resendApiKey,
+      `${CONTACTS_URL}/${encodeURIComponent(email)}`,
+      "PATCH",
+      { unsubscribed }
+    );
+    if (patched.ok) {
       return { status: "synced" };
     }
-    throw new ResendSendError(created.status, created.detail);
+    throw new ResendSendError(patched.status, patched.detail);
   }
 
-  throw new ResendSendError(patched.status, patched.detail);
+  throw new ResendSendError(created.status, created.detail);
+}
+
+function isExistingContactConflict(status: number, detail: string): boolean {
+  if (status === 409) return true;
+  if (status !== 422 && status !== 400) return false;
+  return /already exists|already a contact/i.test(detail);
 }
 
 async function resendContactRequest(

--- a/src/lib/email/resend-webhook.ts
+++ b/src/lib/email/resend-webhook.ts
@@ -1,0 +1,187 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { createAdminClient } from "@/lib/supabase/server";
+import { isMilEmail, syncResendMarketingContact } from "@/lib/email/resend-contacts";
+import type { MarketingEmailOptInSource } from "@/lib/marketing-email-opt-in";
+
+const MAX_TIMESTAMP_SKEW_SEC = 5 * 60;
+
+export type ResendWebhookEvent = {
+  type: string;
+  created_at?: string;
+  data?: Record<string, unknown>;
+};
+
+export type ResendListAction =
+  | { kind: "ignore"; reason: string }
+  | {
+      kind: "preference";
+      email: string;
+      optedIn: boolean;
+      /** Bounce/complaint: also mark the Resend contact unsubscribed. */
+      syncContact: boolean;
+    };
+
+export function verifyResendWebhookSignature(params: {
+  payload: string;
+  id: string;
+  timestamp: string;
+  signatureHeader: string;
+  secret: string;
+}): void {
+  const ts = Number(params.timestamp);
+  if (!Number.isFinite(ts)) {
+    throw new Error("Invalid webhook timestamp");
+  }
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - ts) > MAX_TIMESTAMP_SKEW_SEC) {
+    throw new Error("Webhook timestamp too old");
+  }
+
+  const secretB64 = params.secret.startsWith("whsec_")
+    ? params.secret.slice(6)
+    : params.secret;
+  const key = Buffer.from(secretB64, "base64");
+  const signed = `${params.id}.${params.timestamp}.${params.payload}`;
+  const digest = createHmac("sha256", key).update(signed).digest("base64");
+  const expected = Buffer.from(`v1,${digest}`);
+
+  const candidates = params.signatureHeader.split(/\s+/).filter(Boolean);
+  let matched = false;
+  for (const candidate of candidates) {
+    const given = Buffer.from(candidate);
+    if (given.length !== expected.length) continue;
+    if (timingSafeEqual(given, expected)) matched = true;
+  }
+  if (!matched) {
+    throw new Error("Invalid webhook signature");
+  }
+}
+
+export function parseResendWebhookEvent(payload: string): ResendWebhookEvent {
+  const parsed = JSON.parse(payload) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Invalid webhook payload");
+  }
+  const type = (parsed as { type?: unknown }).type;
+  if (typeof type !== "string" || !type) {
+    throw new Error("Invalid webhook payload");
+  }
+  const data = (parsed as { data?: unknown }).data;
+  return {
+    type,
+    created_at:
+      typeof (parsed as { created_at?: unknown }).created_at === "string"
+        ? (parsed as { created_at: string }).created_at
+        : undefined,
+    data:
+      data && typeof data === "object" && !Array.isArray(data)
+        ? (data as Record<string, unknown>)
+        : undefined,
+  };
+}
+
+export function interpretResendWebhookEvent(
+  event: ResendWebhookEvent
+): ResendListAction {
+  if (event.type === "contact.updated" || event.type === "contact.created") {
+    const email = firstEmail(event.data?.email);
+    if (!email) return { kind: "ignore", reason: "no_email" };
+    if (isMilEmail(email)) return { kind: "ignore", reason: "mil" };
+    return {
+      kind: "preference",
+      email,
+      optedIn: event.data?.unsubscribed !== true,
+      syncContact: false,
+    };
+  }
+
+  if (event.type === "email.complained") {
+    const email = firstEmail(event.data?.to);
+    if (!email) return { kind: "ignore", reason: "no_email" };
+    if (isMilEmail(email)) return { kind: "ignore", reason: "mil" };
+    return { kind: "preference", email, optedIn: false, syncContact: true };
+  }
+
+  if (event.type === "email.bounced") {
+    const bounce = event.data?.bounce;
+    const bounceType =
+      bounce && typeof bounce === "object"
+        ? (bounce as { type?: unknown }).type
+        : undefined;
+    if (typeof bounceType === "string" && bounceType.toLowerCase() !== "permanent") {
+      return { kind: "ignore", reason: "soft_bounce" };
+    }
+    const email = firstEmail(event.data?.to);
+    if (!email) return { kind: "ignore", reason: "no_email" };
+    if (isMilEmail(email)) return { kind: "ignore", reason: "mil" };
+    return { kind: "preference", email, optedIn: false, syncContact: true };
+  }
+
+  return { kind: "ignore", reason: "unhandled_type" };
+}
+
+function firstEmail(value: unknown): string | null {
+  if (typeof value === "string") {
+    const email = value.trim().toLowerCase();
+    return email.includes("@") ? email : null;
+  }
+  if (Array.isArray(value) && typeof value[0] === "string") {
+    return firstEmail(value[0]);
+  }
+  return null;
+}
+
+function escapeIlikeExact(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+export async function applyResendListAction(
+  action: ResendListAction,
+  deps: {
+    admin?: ReturnType<typeof createAdminClient>;
+    syncContact?: typeof syncResendMarketingContact;
+  } = {}
+): Promise<{ status: "ignored" | "updated" | "unchanged" }> {
+  if (action.kind === "ignore") {
+    return { status: "ignored" };
+  }
+
+  const admin = deps.admin ?? createAdminClient();
+  const { data: profile, error } = await admin
+    .from("profiles")
+    .select("id, marketing_email_opt_in")
+    .ilike("email", escapeIlikeExact(action.email))
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+  if (action.syncContact) {
+    const sync = deps.syncContact ?? syncResendMarketingContact;
+    await sync({ email: action.email, optedIn: action.optedIn });
+  }
+
+  if (!profile) {
+    return { status: "ignored" };
+  }
+
+  if (profile.marketing_email_opt_in === action.optedIn) {
+    return { status: "unchanged" };
+  }
+
+  const source: MarketingEmailOptInSource = "resend";
+  const { error: updateError } = await admin
+    .from("profiles")
+    .update({
+      marketing_email_opt_in: action.optedIn,
+      marketing_email_opt_in_at: new Date().toISOString(),
+      marketing_email_opt_in_source: source,
+    } as never)
+    .eq("id", profile.id);
+
+  if (updateError) {
+    throw updateError;
+  }
+
+  return { status: "updated" };
+}

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -88,3 +88,8 @@ export function getResendApiKey(): string | null {
 export function getResendContactsApiKey(): string | null {
   return normalizeEnvSecret(process.env.RESEND_CONTACTS_API_KEY);
 }
+
+/** Svix signing secret from the Resend webhook endpoint page (`whsec_…`). */
+export function getResendWebhookSecret(): string | null {
+  return normalizeEnvSecret(process.env.RESEND_WEBHOOK_SECRET);
+}

--- a/src/lib/marketing-email-opt-in.ts
+++ b/src/lib/marketing-email-opt-in.ts
@@ -1,4 +1,8 @@
-export type MarketingEmailOptInSource = "signup" | "onboarding" | "settings";
+export type MarketingEmailOptInSource =
+  | "signup"
+  | "onboarding"
+  | "settings"
+  | "resend";
 
 export const SIGNUP_MARKETING_OPT_IN_KEY = "epb_marketing_email_opt_in";
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -47,7 +47,12 @@ export interface Profile {
   /** null = legacy, never asked. false = declined. true = opted in. */
   marketing_email_opt_in: boolean | null;
   marketing_email_opt_in_at: string | null;
-  marketing_email_opt_in_source: "signup" | "onboarding" | "settings" | null;
+  marketing_email_opt_in_source:
+    | "signup"
+    | "onboarding"
+    | "settings"
+    | "resend"
+    | null;
   trial_intro_seen_at: string | null;
   earn_tokens_intro_seen_at: string | null;
   coaching_features_intro_seen_at: string | null;

--- a/supabase/migrations/214_resend_marketing_opt_in_source.sql
+++ b/supabase/migrations/214_resend_marketing_opt_in_source.sql
@@ -1,0 +1,15 @@
+-- Resend webhook (unsubscribe / bounce / complaint) may persist opt-out.
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_marketing_email_opt_in_source_check;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_marketing_email_opt_in_source_check
+  CHECK (
+    marketing_email_opt_in_source IS NULL
+    OR marketing_email_opt_in_source IN (
+      'signup',
+      'onboarding',
+      'settings',
+      'resend'
+    )
+  );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`PATCH /contacts/{email}` returns **404 Contact not found** when the address is not already on the Resend list. Onboarding opt-in always hit that path first, so Resend’s error debugger filled up even though we then created the contact.

## What changed

- **Create first**, then **PATCH only on conflict** (409 / “already exists”) in `syncResendMarketingContact`.
- Still uses **`RESEND_CONTACTS_API_KEY`** (full access) for contacts and **`RESEND_API_KEY`** for sending.
- New webhook: **`POST https://myepbuddy.com/api/webhooks/resend`**
  - Verify Svix `svix-id` / `svix-timestamp` / `svix-signature` with `RESEND_WEBHOOK_SECRET`
  - Events to subscribe: `contact.updated`, `contact.created`, `email.bounced`, `email.complained`
  - Hard bounce / complaint → local opt-out + mark contact unsubscribed
  - Resend unsubscribe (`contact.updated` with `unsubscribed: true`) → local opt-out only (no PATCH loop)
  - Skips `.mil` addresses
- Migration **214** allows `marketing_email_opt_in_source = 'resend'`

## Dashboard setup

1. Add env `RESEND_WEBHOOK_SECRET` from the webhook details page.
2. Create webhook URL: `https://myepbuddy.com/api/webhooks/resend`
3. Select events: `contact.updated`, `contact.created`, `email.bounced`, `email.complained`.

## Tests

Vitest coverage for create-first contact sync, Svix signature verification, and webhook event interpretation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b271e79-2ddf-4b7a-9354-be9d9d21d3a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b271e79-2ddf-4b7a-9354-be9d9d21d3a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

